### PR TITLE
Fix numpydoc warnings in a couple of modules

### DIFF
--- a/skbio/core/alignment.py
+++ b/skbio/core/alignment.py
@@ -87,7 +87,7 @@ class SequenceCollection(object):
             If True, runs the `is_valid` method after construction and raises
             `SequenceCollectionError` if ``is_valid == False``.
 
-        Results
+        Returns
         -------
         SequenceCollection (or a derived class)
             The new `SequenceCollection` object.
@@ -149,7 +149,7 @@ class SequenceCollection(object):
             If True, runs the `is_valid` method after construction and raises
             `SequenceCollectionError` if ``is_valid == False``.
 
-        Results
+        Returns
         -------
         SequenceCollection (or a derived class)
             The new `SequenceCollection` object.
@@ -349,8 +349,8 @@ class SequenceCollection(object):
             Should take a list-like object and return a single value
             representing the spread of the distribution.
 
-        Return
-        ------
+        Returns
+        -------
         tuple of (int, float, float)
             The sequence count, center of length distribution, spread of length
             distribution.

--- a/skbio/util/trie.py
+++ b/skbio/util/trie.py
@@ -271,8 +271,8 @@ class CompressedTrie:
     pair_list : list of tuples, optional
         List of (key, value) pairs to initialize the Trie
 
-    Attributes:
-    -----------
+    Attributes
+    ----------
     size
     prefix_map
     """


### PR DESCRIPTION
These aren't marked as Sphinx warnings, so that's why they didn't fail Travis' tests.
