### PR TITLE
DOC: there's actually a better way to check if something is an integer

### DIFF
--- a/doc/source/development/py3.rst
+++ b/doc/source/development/py3.rst
@@ -278,7 +278,10 @@ Numbers
 
 The `long` type no longer exists in Py2. To test if a number is an
 integer (`int` or `long` in Py2, `int` in Py3), compare it to
-`future.builtins.int`.
+the abstract base class `Integral`::
+
+    from numbers import Integral
+    isinstance(quality, Integral)
 
 Implementing comparisons
 ========================

--- a/skbio/parse/record.py
+++ b/skbio/parse/record.py
@@ -8,10 +8,11 @@
 # The full license is in the file COPYING.txt, distributed with this software.
 # ----------------------------------------------------------------------------
 
-from future.builtins import int
 from future.utils import viewitems
 
+from numbers import Integral
 from copy import deepcopy
+
 from skbio.core.exception import FieldError
 
 
@@ -31,7 +32,7 @@ def DelimitedSplitter(delimiter=None, max_splits=1):
 
     Note: leaves empty fields in place.
     """
-    is_int = isinstance(max_splits, int)
+    is_int = isinstance(max_splits, Integral)
     if is_int and (max_splits > 0):
         def parser(line):
             return [i.strip() for i in line.split(delimiter, max_splits)]


### PR DESCRIPTION
than shadowing the builtin int in Py2, and with no need for a compatibility package.
