### PR TITLE
Support versions of IPython < 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 * Added ``skbio.stats.distance.anosim`` and ``skbio.stats.distance.permanova`` functions, which replace the ``skbio.stats.distance.ANOSIM`` and ``skbio.stats.distance.PERMANOVA`` classes. These new functions provide simpler procedural interfaces to running these statistical methods. They also provide more convenient access to results by returning a ``pandas.Series`` instead of a ``CategoricalStatsResults`` object. These functions have more extensive documentation than their previous versions. If significance tests are suppressed, p-values are returned as ``np.nan`` instead of ``None`` for consistency with other statistical methods in scikit-bio. [#754](https://github.com/biocore/scikit-bio/issues/754)
 * Added `skbio.stats.power` for performing emperical power analysis. The module uses existing datasets and iteratively draws samples to estimate the number of samples needed to see a significant difference for a given critical value.
 
+### Bug fixes
+* Fixed issue where SSW wouldn't compile on i686 architectures ([#409](https://github.com/biocore/scikit-bio/issues/409)).
+
 ### Deprecated functionality
 * Deprecated ``skbio.stats.p_value_to_str``. This function will be removed in scikit-bio 0.3.0. Permutation-based p-values in scikit-bio are calculated as ``(num_extreme + 1) / (num_permutations + 1)``, so it is impossible to obtain a p-value of zero. This function historically existed for correcting the number of digits displayed when obtaining a p-value of zero. Since this is no longer possible, this functionality will be removed.
 * Deprecated ``skbio.stats.distance.ANOSIM`` and ``skbio.stats.distance.PERMANOVA`` in favor of ``skbio.stats.distance.anosim`` and ``skbio.stats.distance.permanova``, respectively.
@@ -15,9 +18,7 @@
 
 ### Miscellaneous
 * The ``pandas.DataFrame`` returned by ``skbio.stats.distance.pwmantel`` now stores p-values as floats and does not convert them to strings with a specific number of digits. p-values that were previously stored as "N/A" are now stored as ``np.nan`` for consistency with other statistical methods in scikit-bio. See note in "Deprecated functionality" above regarding ``p_value_to_str`` for details.
-
-### Bug fixes
-* Fixed issue where SSW wouldn't compile on i686 architectures ([#409](https://github.com/biocore/scikit-bio/issues/409)).
+* scikit-bio now supports versions of IPython < 2.0.0 ([#767](https://github.com/biocore/scikit-bio/issues/767)).
 
 ## Version 0.2.1 (2014-10-27)
 

--- a/skbio/stats/distance/tests/test_base.py
+++ b/skbio/stats/distance/tests/test_base.py
@@ -17,7 +17,7 @@ mpl.use('Agg')
 import numpy as np
 import numpy.testing as npt
 import pandas as pd
-from IPython.display import Image, SVG
+from IPython.core.display import Image, SVG
 
 from skbio import DistanceMatrix
 from skbio.stats.distance import (
@@ -326,9 +326,11 @@ class DissimilarityMatrixTests(DissimilarityMatrixTestData):
         self.assertTrue(len(obs) > 0)
 
     def test_repr_svg(self):
-        dm = self.dm_1x1
-        obs = dm._repr_svg_()
-        self.assertIsInstance(obs, text_type)
+        obs = self.dm_1x1._repr_svg_()
+        # print_figure(format='svg') can return text or bytes depending on the
+        # version of IPython
+        self.assertTrue(isinstance(obs, text_type) or
+                        isinstance(obs, binary_type))
         self.assertTrue(len(obs) > 0)
 
     def test_png(self):

--- a/skbio/stats/ordination/tests/test_ordination.py
+++ b/skbio/stats/ordination/tests/test_ordination.py
@@ -879,7 +879,9 @@ class TestOrdinationResults(unittest.TestCase):
 
     def test_repr_svg(self):
         obs = self.min_ord_results._repr_svg_()
-        assert_is_instance(obs, text_type)
+        # print_figure(format='svg') can return text or bytes depending on the
+        # version of IPython
+        assert_true(isinstance(obs, text_type) or isinstance(obs, binary_type))
         assert_true(len(obs) > 0)
 
     def test_png(self):


### PR DESCRIPTION
Modified a few tests to work with older and current versions of IPython. Also
fixed ordering of sections in the changelog.

Fixes #767.
