### PR TITLE
BUG/ENH: Remove repeated exception classes

### DIFF
--- a/skbio/core/exception.py
+++ b/skbio/core/exception.py
@@ -28,8 +28,6 @@ Exceptions
    DuplicateNodeError
    MissingNodeError
    NoParentError
-   FileFormatError
-   RecordError
    FastqParseError
 
 """
@@ -122,15 +120,6 @@ class NoParentError(MissingNodeError):
     pass
 
 
-class FileFormatError(Exception):
-    """Exception raised when a file can not be parsed."""
-    pass
-
-
-class RecordError(FileFormatError):
-    """Exception raised when a record is bad."""
-    pass
-
-
 class FastqParseError(FileFormatError):
+    """Exception raised when a FASTQ formatted file cannot be parsed"""
     pass


### PR DESCRIPTION
FileFormatError and RecordError were declared twice in the exceptions module.

FastqParseError was missing a docstring which has now been added.

Fixes #257
