### PR TITLE
Test coveralls, do not merge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,4 +33,4 @@ script:
   - make html
   - popd
 after_success:
-  - coveralls
+  - coveralls debug


### PR DESCRIPTION
Running debug to see if we can figure out anything.

I noticed that coveralls will return if python 3 fails, but not if it succeeds. May be a coincidence though. 
