### PR TITLE
Update .gitignore to ignore the generated folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ nosetests.xml
 
 # vi
 .*.swp
+
+# Sphinx builds
+doc/source/generated


### PR DESCRIPTION
This folder is created when the documentation is built and pollutes the
output of git status.
