### PR TITLE
added missing __init__ to tests for ssw

### DIFF
--- a/skbio/core/ssw/tests/__init__.py
+++ b/skbio/core/ssw/tests/__init__.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python
+
+# ----------------------------------------------------------------------------
+# Copyright (c) 2013--, scikit-bio development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+# ----------------------------------------------------------------------------


### PR DESCRIPTION
This will allow tests to run on ssw from nosetests given a distribution
