### PR TITLE
Add style for single back ticks

### DIFF
--- a/doc/source/_static/skbio.css
+++ b/doc/source/_static/skbio.css
@@ -1,0 +1,10 @@
+/* as suggested in http://stackoverflow.com/a/4410376/379593 */
+
+@import url("default.css");
+
+/* -- change the font for elements enclosed in single back ticks ------------ */
+
+cite {
+    font-family: "Courier New";
+}
+

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -181,7 +181,8 @@ html_theme_options = {
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-#html_static_path = ['_static']
+html_static_path = ['_static/']
+html_style = 'skbio.css'
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied


### PR DESCRIPTION
Add custom CSS to change the font of things that are enclosed in single 
back-ticks. Currently it uses Courier New, but this can easily be changed in
case someone thinks it should be anything different.
