### PR TITLE
ENH: Speed up travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ install:
   - conda create --yes -n env_name python=$PYTHON_VERSION pip numpy=$NUMPY_VERSION scipy matplotlib pandas nose pep8 flake8 Sphinx
   - if [ ${USE_CYTHON} ]; then conda install --yes -n env_name cython; fi
   - source activate env_name
-  - pip install sphinx-bootstrap-theme future coverage coveralls natsort
+  - pip install sphinx-bootstrap-theme future coveralls natsort
   - pip install -e . --no-deps
 script:
   - if [ ${WITH_DOCTEST} ]; then nosetests --with-doctest --with-coverage; else nosetests --with-coverage; fi


### PR DESCRIPTION
The previous configuration file would run the test suite twice, and would
always submit a coveralls report (even if the tests failed).
