### PR TITLE
Change linkcheck timeout to 30 seconds

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -412,4 +412,4 @@ def linkcode_resolve(domain, info):
 #------------------------------------------------------------------------------
 
 # Link-checking on Travis sometimes times out.
-linkcheck_timeout = 5
+linkcheck_timeout = 30


### PR DESCRIPTION
It was previously 5 seconds but this kept yielding false positive
failures.

Fixes #212
