### PR TITLE
Add intersphinx mapping for hyperlinks to external docs (numpy, scipy, etc.)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 * Added powertrip.py script to perform basic sanity-checking of the repo based on recurring issues that weren't being caught until release time; added to Travis build.
 * Added RELEASE.md with release instructions.
+* Added intersphinx mappings to docs so that "See Also" references to numpy, scipy, matplotlib, and pandas are hyperlinks.
 
 ## Version 0.1.3 (2014-06-12)
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -28,7 +28,8 @@ extensions = [
     'numpydoc',
     'sphinx.ext.coverage',
     'sphinx.ext.doctest',
-    'sphinx.ext.autosummary'
+    'sphinx.ext.autosummary',
+    'sphinx.ext.intersphinx'
 ]
 
 # Determine if the matplotlib has a recent enough version of the
@@ -337,6 +338,17 @@ plot_rcparams = {
 if not use_matplotlib_plot_directive:
     import matplotlib
     matplotlib.rcParams.update(plot_rcparams)
+
+# -----------------------------------------------------------------------------
+# Intersphinx configuration
+# -----------------------------------------------------------------------------
+intersphinx_mapping = {
+        'http://docs.python.org/dev': None,
+        'http://docs.scipy.org/doc/numpy': None,
+        'http://docs.scipy.org/doc/scipy/reference': None,
+        'http://matplotlib.org': None,
+        'http://pandas.pydata.org': None
+}
 
 # -----------------------------------------------------------------------------
 # Source code links

--- a/skbio/core/alignment/alignment.py
+++ b/skbio/core/alignment/alignment.py
@@ -41,7 +41,7 @@ class SequenceCollection(object):
     See Also
     --------
     skbio.core.sequence.BiologicalSequence
-    skbio.core.sequence.NucelotideSequence
+    skbio.core.sequence.NucleotideSequence
     skbio.core.sequence.DNASequence
     skbio.core.sequence.RNASequence
     Alignment
@@ -88,7 +88,7 @@ class SequenceCollection(object):
         See Also
         --------
         skbio.core.sequence.BiologicalSequence
-        skbio.core.sequence.NucelotideSequence
+        skbio.core.sequence.NucleotideSequence
         skbio.core.sequence.DNASequence
         skbio.core.sequence.RNASequence
         Alignment
@@ -775,7 +775,7 @@ class Alignment(SequenceCollection):
     See Also
     --------
     skbio.core.sequence.BiologicalSequence
-    skbio.core.sequence.NucelotideSequence
+    skbio.core.sequence.NucleotideSequence
     skbio.core.sequence.DNASequence
     skbio.core.sequence.RNASequence
     SequenceCollection

--- a/skbio/core/sequence.py
+++ b/skbio/core/sequence.py
@@ -1230,7 +1230,7 @@ class NucleotideSequence(BiologicalSequence):
 
     See Also
     --------
-    BiologialSequence
+    BiologicalSequence
 
     Notes
     -----
@@ -1566,7 +1566,7 @@ class ProteinSequence(BiologicalSequence):
 
     See Also
     --------
-    BiologialSequence
+    BiologicalSequence
 
     Notes
     -----

--- a/skbio/math/stats/distance/base.py
+++ b/skbio/math/stats/distance/base.py
@@ -27,7 +27,8 @@ class CategoricalStats(object):
 
     See Also
     --------
-    ANOSIM, PERMANOVA
+    ANOSIM
+    PERMANOVA
 
     """
 

--- a/skbio/math/stats/ordination/base.py
+++ b/skbio/math/stats/ordination/base.py
@@ -359,6 +359,7 @@ class OrdinationResults(namedtuple('OrdinationResults',
             file. If it's a file-like object, it must have a ``write``
             method, and it won't be closed. Else, it is opened and
             closed after writing.
+
         See Also
         --------
         from_file

--- a/skbio/math/stats/ordination/tests/test_ordination.py
+++ b/skbio/math/stats/ordination/tests/test_ordination.py
@@ -96,11 +96,9 @@ def normalize_signs(arr1, arr2):
 
 
 def chi_square_distance(data_table, between_rows=True):
-    """Computes the chi-square distance between two rows or columns of
-    input.
+    """Computes the chi-square distance between two rows or columns of input.
 
-    It is a measure that has no upper limit, and it excludes
-    double-zeros.
+    It is a measure that has no upper limit, and it excludes double-zeros.
 
     Parameters
     ----------
@@ -122,9 +120,7 @@ def chi_square_distance(data_table, between_rows=True):
 
     See Also
     --------
-    `scipy.spatial.distance.squareform` for a routine that transforms
-    condensed distance matrices to square-form distance matrices (and
-    vice-versa).
+    scipy.spatial.distance.squareform
 
     References
     ----------

--- a/skbio/parse/sequences/factory.py
+++ b/skbio/parse/sequences/factory.py
@@ -101,9 +101,9 @@ def load(seqs, qual=None, constructor=None, **kwargs):
 
     See Also
     --------
-    skbio.parse.sequences.iterator.SequenceIterator
-    skbio.parse.sequences.iterator.FastaIterator
-    skbio.parse.sequences.iterator.FastqIterator
+    SequenceIterator
+    FastaIterator
+    FastqIterator
 
     """
     if not seqs:


### PR DESCRIPTION
The "See Also" section of docstrings now support hyperlinks to numpy, scipy, matplotlib, pandas, and python docs.

For example, `bioenv`'s "See Also" section previously referenced `scipy.stats.spearmanr`. The function name is now a clickable hyperlink to scipy's docs for that function.

Also fixed a few errors in docs while browsing through and verified that existing references to numpy, scipy, and matplotlib are working.

Partially addresses #190.
