### PR TITLE
DEP: deprecated `util.flatten`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,8 @@
 ### Bug fixes
 
 ### Deprecated functionality
-* Deprecated `skbio.util.flatten`. Please use standard python library functionality
-described here (http://stackoverflow.com/questions/952914/making-a-flat-list-out-of-list-of-lists-in-python)
- (http://stackoverflow.com/questions/406121/flattening-a-shallow-list-in-python) ([#833](https://github.com/biocore/scikit-bio/issues/833))
+* Deprecated `skbio.util.flatten`. This function will be removed in scikit-bio 0.3.1. Please use standard python library functionality
+described here [Making a flat list out of lists of lists](http://stackoverflow.com/a/952952/3639023), [Flattening a shallow list](http://stackoverflow.com/a/406199/3639023) ([#833](https://github.com/biocore/scikit-bio/issues/833))
 
 ### Backward-incompatible changes
 * Removed the following deprecated functionality:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 ### Bug fixes
 
+### Deprecated functionality
+* Deprecated `skbio.util.flatten`. Please use standard python library functionality
+described here (http://stackoverflow.com/questions/952914/making-a-flat-list-out-of-list-of-lists-in-python)
+ (http://stackoverflow.com/questions/406121/flattening-a-shallow-list-in-python) ([#833](https://github.com/biocore/scikit-bio/issues/833))
+
 ### Backward-incompatible changes
 * Removed the following deprecated functionality:
     - `skbio.parse` subpackage, including `SequenceIterator`, `FastaIterator`, `FastqIterator`, `load`, `parse_fasta`, `parse_fastq`, `parse_qual`, `write_clustal`, `parse_clustal`, and `FastqParseError`; please use `skbio.io` instead.

--- a/skbio/util/_misc.py
+++ b/skbio/util/_misc.py
@@ -270,14 +270,12 @@ def flatten(items):
     """Removes one level of nesting from items
 
     .. note:: Deprecated in scikit-bio 0.2.3-dev
-       ``util.flatten`` will be removed in scikit-bio 0.3.1
+       ``skbio.util.flatten`` will be removed in scikit-bio 0.3.1
        it is being deprecated in favor of solutions present
        in the standard python library.
        Please refer to the following links for good alternatives:
-       http://stackoverflow.com/questions/952914/making-a-flat-list
-       -out-of-list-of-lists-in-python
-       http://stackoverflow.com/questions/406121/flattening-a-shallow-
-       list-in-python.
+       http://stackoverflow.com/a/952952/3639023
+       http://stackoverflow.com/a/406199/3639023.
 
     Parameters
     ----------
@@ -298,12 +296,10 @@ def flatten(items):
     ['a', 'b', 'c', 'd', 1, 2, 3, 4, 5, 'x', 'y', 'foo']
 
     """
-    warn("flatten is deprecated. Please refer to the following links for "
-         "solutions from the standard python library "
-         "http://stackoverflow.com/questions/952914/making-a-flat-list"
-         "-out-of-list-of-lists-in-python "
-         "http://stackoverflow.com/questions/406121/flattening-a-shallow-"
-         "list-in-python.", DeprecationWarning)
+    warn("skbio.util.flatten is deprecated. Please refer to the following "
+         "links for solutions from the standard python library: "
+         "http://stackoverflow.com/a/952952/3639023 "
+         "http://stackoverflow.com/a/406199/3639023", DeprecationWarning)
 
     result = []
     for i in items:

--- a/skbio/util/_misc.py
+++ b/skbio/util/_misc.py
@@ -12,6 +12,8 @@ import hashlib
 from os import remove, makedirs
 from os.path import exists, isdir
 from functools import partial
+from warnings import warn
+
 
 
 def cardinal_to_ordinal(n):
@@ -268,6 +270,17 @@ def find_duplicates(iterable):
 def flatten(items):
     """Removes one level of nesting from items
 
+    .. note:: Deprecated in scikit-bio 0.2.3-dev
+       ``util.flatten`` will be removed in scikit-bio 0.3.1
+       it is being deprecated in favor of solutions present
+       in the standard python library.
+       Please refer to the following links for good alternatives:
+       http://stackoverflow.com/questions/952914/making-a-flat-list
+       -out-of-list-of-lists-in-python
+       http://stackoverflow.com/questions/406121/flattening-a-shallow-
+       list-in-python.
+
+
     Parameters
     ----------
     items : iterable
@@ -287,6 +300,13 @@ def flatten(items):
     ['a', 'b', 'c', 'd', 1, 2, 3, 4, 5, 'x', 'y', 'foo']
 
     """
+    warn("flatten is deprecated. Please refer to the following links for "
+         "solutions from the standard python library "
+         "http://stackoverflow.com/questions/952914/making-a-flat-list"
+         "-out-of-list-of-lists-in-python "
+         "http://stackoverflow.com/questions/406121/flattening-a-shallow-"
+         "list-in-python.", DeprecationWarning)
+
     result = []
     for i in items:
         try:

--- a/skbio/util/_misc.py
+++ b/skbio/util/_misc.py
@@ -15,7 +15,6 @@ from functools import partial
 from warnings import warn
 
 
-
 def cardinal_to_ordinal(n):
     """Return ordinal string version of cardinal int `n`.
 
@@ -279,7 +278,6 @@ def flatten(items):
        -out-of-list-of-lists-in-python
        http://stackoverflow.com/questions/406121/flattening-a-shallow-
        list-in-python.
-
 
     Parameters
     ----------


### PR DESCRIPTION
Deprecated `util.flatten` in favor of standard python solutions.
This is deprecated in 0.2.3-dev. addresses part of #833