### PR TITLE
tracks reasons for _not_executed

### DIFF
--- a/skbio/core/workflow.py
+++ b/skbio/core/workflow.py
@@ -64,7 +64,8 @@ from types import MethodType
 
 class NotExecuted(object):
     """Helper object to track if a method was executed"""
-    msg = None
+    def __init__(self):
+        self.msg = None
 
     def __call__(self, msg):
         self.msg = msg


### PR DESCRIPTION
Covers #119. 

Also noticed the module doc string, among others, are not up to numpy doc spec. Not an issue to block this PR on that if necessary
