### PR TITLE
Add symmetric distance matrix subclass

### DIFF
--- a/bipy/core/distance.py
+++ b/bipy/core/distance.py
@@ -487,12 +487,16 @@ class SymmetricDistanceMatrix(DistanceMatrix):
 
 
 def random_distance_matrix(num_samples, sample_ids=None,
-                           constructor=DistanceMatrix):
+                           constructor=DistanceMatrix,
+                           random_fn=np.random.rand):
     """Return a distance matrix populated with random distances.
 
-    Distances are randomly drawn from a uniform distribution over ``[0, 1)``
-    (see ``numpy.random.rand`` for more details). The distance matrix is
-    guaranteed to be symmetric and hollow.
+    Using the default ``random_fn``, distances are randomly drawn from a
+    uniform distribution over ``[0, 1)`` (see ``numpy.random.rand`` for more
+    details).
+
+    Regardless of the ``random_fn`` that is used to populate the matrix, the
+    returned distance matrix is guaranteed to be symmetric and hollow.
 
     Arguments:
     num_samples -- the number of samples in the resulting distance matrix. For
@@ -505,9 +509,12 @@ def random_distance_matrix(num_samples, sample_ids=None,
     constructor -- ``DistanceMatrix`` or subclass constructor to use when
         creating the distance matrix. The returned distance matrix will be of
         this type
+    random_fn -- function to generate random values. Function must accept two
+        arguments (number of rows and number of columns) and return a 2D
+        ``numpy.ndarray`` of floats (or something that can be casted to float)
 
     """
-    data = np.tril(np.random.rand(num_samples, num_samples), -1)
+    data = np.tril(random_fn(num_samples, num_samples), -1)
     data += data.T
 
     if not sample_ids:

--- a/bipy/core/tests/test_distance.py
+++ b/bipy/core/tests/test_distance.py
@@ -466,6 +466,19 @@ class RandomDistanceMatrixTests(TestCase):
         self.assertEqual(obs, exp)
         self.assertTrue(isinstance(obs, SymmetricDistanceMatrix))
 
+    def test_random_fn(self):
+        """Test passing a different random function than the default."""
+        def myrand(num_rows, num_cols):
+            # One dm to rule them all...
+            data = np.empty((num_rows, num_cols))
+            data.fill(42)
+            return data
+
+        exp = DistanceMatrix(np.asarray([[0, 42, 42], [42, 0, 42],
+                                         [42, 42, 0]]), ['1', '2', '3'])
+        obs = random_distance_matrix(3, random_fn=myrand)
+        self.assertEqual(obs, exp)
+
     def test_invalid_input(self):
         """Test error-handling upon invalid input."""
         # Invalid dimensions.


### PR DESCRIPTION
Added `SymmetricDistanceMatrix`, which is a subclass of `DistanceMatrix`. `DistanceMatrix` now requires that input is 2D, square, and hollow, and `SymmetricDistanceMatrix` has an additional requirement that the data is symmetric.

We'll need this as I start working on QIIME integration (https://github.com/qiime/qiime/issues/829) because we have some scripts that only accept symmetric and hollow distance matrices. There are other scripts that work with both symmetric and asymmetric matrices (e.g., derived from the `unifrac_g` metric), so this is why I made the distinction between matrix types.
