### PR TITLE
Remove skbio deps from readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -42,24 +42,9 @@ To install the latest release version of scikit-bio you should run::
     pip install numpy
     pip install scikit-bio
 
-If you'd like to install the dependencies manually (or some other way
-than using pip), you can find those here:
+If you have trouble getting scikit-bio's dependencies installed (scipy, in particular, can be tricky), you should try installing `Canopy Express <https://www.enthought.com/canopy-express/>`_, which includes all of these dependencies.
 
--  `Python <http://www.python.org/>`__ 2.7 or >= 3.3
--  `numpy <http://www.numpy.org/>`__ >= 1.7
--  `scipy <http://www.scipy.org/>`__ >= 0.13.0
--  `matplotlib <http://www.matplotlib.org/>`__ >= 1.1.0
--  `pandas <http://pandas.pydata.org/>`__
--  `future <https://pypi.python.org/pypi/future>`__
--  `six <https://pypi.python.org/pypi/six`__
--  `natsort <https://pypi.python.org/pypi/natsort>`__
--  `IPython <http://ipython.org>`__ 
-
-If you have trouble getting these dependencies installed (scipy, in particular, can be tricky), you should try installing `Canopy Express <https://www.enthought.com/canopy-express/>`_, which includes all of these dependencies. You should then be able to easily install scikit-bio by running::
-
-    pip install scikit-bio
-
-After installation with ``pip``, you can run the scikit-bio unittest suite as follows::
+You can verify your installation by running the scikit-bio unit tests as follows::
 
     nosetests --with-doctest skbio
 
@@ -73,7 +58,7 @@ If you're interested in working with the latest development release of scikit-bi
     cd scikit-bio
     pip install .
 
-After this completes, you can run the scikit-bio unittest suite as follows. You must first ``cd`` out of the ``scikit-bio`` directory for the tests to pass (here we ``cd`` to the home directory).
+After this completes, you can run the scikit-bio unit tests as follows. You must first ``cd`` out of the ``scikit-bio`` directory for the tests to pass (here we ``cd`` to the home directory).
 ::
 
     cd
@@ -83,13 +68,13 @@ For developers of scikit-bio, if you don't want to be forced to re-install after
 
     pip install -e .
 
-This will build scikit-bio's cython extensions, and will create a link in the ``site-packages`` directory to the scikit-bio source directory. When you then make changes to code in the source directory, those will be used (e.g., by the unittests) without re-installing.
+This will build scikit-bio's Cython extensions, and will create a link in the ``site-packages`` directory to the scikit-bio source directory. When you then make changes to code in the source directory, those will be used (e.g., by the unit tests) without re-installing.
 
 Finally, if you don't want to use ``pip`` to install scikit-bio, and prefer to just put ``scikit-bio`` in your ``$PYTHONPATH``, at the minimum you should run::
 
     python setup.py build_ext --inplace
 
-This will build scikit-bio's cython extensions, but not create a link to the scikit-bio source directory in ``site-packages``. If this isn't done, using certain components of scikit-bio will be inefficient and will produce an ``EfficiencyWarning``.
+This will build scikit-bio's Cython extensions, but not create a link to the scikit-bio source directory in ``site-packages``. If this isn't done, using certain components of scikit-bio will be inefficient and will produce an ``EfficiencyWarning``.
 
 Getting help
 ------------


### PR DESCRIPTION
@gregcaporaso and I chatted about this (in the context of scikit-bio and [IAB](http://applied-bioinformatics.org)) and thought it'd be a good idea to remove the explicit dependency list from the README in both projects. This list is nearly always outdated and `pip` should handle installing the dependencies. If someone wants to see the exact dependencies required by skbio, they can always look in setup.py.
