### PR TITLE
Port subsample_multinomial from pycogent

### DIFF
--- a/skbio/maths/subsample.py
+++ b/skbio/maths/subsample.py
@@ -30,17 +30,15 @@ import numpy as np
 
 
 def subsample(counts, n, replace=False):
-    """Randomly subsample from a vector of counts.
-
-    Returns a copy of `counts` if `n` is equal to or larger than the number of
-    items in `counts`.
+    """Randomly subsample from a vector of counts, with or without replacement.
 
     Parameters
     ----------
     counts : 1-D array_like
         Vector of counts (integers) to randomly subsample from.
     n : int
-        Number of items to subsample from `counts`.
+        Number of items to subsample from `counts`. Must be less than or equal
+        to the sum of `counts`.
     replace : bool, optional
         If ``True``, subsample with replacement. If ``False`` (the default),
         subsample without replacement.
@@ -49,12 +47,25 @@ def subsample(counts, n, replace=False):
     -------
     subsampled : ndarray
         Subsampled vector of counts where the sum of the elements equals `n`
-        (i.e., ``subsampled.sum() == n``).
+        (i.e., ``subsampled.sum() == n``). Will have the same shape as
+        `counts`.
 
     Raises
     ------
     TypeError
         If `counts` cannot be safely converted to an integer datatype.
+    ValueError
+        If `n` is less than zero or greater than the sum of `counts`.
+
+    Notes
+    -----
+    If subsampling is performed without replacement (``replace=False``), a copy
+    of `counts` is returned if `n` is equal to the number of items in `counts`,
+    as all items will be chosen from the original vector.
+
+    If subsampling is performed with replacement (``replace=True``) and `n` is
+    equal to the number of items in `counts`, the subsampled vector that is
+    returned may not necessarily be the same vector as `counts`.
 
     Examples
     --------
@@ -66,11 +77,13 @@ def subsample(counts, n, replace=False):
     >>> sub = subsample(a, 4)
     >>> sub.sum()
     4
+    >>> sub.shape
+    (5,)
 
-    Trying to subsample an equal or greater number of items results in the same
-    vector as our input:
+    Trying to subsample an equal number of items (without replacement) results
+    in the same vector as our input:
 
-    >>> subsample([0, 3, 0, 1], 8)
+    >>> subsample([0, 3, 0, 1], 4)
     array([0, 3, 0, 1])
 
     Subsample 5 items (with replacement):
@@ -78,8 +91,13 @@ def subsample(counts, n, replace=False):
     >>> sub = subsample([1, 0, 1, 2, 2, 3, 0, 1], 5, replace=True)
     >>> sub.sum()
     5
+    >>> sub.shape
+    (8,)
 
     """
+    if n < 0:
+        raise ValueError("n cannot be negative.")
+
     counts = np.asarray(counts)
     counts = counts.astype(int, casting='safe')
 
@@ -87,20 +105,24 @@ def subsample(counts, n, replace=False):
         raise ValueError("Only 1-D vectors are supported.")
 
     counts_sum = counts.sum()
-    if counts_sum <= n:
-        return counts
+    if n > counts_sum:
+        raise ValueError("Cannot subsample more items than exist in input "
+                         "counts vector.")
 
     if replace:
         probs = counts / counts_sum
         result = np.random.multinomial(n, probs)
     else:
-        nz = counts.nonzero()[0]
-        unpacked = np.concatenate([np.repeat(np.array(i,), counts[i])
-                                   for i in nz])
-        permuted = np.random.permutation(unpacked)[:n]
+        if counts_sum == n:
+            result = counts
+        else:
+            nz = counts.nonzero()[0]
+            unpacked = np.concatenate([np.repeat(np.array(i,), counts[i])
+                                       for i in nz])
+            permuted = np.random.permutation(unpacked)[:n]
 
-        result = np.zeros(len(counts), dtype=int)
-        for p in permuted:
-            result[p] += 1
+            result = np.zeros(len(counts), dtype=int)
+            for p in permuted:
+                result[p] += 1
 
     return result

--- a/skbio/maths/tests/test_subsample.py
+++ b/skbio/maths/tests/test_subsample.py
@@ -22,12 +22,20 @@ class SubsampleTests(TestCase):
         """Should function correctly for nonrandom cases."""
         a = np.array([0, 5, 0])
 
-        # Input has too few counts.
-        np.testing.assert_equal(subsample(a, 6), a)
+        # Subsample same number of items that are in input (without
+        # replacement).
         np.testing.assert_equal(subsample(a, 5), a)
 
         # Can only choose from one bin.
-        np.testing.assert_equal(subsample(a, 2), np.array([0, 2, 0]))
+        exp = np.array([0, 2, 0])
+        np.testing.assert_equal(subsample(a, 2), exp)
+        np.testing.assert_equal(subsample(a, 2, replace=True), exp)
+
+        # Subsample zero items.
+        a = [3, 0, 1]
+        exp = np.array([0, 0, 0])
+        np.testing.assert_equal(subsample(a, 0), exp)
+        np.testing.assert_equal(subsample(a, 0, replace=True), exp)
 
     def test_subsample_without_replacement(self):
         """Should return a random subsample (without replacement)."""
@@ -68,15 +76,33 @@ class SubsampleTests(TestCase):
             actual.add(tuple(obs))
         self.assertTrue(len(actual) > 10)
 
+    def test_subsample_with_replacement_equal_n(self):
+        """Returns random subsample (w/ replacement) when n == counts.sum()."""
+        a = np.array([0, 0, 3, 4, 2, 1])
+        actual = set()
+        for i in range(1000):
+            obs = subsample(a, 10, replace=True)
+            self.assertEqual(obs.sum(), 10)
+            actual.add(tuple(obs))
+        self.assertTrue(len(actual) > 1)
+
     def test_subsample_invalid_input(self):
         """Should raise an error on invalid input."""
-        # Wrong number of dimensions.
+        # Negative n.
         with self.assertRaises(ValueError):
-            _ = subsample([[1, 2, 3], [4, 5, 6]], 2)
+            _ = subsample([1, 2, 3], -1)
 
         # Floats.
         with self.assertRaises(TypeError):
             _ = subsample([1, 2.3, 3], 2)
+
+        # Wrong number of dimensions.
+        with self.assertRaises(ValueError):
+            _ = subsample([[1, 2, 3], [4, 5, 6]], 2)
+
+        # Input has too few counts.
+        with self.assertRaises(ValueError):
+            _ = subsample([0, 5, 0], 6)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Ported `subsample_multinomial` from PyCogent:
- improved its unit tests, as the previous ones also worked for subsampling without replacement
- combined multinomial subsampling with the `subsample` function as the functions shared a fair amount of code, and both are pretty short
- kept `subsample_multinomial`, which is now a simple wrapper. Useful in QIIME's case, where it expects the subsampling functions to share a common interface
- fixed a potential pitfall that modified the input `counts` vector in place, and also returned it. This behavior was inconsistent with `subsample`, which doesn't modify in place

I'd appreciate it if at least one other person looked over `test_subsample_multinomial` to verify that the tests are sane and that I'm not misunderstanding what multinomial subsampling is. The previous unit test in PyCogent wasn't that great because it also worked for subsampling _without_ replacement. These new tests work only when subsampling _with_ replacement.
