### PR TITLE
Fix remaining RTD issues

### DIFF
--- a/doc/source/_templates/page.html
+++ b/doc/source/_templates/page.html
@@ -1,6 +1,13 @@
 {% extends "!page.html" %}
 
-{# Taken and modified from sphinx-bootstrap-theme demo site (https://github.com/ryan-roemer/sphinx-bootstrap-theme/blob/master/demo/source/_templates/layout.html). #}
+{# Taken and modified from sphinx-bootstrap-theme demo site
+   (https://github.com/ryan-roemer/sphinx-bootstrap-theme/blob/master/demo/source/_templates/layout.html).
+
+   We override page.html and search.html instead of layout.html because RTD
+   uses its own layout.html, which currently can't be overridden. When
+   https://github.com/rtfd/readthedocs.org/issues/152 is fixed, this hack
+   should be removed. See also search.html, in this same directory.
+#}
 
 {# Add github banner (from: https://github.com/blog/273-github-ribbons). #}
 {% block header %}

--- a/doc/source/_templates/search.html
+++ b/doc/source/_templates/search.html
@@ -1,6 +1,13 @@
 {% extends "!search.html" %}
 
-{# Taken and modified from sphinx-bootstrap-theme demo site (https://github.com/ryan-roemer/sphinx-bootstrap-theme/blob/master/demo/source/_templates/layout.html). #}
+{# Taken and modified from sphinx-bootstrap-theme demo site
+   (https://github.com/ryan-roemer/sphinx-bootstrap-theme/blob/master/demo/source/_templates/layout.html).
+
+   We override page.html and search.html instead of layout.html because RTD
+   uses its own layout.html, which currently can't be overridden. When
+   https://github.com/rtfd/readthedocs.org/issues/152 is fixed, this hack
+   should be removed. See also page.html, in this same directory.
+#}
 
 {# Add github banner (from: https://github.com/blog/273-github-ribbons). #}
 {% block header %}

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -10,6 +10,16 @@ import skbio
 # NOTE: parts of this file were taken from scipy's doc/source/conf.py. See
 # scikit-bio/licenses/scipy.txt for scipy's license.
 
+# If readthedocs.org is building the project, delete the generated/ directory,
+# which is created by autosummary when generating the API reference. For some
+# reason, when RTD rebuilds the docs (i.e., not starting from a fresh build),
+# some links are not generated correctly if generated/ already exists. Links to
+# modules/subpackages work, but links aren't created for classes, methods,
+# attributes, etc. and we get a bunch of warnings. This does not happen when
+# building the docs locally or on Travis.
+#
+# Code to check whether RTD is building our project is taken from
+# http://read-the-docs.readthedocs.org/en/latest/faq.html
 on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 if on_rtd:
     generated_path = os.path.join(os.path.dirname(__file__), 'generated')


### PR DESCRIPTION
Fixes the two remaining RTD issues I noted in my [previous pull request](https://github.com/biocore/scikit-bio/pull/234):
- GitHub "Fork me" banner now displays
- Doc rebuilds seem to work if `generated/` is removed before the rebuild

It's probably a good idea to monitor the RTD-hosted site before making it the "official" skbio website just in case there are other issues that show up. Probably by the first release we can switch over to RTD fully.
