### PR TITLE
Use DeprecationWarning for deprecation warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@
 * Deprecated ``skbio.stats.distance.CategoricalStatsResults`` in favor of using ``pandas.Series`` to store statistical method results. ``anosim`` and ``permanova`` return ``pandas.Series`` instead of ``CategoricalStatsResults``.
 * Deprecated ``skbio.stats.subsample`` in favor of ``skbio.stats.subsample_counts``, which provides an identical interface; only the function name has changed. ``skbio.stats.subsample`` will be removed in scikit-bio 0.3.0.
 
+### Backward-incompatible changes
+* Deprecation warnings are now raised using ``DeprecationWarning`` instead of ``UserWarning`` ([#774](https://github.com/biocore/scikit-bio/issues/774)).
+
 ### Miscellaneous
 * The ``pandas.DataFrame`` returned by ``skbio.stats.distance.pwmantel`` now stores p-values as floats and does not convert them to strings with a specific number of digits. p-values that were previously stored as "N/A" are now stored as ``np.nan`` for consistency with other statistical methods in scikit-bio. See note in "Deprecated functionality" above regarding ``p_value_to_str`` for details.
 * scikit-bio now supports versions of IPython < 2.0.0 ([#767](https://github.com/biocore/scikit-bio/issues/767)).

--- a/README.rst
+++ b/README.rst
@@ -29,10 +29,12 @@
 
 scikit-bio is an open-source, BSD-licensed python package providing data structures, algorithms and educational resources for bioinformatics.
 
-scikit-bio is currently in alpha. We are very actively developing it, and **backwards-incompatible interface changes can and will arise**. Once the API has started to solidify, we will strive to maintain backwards compatibility. We will provide deprecation warnings, etc. wherever possible.
-
 To view scikit-bio's documentation, visit `scikit-bio.org
 <http://scikit-bio.org>`__.
+
+scikit-bio is currently in alpha. We are very actively developing it, and **backwards-incompatible interface changes can and will arise**. Once the API has started to solidify, we will strive to maintain backwards compatibility. We will provide deprecation warnings wherever possible in the scikit-bio code, documentation, and CHANGELOG.md.
+
+**Note:** Deprecation warnings will be issued using Python's ``DeprecationWarning`` class. Since Python 2.7, these types of warnings are **silenced by default**. When developing a tool that uses scikit-bio, we recommend enabling the display of deprecation warnings to be informed of upcoming API changes. For details on how to display deprecation warnings, see `Python's deprecation warning docs <https://docs.python.org/3/whatsnew/2.7.html#changes-to-the-handling-of-deprecation-warnings>`_.
 
 Installation of release version (recommended for most users)
 ------------------------------------------------------------

--- a/skbio/alignment/_alignment.py
+++ b/skbio/alignment/_alignment.py
@@ -128,7 +128,7 @@ class SequenceCollection(SkbioObject):
         warnings.warn(
             "SequenceCollection.from_fasta_records is deprecated and will be "
             "removed in scikit-bio 0.3.0. Please update your code to use "
-            "SequenceCollection.read.", UserWarning)
+            "SequenceCollection.read.", DeprecationWarning)
 
         data = []
         for seq_id, seq in fasta_records:
@@ -691,7 +691,7 @@ class SequenceCollection(SkbioObject):
         warnings.warn(
             "SequenceCollection.int_map is deprecated and will be removed in "
             "scikit-bio 0.3.0. Please update your code to use "
-            "SequenceCollection.update_ids instead.", UserWarning)
+            "SequenceCollection.update_ids instead.", DeprecationWarning)
 
         int_keys = []
         int_map = []
@@ -880,7 +880,7 @@ class SequenceCollection(SkbioObject):
         warnings.warn(
             "SequenceCollection.to_fasta is deprecated and will be removed in "
             "scikit-bio 0.3.0. Please update your code to use "
-            "SequenceCollection.write.", UserWarning)
+            "SequenceCollection.write.", DeprecationWarning)
 
         return ''.join([seq.to_fasta() for seq in self._data])
 
@@ -904,7 +904,7 @@ class SequenceCollection(SkbioObject):
         """
         warnings.warn(
             "SequenceCollection.toFasta() is deprecated. You should use "
-            "SequenceCollection.to_fasta().")
+            "SequenceCollection.to_fasta().", DeprecationWarning)
         return self.to_fasta()
 
     def upper(self):
@@ -1336,7 +1336,7 @@ class Alignment(SequenceCollection):
                 "deprecated and will be removed in scikit-bio 0.3.0. Please "
                 "update your code to construct the desired object from the "
                 "BiologicalSequence (or subclass) that is returned by this "
-                "method.", UserWarning)
+                "method.", DeprecationWarning)
 
         result = []
         for c in self.position_counters():
@@ -1638,7 +1638,7 @@ class Alignment(SequenceCollection):
         warnings.warn(
             "Alignment.to_phylip is deprecated and will be removed in "
             "scikit-bio 0.3.0. Please update your code to use "
-            "Alignment.write.", UserWarning)
+            "Alignment.write.", DeprecationWarning)
 
         if self.is_empty():
             raise SequenceCollectionError("PHYLIP-formatted string can only "

--- a/skbio/alignment/_pairwise.py
+++ b/skbio/alignment/_pairwise.py
@@ -594,7 +594,8 @@ def make_identity_substitution_matrix(match_score, mismatch_score,
     warn("make_identity_substitution_matrix is deprecated and will soon be "
          "replaced, though at the time of this writing the new name has not "
          "been finalized. Updates will be posted to issue #161: "
-         "https://github.com/biocore/scikit-bio/issues/161")
+         "https://github.com/biocore/scikit-bio/issues/161",
+         DeprecationWarning)
 
     result = {}
     for c1 in alphabet:

--- a/skbio/alignment/tests/test_alignment.py
+++ b/skbio/alignment/tests/test_alignment.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 # ----------------------------------------------------------------------------
 # Copyright (c) 2013--, scikit-bio development team.
 #
@@ -439,12 +437,13 @@ class SequenceCollectionTests(TestCase):
     def test_int_map(self):
         expected1 = {"1": self.d1, "2": self.d2}
         expected2 = {"1": "d1", "2": "d2"}
-        obs = npt.assert_warns(UserWarning, self.s1.int_map)
+        obs = npt.assert_warns(DeprecationWarning, self.s1.int_map)
         self.assertEqual(obs, (expected1, expected2))
 
         expected1 = {"h-1": self.d1, "h-2": self.d2}
         expected2 = {"h-1": "d1", "h-2": "d2"}
-        obs = npt.assert_warns(UserWarning, self.s1.int_map, prefix='h-')
+        obs = npt.assert_warns(DeprecationWarning, self.s1.int_map,
+                               prefix='h-')
         self.assertEqual(obs, (expected1, expected2))
 
     def test_is_empty(self):
@@ -503,7 +502,7 @@ class SequenceCollectionTests(TestCase):
 
     def test_toFasta(self):
         exp = ">d1\nGATTACA\n>d2\nTTG\n"
-        obs = npt.assert_warns(UserWarning, self.s1.toFasta)
+        obs = npt.assert_warns(DeprecationWarning, self.s1.toFasta)
         self.assertEqual(obs, exp)
 
     def test_upper(self):
@@ -711,7 +710,7 @@ class AlignmentTests(TestCase):
         d3 = DNASequence('TC-', id="d3")
         a1 = Alignment([d1, d2, d3])
 
-        obs = npt.assert_warns(UserWarning, a1.majority_consensus,
+        obs = npt.assert_warns(DeprecationWarning, a1.majority_consensus,
                                constructor=str)
         self.assertEqual(obs, 'TT-')
 
@@ -816,7 +815,7 @@ class AlignmentTests(TestCase):
         d3 = DNASequence('.-ACC-GTTGC--', id="d3")
         a = Alignment([d1, d2, d3])
 
-        phylip_str, id_map = npt.assert_warns(UserWarning, a.to_phylip,
+        phylip_str, id_map = npt.assert_warns(DeprecationWarning, a.to_phylip,
                                               map_labels=False)
         self.assertEqual(id_map, {'d1': 'd1',
                                   'd3': 'd3',
@@ -833,7 +832,7 @@ class AlignmentTests(TestCase):
         d3 = DNASequence('.-ACC-GTTGC--', id="d3")
         a = Alignment([d1, d2, d3])
 
-        phylip_str, id_map = npt.assert_warns(UserWarning, a.to_phylip,
+        phylip_str, id_map = npt.assert_warns(DeprecationWarning, a.to_phylip,
                                               map_labels=True,
                                               label_prefix="s")
         self.assertEqual(id_map, {'s1': 'd1',
@@ -847,7 +846,7 @@ class AlignmentTests(TestCase):
 
     def test_to_phylip_no_sequences(self):
         with self.assertRaises(SequenceCollectionError):
-            npt.assert_warns(UserWarning, Alignment([]).to_phylip)
+            npt.assert_warns(DeprecationWarning, Alignment([]).to_phylip)
 
     def test_to_phylip_no_positions(self):
         d1 = DNASequence('', id="d1")
@@ -855,7 +854,7 @@ class AlignmentTests(TestCase):
         a = Alignment([d1, d2])
 
         with self.assertRaises(SequenceCollectionError):
-            npt.assert_warns(UserWarning, a.to_phylip)
+            npt.assert_warns(DeprecationWarning, a.to_phylip)
 
     def test_validate_lengths(self):
         self.assertTrue(self.a1._validate_lengths())

--- a/skbio/diversity/beta/_base.py
+++ b/skbio/diversity/beta/_base.py
@@ -88,7 +88,7 @@ def pw_distances_from_table(table, metric="braycurtis"):
     warn("pw_distances_from_table is deprecated. In the future (tentatively "
          "scikit-bio 0.2.0), pw_distance will take a biom.table.Table object "
          "and this function will be removed. You will need to update your "
-         "code to call pw_distances at that time.")
+         "code to call pw_distances at that time.", DeprecationWarning)
     sample_ids = table.ids(axis="sample")
     num_samples = len(sample_ids)
 

--- a/skbio/diversity/beta/tests/test_base.py
+++ b/skbio/diversity/beta/tests/test_base.py
@@ -8,7 +8,7 @@ from __future__ import absolute_import, division, print_function
 # The full license is in the file COPYING.txt, distributed with this software.
 # ----------------------------------------------------------------------------
 
-from unittest import TestCase
+from unittest import TestCase, main
 
 import numpy as np
 import numpy.testing as npt
@@ -128,14 +128,16 @@ class BaseTests(TestCase):
         # results are equal when passed as Table or matrix
         m_dm = pw_distances(self.t1, self.ids1, 'euclidean')
         t_dm = npt.assert_warns(
-            UserWarning, pw_distances_from_table, self.table1, 'euclidean')
+            DeprecationWarning, pw_distances_from_table, self.table1,
+            'euclidean')
         for id1 in self.ids1:
             for id2 in self.ids1:
                 npt.assert_almost_equal(m_dm[id1, id2], t_dm[id1, id2])
 
         m_dm = pw_distances(self.t2, self.ids2, 'euclidean')
         t_dm = npt.assert_warns(
-            UserWarning, pw_distances_from_table, self.table2, 'euclidean')
+            DeprecationWarning, pw_distances_from_table, self.table2,
+            'euclidean')
         for id1 in self.ids2:
             for id2 in self.ids2:
                 npt.assert_almost_equal(m_dm[id1, id2], t_dm[id1, id2])
@@ -144,14 +146,20 @@ class BaseTests(TestCase):
         # results are equal when passed as Table or matrix
         m_dm = pw_distances(self.t1, self.ids1, 'braycurtis')
         t_dm = npt.assert_warns(
-            UserWarning, pw_distances_from_table, self.table1, 'braycurtis')
+            DeprecationWarning, pw_distances_from_table, self.table1,
+            'braycurtis')
         for id1 in self.ids1:
             for id2 in self.ids1:
                 npt.assert_almost_equal(m_dm[id1, id2], t_dm[id1, id2])
 
         m_dm = pw_distances(self.t2, self.ids2, 'braycurtis')
         t_dm = npt.assert_warns(
-            UserWarning, pw_distances_from_table, self.table2, 'braycurtis')
+            DeprecationWarning, pw_distances_from_table, self.table2,
+            'braycurtis')
         for id1 in self.ids2:
             for id2 in self.ids2:
                 npt.assert_almost_equal(m_dm[id1, id2], t_dm[id1, id2])
+
+
+if __name__ == "__main__":
+    main()

--- a/skbio/format/sequences/fasta.py
+++ b/skbio/format/sequences/fasta.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-"""Writer for FASTA sequence format"""
-
 # ----------------------------------------------------------------------------
 # Copyright (c) 2013--, scikit-bio development team.
 #
@@ -68,7 +65,7 @@ def fasta_from_sequences(seqs, make_seqlabel=None, line_wrap=None):
     warnings.warn(
         "`fasta_from_sequences` is deprecated and will be removed in "
         "scikit-bio 0.3.0. Please update your code to use `skbio.io.write`.",
-        UserWarning)
+        DeprecationWarning)
 
     fasta_list = []
     for i, seq in enumerate(seqs):
@@ -158,7 +155,7 @@ def fasta_from_alignment(aln, make_seqlabel=None, line_wrap=None, sort=True):
     warnings.warn(
         "`fasta_from_alignment` is deprecated and will be removed in "
         "scikit-bio 0.3.0. Please update your code to use `skbio.io.write` "
-        "or `skbio.Alignment.write`.", UserWarning)
+        "or `skbio.Alignment.write`.", DeprecationWarning)
 
     # check if it's an Alignment object or a dictionary
     if isinstance(aln, Alignment):

--- a/skbio/format/sequences/fastq.py
+++ b/skbio/format/sequences/fastq.py
@@ -1,5 +1,3 @@
-"""Formatters for FASTQ"""
-
 # ----------------------------------------------------------------------------
 # Copyright (c) 2013--, scikit-bio development team.
 #
@@ -68,7 +66,7 @@ def format_fastq_record(seqid, seq, qual, phred_offset=33):
     warnings.warn(
         "`format_fastq_record` is deprecated and will be removed in "
         "scikit-bio 0.3.0. Please update your code to use `skbio.io.write`.",
-        UserWarning)
+        DeprecationWarning)
 
     if phred_offset == 33:
         phred_f = _phred_to_ascii33

--- a/skbio/parse/record.py
+++ b/skbio/parse/record.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 # ----------------------------------------------------------------------------
 # Copyright (c) 2013--, scikit-bio development team.
 #

--- a/skbio/parse/sequences/clustal.py
+++ b/skbio/parse/sequences/clustal.py
@@ -72,7 +72,7 @@ def write_clustal(records, fh):
     warnings.warn(
         "write_clustal is deprecated and will be removed in "
         "scikit-bio 0.3.0. Please update your code to use Alignment.write.",
-        UserWarning)
+        DeprecationWarning)
     clen = 60
     records = list(records)
     names, seqs = zip(*records)
@@ -90,7 +90,7 @@ def parse_clustal(record, strict=True):
     warnings.warn(
         "parse_clustal is deprecated and will be removed in "
         "scikit-bio 0.3.0. Please update your code to use Alignment.read.",
-        UserWarning)
+        DeprecationWarning)
 
     records = map(_delete_trailing_number,
                   filter(_is_clustal_seq_line, record))

--- a/skbio/parse/sequences/fasta.py
+++ b/skbio/parse/sequences/fasta.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -----------------------------------------------------------------------------
 # Copyright (c) 2013--, scikit-bio development team.
 #
@@ -132,7 +131,7 @@ def parse_fasta(infile, strict=True, label_to_name=None, finder=FastaFinder,
         "`parse_fasta` is deprecated and will be removed in scikit-bio 0.3.0. "
         "Please update your code to use `skbio.io.read(fh, format='fasta')` "
         "to obtain a generator of `BiologicalSequence` objects (or "
-        "subclasses, see the `constructor` parameter).", UserWarning)
+        "subclasses, see the `constructor` parameter).", DeprecationWarning)
 
     for rec in finder(infile):
         # first line must be a label line
@@ -223,7 +222,7 @@ def parse_qual(infile, full_header=False):
         "Please update your code to use "
         "`skbio.io.read(fasta_fh, qual=qual_fh, format='fasta')` to obtain a "
         "generator of `BiologicalSequence` objects (or subclasses, see the "
-        "`constructor` parameter) with quality scores.", UserWarning)
+        "`constructor` parameter) with quality scores.", DeprecationWarning)
 
     for rec in FastaFinder(infile):
         curr_id = rec[0][1:]

--- a/skbio/parse/sequences/fastq.py
+++ b/skbio/parse/sequences/fastq.py
@@ -122,7 +122,7 @@ def parse_fastq(data, strict=False, enforce_qual_range=True, phred_offset=33):
         "`parse_fastq` is deprecated and will be removed in scikit-bio 0.3.0. "
         "Please update your code to use `skbio.io.read(fh, format='fastq')` "
         "to obtain a generator of `BiologicalSequence` objects (or "
-        "subclasses, see the `constructor` parameter).", UserWarning)
+        "subclasses, see the `constructor` parameter).", DeprecationWarning)
 
     if phred_offset == 33:
         phred_f = ascii_to_phred33

--- a/skbio/sequence/_sequence.py
+++ b/skbio/sequence/_sequence.py
@@ -1421,7 +1421,7 @@ class BiologicalSequence(Sequence, SkbioObject):
         warnings.warn(
             "BiologicalSequence.to_fasta is deprecated and will be removed in "
             "scikit-bio 0.3.0. Please update your code to use "
-            "BiologicalSequence.write.", UserWarning)
+            "BiologicalSequence.write.", DeprecationWarning)
 
         if self._description:
             header_line = '%s%s%s' % (self._id, field_delimiter,

--- a/skbio/stats/_misc.py
+++ b/skbio/stats/_misc.py
@@ -45,7 +45,7 @@ def p_value_to_str(p_value, permutations):
     warnings.warn(
         "skbio.stats.p_value_to_str is deprecated and will be removed in "
         "scikit-bio 0.3.0. There are no plans to provide a replacement for "
-        "this functionality.", UserWarning)
+        "this functionality.", DeprecationWarning)
 
     if p_value is None or np.isnan(p_value):
         result = 'N/A'

--- a/skbio/stats/distance/_anosim.py
+++ b/skbio/stats/distance/_anosim.py
@@ -244,7 +244,7 @@ class ANOSIM(CategoricalStats):
         warnings.warn(
             "skbio.stats.distance.ANOSIM is deprecated and will be removed in "
             "scikit-bio 0.3.0. Please update your code to use "
-            "skbio.stats.distance.anosim.", UserWarning)
+            "skbio.stats.distance.anosim.", DeprecationWarning)
 
         super(ANOSIM, self).__init__(distance_matrix, grouping, column=column)
 

--- a/skbio/stats/distance/_base.py
+++ b/skbio/stats/distance/_base.py
@@ -141,7 +141,7 @@ class DissimilarityMatrix(SkbioObject):
             "DissimilarityMatrix.from_file and DistanceMatrix.from_file are "
             "deprecated and will be removed in scikit-bio 0.3.0. Please "
             "update your code to use DissimilarityMatrix.read and "
-            "DistanceMatrix.read.", UserWarning)
+            "DistanceMatrix.read.", DeprecationWarning)
         return cls.read(lsmat_f, format='lsmat', delimiter=delimiter)
 
     def to_file(self, out_f, delimiter='\t'):
@@ -173,7 +173,7 @@ class DissimilarityMatrix(SkbioObject):
             "DissimilarityMatrix.to_file and DistanceMatrix.to_file are "
             "deprecated and will be removed in scikit-bio 0.3.0. Please "
             "update your code to use DissimilarityMatrix.write and "
-            "DistanceMatrix.write.", UserWarning)
+            "DistanceMatrix.write.", DeprecationWarning)
         self.write(out_f, format='lsmat', delimiter=delimiter)
 
     def __init__(self, data, ids=None):
@@ -1154,7 +1154,7 @@ class CategoricalStatsResults(object):
             "will be removed in scikit-bio 0.3.0. Please update your code to "
             "use either skbio.stats.distance.anosim or "
             "skbio.stats.distance.permanova, which will return a "
-            "pandas.Series object.", UserWarning)
+            "pandas.Series object.", DeprecationWarning)
 
         self.short_method_name = short_method_name
         self.long_method_name = long_method_name

--- a/skbio/stats/distance/_permanova.py
+++ b/skbio/stats/distance/_permanova.py
@@ -175,7 +175,7 @@ class PERMANOVA(CategoricalStats):
         warnings.warn(
             "skbio.stats.distance.PERMANOVA is deprecated and will be removed "
             "in scikit-bio 0.3.0. Please update your code to use "
-            "skbio.stats.distance.permanova.", UserWarning)
+            "skbio.stats.distance.permanova.", DeprecationWarning)
 
         super(PERMANOVA, self).__init__(distance_matrix, grouping,
                                         column=column)

--- a/skbio/stats/distance/tests/test_base.py
+++ b/skbio/stats/distance/tests/test_base.py
@@ -59,9 +59,9 @@ class DissimilarityMatrixTests(DissimilarityMatrixTestData):
 
     def test_deprecated_io(self):
         fh = StringIO()
-        npt.assert_warns(UserWarning, self.dm_3x3.to_file, fh)
+        npt.assert_warns(DeprecationWarning, self.dm_3x3.to_file, fh)
         fh.seek(0)
-        deserialized = npt.assert_warns(UserWarning,
+        deserialized = npt.assert_warns(DeprecationWarning,
                                         DissimilarityMatrix.from_file, fh)
         self.assertEqual(deserialized, self.dm_3x3)
         self.assertTrue(type(deserialized) == DissimilarityMatrix)
@@ -460,9 +460,9 @@ class DistanceMatrixTests(DissimilarityMatrixTestData):
 
     def test_deprecated_io(self):
         fh = StringIO()
-        npt.assert_warns(UserWarning, self.dm_3x3.to_file, fh)
+        npt.assert_warns(DeprecationWarning, self.dm_3x3.to_file, fh)
         fh.seek(0)
-        deserialized = npt.assert_warns(UserWarning,
+        deserialized = npt.assert_warns(DeprecationWarning,
                                         DistanceMatrix.from_file, fh)
         self.assertEqual(deserialized, self.dm_3x3)
         self.assertTrue(type(deserialized) == DistanceMatrix)

--- a/skbio/stats/ordination/_base.py
+++ b/skbio/stats/ordination/_base.py
@@ -111,7 +111,7 @@ class OrdinationResults(SkbioObject):
         warnings.warn(
             "OrdinationResults.from_file is deprecated and will be removed in "
             "scikit-bio 0.3.0. Please update your code to use "
-            "OrdinationResults.read.", UserWarning)
+            "OrdinationResults.read.", DeprecationWarning)
         return cls.read(ord_res_f, format='ordination')
 
     def to_file(self, out_f):
@@ -140,7 +140,7 @@ class OrdinationResults(SkbioObject):
         warnings.warn(
             "OrdinationResults.to_file is deprecated and will be removed in "
             "scikit-bio 0.3.0. Please update your code to use "
-            "OrdinationResults.write.", UserWarning)
+            "OrdinationResults.write.", DeprecationWarning)
         self.write(out_f, format='ordination')
 
     def __str__(self):

--- a/skbio/stats/ordination/tests/test_ordination.py
+++ b/skbio/stats/ordination/tests/test_ordination.py
@@ -665,9 +665,10 @@ class TestOrdinationResults(unittest.TestCase):
 
     def test_deprecated_io(self):
         fh = StringIO()
-        npt.assert_warns(UserWarning, self.ordination_results.to_file, fh)
+        npt.assert_warns(DeprecationWarning, self.ordination_results.to_file,
+                         fh)
         fh.seek(0)
-        deserialized = npt.assert_warns(UserWarning,
+        deserialized = npt.assert_warns(DeprecationWarning,
                                         OrdinationResults.from_file, fh)
         assert_ordination_results_equal(deserialized, self.ordination_results)
         self.assertTrue(type(deserialized) == OrdinationResults)

--- a/skbio/tree/_tree.py
+++ b/skbio/tree/_tree.py
@@ -1869,7 +1869,7 @@ class TreeNode(SkbioObject):
         warnings.warn(
             "TreeNode.from_file is deprecated and will be removed in "
             "scikit-bio 0.3.0. Please update your code to use TreeNode.read.",
-            UserWarning)
+            DeprecationWarning)
         return cls.read(tree_f, format='newick')
 
     def _balanced_distance_to_tip(self):
@@ -2033,7 +2033,7 @@ class TreeNode(SkbioObject):
         warnings.warn(
             "TreeNode.from_newick is deprecated and will be removed in "
             "scikit-bio 0.3.0. Please update your code to use TreeNode.read.",
-            UserWarning)
+            DeprecationWarning)
 
         def _new_child(old_node):
             """Returns new_node which has old_node as its parent."""
@@ -2341,7 +2341,7 @@ class TreeNode(SkbioObject):
         warnings.warn(
             "TreeNode.to_newick is deprecated and will be removed in "
             "scikit-bio 0.3.0. Please update your code to use TreeNode.write.",
-            UserWarning)
+            DeprecationWarning)
         result = ['(']
         nodes_stack = [[self, len(self.children)]]
         node_count = 1

--- a/skbio/tree/tests/test_tree.py
+++ b/skbio/tree/tests/test_tree.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 # ----------------------------------------------------------------------------
 # Copyright (c) 2013--, scikit-bio development team.
 #


### PR DESCRIPTION
Previously we were using `UserWarning`. Fixes #774.

@gregcaporaso @ebolyen are you available to review?
