### PR TITLE
Fix typo pairwise alignment typo

### DIFF
--- a/skbio/alignment/_pairwise.py
+++ b/skbio/alignment/_pairwise.py
@@ -766,7 +766,7 @@ def _compute_score_and_traceback_matrices(
     score_matrix, traceback_matrix = init_matrices_f(
         aln1, aln2, gap_open_penalty, gap_extend_penalty)
 
-    # Iterate over the characters in aln2 (which corresponds to the vertical 
+    # Iterate over the characters in aln2 (which corresponds to the vertical
     # sequence in the matrix)
     for aln2_pos, aln2_chars in enumerate(aln2.iter_positions(str), 1):
         # Iterate over the characters in aln1 (which corresponds to the

--- a/skbio/alignment/_pairwise.py
+++ b/skbio/alignment/_pairwise.py
@@ -766,7 +766,7 @@ def _compute_score_and_traceback_matrices(
     score_matrix, traceback_matrix = init_matrices_f(
         aln1, aln2, gap_open_penalty, gap_extend_penalty)
 
-    # Iterate over the characters in aln2 (which corresponds to the horizontal
+    # Iterate over the characters in aln2 (which corresponds to the vertical 
     # sequence in the matrix)
     for aln2_pos, aln2_chars in enumerate(aln2.iter_positions(str), 1):
         # Iterate over the characters in aln1 (which corresponds to the


### PR DESCRIPTION
The typo mixed up the vertical and horizontal axes in the
traceback matrix at a certain point.

Should resolve #745.