### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,8 @@ extensions = [
               # http://bugs.python.org/issue21121 for details. This acts as a
               # workaround until the next Python 3 release -- thanks
               # Wolfgang Maier (wolma) for the workaround!
-              extra_compile_args=["-Wno-error=declaration-after-statement",'-msse3'])
+              extra_compile_args=["-Wno-error=declaration-after-statement",
+                                  "-msse3"])
 ]
 
 if USE_CYTHON:


### PR DESCRIPTION
including -msse3 to solve the  #error “SSE2 instruction set not enabled” when installing scikit-bio via pip
This issue has been asked and adressed here: http://stackoverflow.com/questions/26211814/error-sse2-instruction-set-not-enabled-when-installing-scikit-bio-via-pip
The solution to incluede the -msee3 flag was found here: https://github.com/rmcgibbo/mixtape/issues/35
