### PR TITLE
DOC/BUG: Move docs from __init__ to class

### DIFF
--- a/skbio/core/alignment.py
+++ b/skbio/core/alignment.py
@@ -83,11 +83,6 @@ class SequenceCollection(object):
         If True, runs the `is_valid` method after construction and raises
         `SequenceCollectionError` if ``is_valid == False``.
 
-    Returns
-    -------
-    SequenceCollection (or a derived class)
-        The new `SequenceCollection` object.
-
     Raises
     ------
     skbio.core.exception.SequenceCollectionError


### PR DESCRIPTION
If documentation is included in the **init** method, it is not rendered by
sphinx and is in turn not available anywhere. Moving it over to the class
declaration makes it appear in the class' index.
