### PR TITLE
Use longer imports in favor of convenience imports

### DIFF
--- a/skbio/alignment/_alignment.py
+++ b/skbio/alignment/_alignment.py
@@ -16,7 +16,7 @@ from warnings import warn
 import numpy as np
 from scipy.stats import entropy
 
-from skbio import DistanceMatrix
+from skbio.stats.distance import DistanceMatrix
 from skbio.util.io import open_file
 from ._exception import SequenceCollectionError, StockholmParseError
 

--- a/skbio/alignment/_pairwise.py
+++ b/skbio/alignment/_pairwise.py
@@ -14,9 +14,9 @@ import numpy as np
 from future.builtins import range, zip
 from future.utils.six import string_types
 
-from skbio.util import EfficiencyWarning
 from skbio.alignment import Alignment
-from skbio import BiologicalSequence
+from skbio.sequence import BiologicalSequence
+from skbio.util import EfficiencyWarning
 
 # This is temporary: blosum50 does not exist in skbio yet as per
 # issue 161. When the issue is resolved, this should be removed in favor

--- a/skbio/diversity/beta/_base.py
+++ b/skbio/diversity/beta/_base.py
@@ -11,10 +11,9 @@ from __future__ import absolute_import, division, print_function
 from warnings import warn
 
 import numpy as np
+from scipy.spatial.distance import pdist, squareform
 
-from skbio import DistanceMatrix
-from scipy.spatial.distance import pdist
-from scipy.spatial.distance import squareform
+from skbio.stats.distance import DistanceMatrix
 
 
 def pw_distances(counts, ids=None, metric="braycurtis"):

--- a/skbio/stats/ordination/_principal_coordinate_analysis.py
+++ b/skbio/stats/ordination/_principal_coordinate_analysis.py
@@ -12,7 +12,7 @@ from warnings import warn
 
 import numpy as np
 
-from skbio import DistanceMatrix
+from skbio.stats.distance import DistanceMatrix
 from ._base import Ordination, OrdinationResults
 
 # - In cogent, after computing eigenvalues/vectors, the imaginary part

--- a/skbio/tree/_nj.py
+++ b/skbio/tree/_nj.py
@@ -10,7 +10,7 @@ from __future__ import absolute_import, division, print_function
 
 import numpy as np
 
-from skbio import DistanceMatrix
+from skbio.stats.distance import DistanceMatrix
 from skbio.tree import TreeNode
 
 

--- a/skbio/tree/_tree.py
+++ b/skbio/tree/_tree.py
@@ -21,7 +21,7 @@ import numpy as np
 from scipy.stats import pearsonr
 from future.builtins import zip
 
-from skbio import DistanceMatrix
+from skbio.stats.distance import DistanceMatrix
 from skbio.util import RecordError
 from skbio.util.io import open_file
 from ._exception import (NoLengthError, DuplicateNodeError, NoParentError,


### PR DESCRIPTION
Instead of using `from skbio import foo` we now use the longer form of the import in order to avoid the chance of circular imports happening. For example, `from skbio import DistanceMatrix` becomes `from skbio.stats.distance import DistanceMatrix`.

The `skbio.io` additions prompted these changes but this was a problem waiting to happen regardless of the I/O system. Unit tests and doctests should still use the shorter/convenience imports as these are testing our user-facing API and we don't have the risk of circular imports there. All skbio library code should use the longer imports though.

@ebolyen can you please review?
