### PR TITLE
PY3: maxint isn't available in py3

### DIFF
--- a/bipy/core/workflow.py
+++ b/bipy/core/workflow.py
@@ -241,7 +241,7 @@ class Workflow(object):
 
     class method(object):
         """Decorate a function to indicate it is a workflow method"""
-        highest_priority = sys.maxint
+        highest_priority = sys.maxsize
 
         def __init__(self, priority=0):
             self.priority = priority


### PR DESCRIPTION
Due to the removal of the distinction between long and int in py3, maxint no longer exists, but maxsize can be used as an equivalent also in py2.
