### PR TITLE
PY3: Close issue #302

### DIFF
--- a/skbio/maths/tests/test_subsample.py
+++ b/skbio/maths/tests/test_subsample.py
@@ -13,7 +13,11 @@ from unittest import TestCase, main
 
 import numpy as np
 
-from future.standard_library.test.support import import_fresh_module
+try:
+    # future >= 0.12
+    from future.backports.test.support import import_fresh_module
+except ImportError:
+    from future.standard_library.test.support import import_fresh_module
 
 cy_subsample = import_fresh_module('skbio.maths.subsample',
                                    fresh=['skbio.maths._subsample'])


### PR DESCRIPTION
Adds compatibility with newest future version (they made a backwards incompatible change to be more explicit about differences between reorganization of the stdlib and backported Py3 functionality).

Thanks to @ElBrogrammer for catching this on day 0!
