### PR TITLE
Add linkcode_resolve function to link to GitHub

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -337,3 +337,73 @@ plot_rcparams = {
 if not use_matplotlib_plot_directive:
     import matplotlib
     matplotlib.rcParams.update(plot_rcparams)
+
+# -----------------------------------------------------------------------------
+# Source code links
+# -----------------------------------------------------------------------------
+
+import inspect
+from os.path import relpath, dirname
+
+for name in ['sphinx.ext.linkcode', 'linkcode', 'numpydoc.linkcode']:
+    try:
+        __import__(name)
+        extensions.append(name)
+        break
+    except ImportError:
+        pass
+else:
+    print "NOTE: linkcode extension not found -- no links to source generated"
+
+def linkcode_resolve(domain, info):
+    """
+    Determine the URL corresponding to Python object
+    """
+    if domain != 'py':
+        return None
+
+    modname = info['module']
+    fullname = info['fullname']
+
+    submod = sys.modules.get(modname)
+    if submod is None:
+        return None
+
+    obj = submod
+    for part in fullname.split('.'):
+        try:
+            obj = getattr(obj, part)
+        except:
+            return None
+
+    try:
+        fn = inspect.getsourcefile(obj)
+    except:
+        fn = None
+    if not fn:
+        try:
+            fn = inspect.getsourcefile(sys.modules[obj.__module__])
+        except:
+            fn = None
+    if not fn:
+        return None
+
+    try:
+        source, lineno = inspect.findsource(obj)
+    except:
+        lineno = None
+
+    if lineno:
+        linespec = "#L%d" % (lineno + 1)
+    else:
+        linespec = ""
+
+    fn = relpath(fn, start=dirname(skbio.__file__))
+
+    if 'dev' in skbio.__version__:
+        return "http://github.com/biocore/scikit-bio/blob/master/skbio/%s%s" % (
+           fn, linespec)
+    else:
+        return "http://github.com/biocore/scikit-bio/blob/%s/skbio/%s%s" % (
+           skbio.__version__, fn, linespec)
+


### PR DESCRIPTION
Add linkcode_resolve to insert a link to the source code of the
documented element. The end result is a sign that reads `[source]`
at the top right of each function, method and class that is
documented with the numpy-doc standard.

Fixes #128

---

For the lazy this is a screenshot, clicking on the link in the top window gets you to the second window:

![screen shot 2014-03-15 at 1 10 16 pm](https://f.cloud.github.com/assets/375307/2429273/9139afb0-ac75-11e3-91d3-449f39076c66.png)
