### PR TITLE
BUG: TreeNode.prune was ignoring length

### DIFF
--- a/skbio/core/tests/test_tree.py
+++ b/skbio/core/tests/test_tree.py
@@ -178,6 +178,33 @@ class TreeTests(TestCase):
         self.assertEqual(self.simple_t.children[0].name, 'i2')
         self.assertEqual(self.simple_t.children[1].name, 'b')
 
+    def test_prune_length(self):
+        """Collapse single descendent nodes"""
+        # check the identity case
+        cp = self.simple_t.copy()
+        self.simple_t.prune()
+
+        gen = zip(cp.traverse(include_self=True),
+                  self.simple_t.traverse(include_self=True))
+
+        for a, b in gen:
+            self.assertIsNot(a, b)
+            self.assertEqual(a.name, b.name)
+            self.assertEqual(a.length, b.length)
+
+        for n in self.simple_t.traverse():
+            n.length = 1.0
+
+        # create a single descendent by removing tip 'a'
+        n = self.simple_t.children[0]
+        n.remove(n.children[0])
+        self.simple_t.prune()
+
+        self.assertEqual(len(self.simple_t.children), 2)
+        self.assertEqual(self.simple_t.children[0].name, 'i2')
+        self.assertEqual(self.simple_t.children[1].name, 'b')
+        self.assertEqual(self.simple_t.children[1].length, 2.0)
+
     def test_subset(self):
         """subset should return set of leaves that descends from node"""
         t = self.simple_t

--- a/skbio/core/tree.py
+++ b/skbio/core/tree.py
@@ -503,7 +503,14 @@ class TreeNode(object):
 
         # clean up the single children nodes
         for node in nodes_to_remove:
-            node.parent.append(node.children[0])
+            child = node.children[0]
+
+            if child.length is None or node.length is None:
+                child.length = child.length or node.length
+            else:
+                child.length += node.length
+
+            node.parent.append(child)
             node.parent.remove(node)
 
 #   def shear(self, names):


### PR DESCRIPTION
Pretty quick one, `TreeNode.prune` was not handling length
