### PR TITLE
ENH: numpy no longer needed prior to running setup.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ described here [Making a flat list out of lists of lists](http://stackoverflow.c
 
 ### Miscellaneous
 
+* `numpy` is no longer required to be installed before installing scikit-bio!
+
 ## Version 0.2.3 (2015-02-13)
 
 ### Features

--- a/README.rst
+++ b/README.rst
@@ -41,7 +41,6 @@ Installation of release version (recommended for most users)
 
 To install the latest release version of scikit-bio you should run::
 
-    pip install numpy
     pip install scikit-bio
 
 Equivalently, you can use the ``conda`` package manager available in `Anaconda <http://continuum.io/downloads>`_ or `miniconda <http://conda.pydata.org/miniconda.html>`_ to install scikit-bio and all its dependencies, without having to compile them::

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -70,7 +70,6 @@ Once the release is created on GitHub, it's a good idea to test out the release 
 
 3. Install the release and run the tests:
 
-        pip install numpy
         pip install .
         cd
         nosetests --with-doctest skbio
@@ -92,7 +91,6 @@ Assuming the GitHub release tarball correctly installs and passes its tests, you
 3. Create a new virtualenv and run:
 
         cd
-        pip install numpy
         pip install <path to extracted scikit-bio release>/dist/scikit-bio-1.2.4.tar.gz
         nosetests --with-doctest skbio
 
@@ -105,7 +103,6 @@ Assuming the GitHub release tarball correctly installs and passes its tests, you
 5. Once the release is available on PyPI, do a final round of testing. Create a new virtualenv and run:
 
         cd
-        pip install numpy
         pip install scikit-bio
         nosetests --with-doctest skbio
 

--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,19 @@ import os
 import platform
 from setuptools import find_packages, setup
 from setuptools.extension import Extension
+from setuptools.command.build_ext import build_ext as _build_ext
 
-import numpy as np
+
+# Bootstrap setup.py with numpy
+# Huge thanks to coldfix's solution
+# http://stackoverflow.com/a/21621689/579416
+class build_ext(_build_ext):
+    def finalize_options(self):
+        _build_ext.finalize_options(self)
+        # Prevent numpy from thinking it is still in its setup process:
+        __builtins__.__NUMPY_SETUP__ = False
+        import numpy
+        self.include_dirs.append(numpy.get_include())
 
 __version__ = "0.2.3-dev"
 
@@ -84,7 +95,8 @@ setup(name='scikit-bio',
       test_suite='nose.collector',
       packages=find_packages(),
       ext_modules=extensions,
-      include_dirs=[np.get_include()],
+      cmdclass={'build_ext': build_ext},
+      setup_requires=['numpy >= 1.7'],
       install_requires=['numpy >= 1.7', 'matplotlib >= 1.1.0',
                         'scipy >= 0.13.0', 'pandas', 'future', 'six',
                         'natsort', 'IPython'],


### PR DESCRIPTION
Thanks to http://stackoverflow.com/a/21621689/579416
we can now `pip install scikit-bio` without numpy! It would be great if others could confirm this works on their system on a fresh venv. 
This is very similar to the approach matplotlib uses, just not quite as heavyweight. 