### PR TITLE
Hommola cospeciation test (skbio.stats.evolve)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Version 0.2.3-dev (changes since 0.2.3 release go here)
 
 ### Features
+* Added new ``skbio.stats.evolve`` subpackage for evolutionary statistics. Currently contains a single function, ``hommola_cospeciation``, which implements a permutation-based test of correlation between two distance matrices.
 
 ### Bug fixes
 * Changed `BiologicalSequence.distance` to raise an error any time two sequences are passed of different lengths regardless of the `distance_fn` being passed. [(#514)](https://github.com/biocore/scikit-bio/issues/514)

--- a/skbio/stats/__init__.py
+++ b/skbio/stats/__init__.py
@@ -14,6 +14,7 @@ Subpackages
    :toctree: generated/
 
    distance
+   evolve
    ordination
    spatial
    gradient

--- a/skbio/stats/evolve/__init__.py
+++ b/skbio/stats/evolve/__init__.py
@@ -30,9 +30,10 @@ Functions
 # The full license is in the file COPYING.txt, distributed with this software.
 # ----------------------------------------------------------------------------
 
+from skbio.util import TestRunner
+
 from ._hommola import hommola_cospeciation
 
 __all__ = ['hommola_cospeciation']
 
-from numpy.testing import Tester
-test = Tester().test
+test = TestRunner(__file__).test

--- a/skbio/stats/evolve/__init__.py
+++ b/skbio/stats/evolve/__init__.py
@@ -1,0 +1,38 @@
+"""
+Evolutionary statistics (:mod:`skbio.stats.evolve`)
+===================================================
+
+.. currentmodule:: skbio.stats.evolve
+
+This package contains statistics pertaining to phylogenies and evolution.
+
+Cophylogenetic methods
+----------------------
+
+These functions test for correlation between phylogenies or representations of
+evolutionary distance (for example, genetic distance matrices).
+
+Functions
+^^^^^^^^^
+
+.. autosummary::
+   :toctree: generated/
+
+   hommola_cospeciation
+
+"""
+
+# ----------------------------------------------------------------------------
+# Copyright (c) 2013--, scikit-bio development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+# ----------------------------------------------------------------------------
+
+from ._hommola import hommola_cospeciation
+
+__all__ = ['hommola_cospeciation']
+
+from numpy.testing import Tester
+test = Tester().test

--- a/skbio/stats/evolve/_hommola.py
+++ b/skbio/stats/evolve/_hommola.py
@@ -1,0 +1,280 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2013--, scikit-bio development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+# ----------------------------------------------------------------------------
+
+from __future__ import absolute_import, division, print_function
+from future.builtins import range
+
+import numpy as np
+from scipy.stats import pearsonr
+
+from skbio import DistanceMatrix
+
+
+def hommola_cospeciation(host_dist, par_dist, interaction, permutations=999):
+    """Performs a cospeciation test
+
+    This test for host/parasite cospeciation is as described in [1]_. This test
+    is a modification of a Mantel test, expanded to accept the case where
+    multiple hosts map to a single parasite (and vice versa).
+
+    For a basic Mantel test, the distance matrices being compared must have the
+    same number of values. To determine the significance of the correlations
+    between distances in the two matrices, the correlation coefficient of those
+    distances is calculated and compared to the correlation coefficients
+    calculated from a set of matrices in which rows and columns have been
+    permuted.
+
+    In this test, rather than comparing host-host to parasite-parasite
+    distances directly (requiring one host per parasite), the distances are
+    compared for each interaction edge between host and parasite. Thus, a host
+    interacting with two different parasites will be represented in two
+    different edges, with the host-host distance for the comparison between
+    those edges equal to zero, and the parasite-parasite distance equal to the
+    distance between those two parasites. Like in the Mantel test, significance
+    of the interaction is assessed by permutation, in this case permutation of
+    the host-symbiont interaction links.
+
+    Note that the null hypothesis being tested here is that the hosts and
+    parasites have evolved independently of one another. The alternative to
+    this is a somewhat weaker case than what is often implied with the term
+    'cospeciation,' which is that each incidence of host speciation is
+    recapitulated in an incidence of symbiont speciation (strict
+    co-cladogenesis). Although there may be many factors that could contribute
+    to non-independence of host and symboint phylogenies, this loss of
+    explanatory specificity comes with increased robustness to phylogenetic
+    uncertainty. Thus, this test may be especially useful for cases where host
+    and/or symbiont phylogenies are poorly resolved, or when simple correlation
+    between host and symbiont evolution is of more interest than strict co-
+    cladogenesis.
+
+    This test requires pairwise distance matrices for hosts and symbionts, as
+    well as an interaction matrix specifying links between hosts (in columns)
+    and symbionts (in rows). This interaction matrix should have the same
+    number of columns as the host distance matrix, and the same number of rows
+    as the symbiont distance matrix. Interactions between hosts and symbionts
+    should be indicated by values of 1 or True, with non-interactions indicated
+    by values of 0 or False.
+
+    Parameters
+    ----------
+    host_dist : array_like or DistanceMatrix
+        Symmetric matrix of m x m pairwise distances between hosts
+    par_dist : array_like or DistanceMatrix
+        Symmetric matrix of n x n pairwise distances between parasites
+    interaction : 2-D array_like, bool
+        n x m binary matrix of parasite x host interactions. Order of hosts
+        (columns) should be identical to order of hosts in host_dist, as should
+        order of parasites (rows)
+    permutations : int, optional
+        Number of permutations to run. Default 999. Must be greater than or
+        equal to zero. If zero, statistical significance calculations will be
+        skipped and the p-value will be ``np.nan``
+
+    Returns
+    -------
+    r : float
+        Correlation coefficient of host : parasite association
+    p_val : float
+        Significance of host : parasite association
+    perm_stats : list of floats
+        List of r values observed using permuted host : parasite interactions
+
+    See Also
+    --------
+    skbio.stats.distance.mantel
+    scipy.stats.pearsonr
+
+    Notes
+    -----
+    It is assumed that the ordering of parasites in par_dist and hosts in
+    host_dist and are identical to their ordering in the rows and columns,
+    respectively, of the interaction matrix. No matching of labels is
+    performed.
+
+    This code is loosely based on the original R code from [1]_.
+
+    References
+    ----------
+    .. [1] Hommola K, Smith JE, Qiu Y, Gilks WR (2009) A Permutation Test of
+       Host-Parasite Cospeciation. Molecular Biology and Evolution, 26,
+       1457-1468.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from skbio.stats.evolve import hommola_cospeciation
+
+    Import arrays for host distances, parasite distances, and the interactions.
+    (Test data from example in [1]_.)
+
+    >>> hdist = np.array([[0,3,8,8,9],[3,0,7,7,8],[8,7,0,6,7],[8,7,6,0,3],
+    ...                  [9,8,7,3,0]])
+    >>> pdist = np.array([[0,5,8,8,8],[5,0,7,7,7],[8,7,0,4,4],[8,7,4,0,2],
+    ...                  [8,7,4,2,0]])
+    >>> interaction = np.array([[1,0,0,0,0],[0,1,0,0,0],[0,0,1,0,0],
+    ...                        [0,0,0,1,0],[0,0,0,1,1]])
+
+    Run the permutation test. Note that the correlation coefficient for the
+    observed values counts against the final reported p value.
+
+    >>> r_val, p_val, perm_stats = hommola_cospeciation(hdist, pdist,
+    ...                                                 interaction, 99)
+    >>> r_val
+    0.83170965463247937
+
+    In this case, the host distances have a fairly strong positive correlation
+    with the symbiont distances. However, this may also reflect structure
+    inherent in the phylogeny, and is not itself indicative of significance.
+
+    >>> p_val <= 0.05
+    True
+
+    After permuting host : parasite interactions, we find that the observed
+    correlation is indeed greater than we would expect by chance.
+    """
+    # Regularize input objects
+    host_dist = DistanceMatrix(host_dist)
+    par_dist = DistanceMatrix(par_dist)
+    interaction = np.asarray(interaction, dtype=bool)
+
+    num_hosts = host_dist.shape[0]
+    num_pars = par_dist.shape[0]
+
+    # Sanity check inputs
+    if num_hosts < 3 or num_pars < 3:
+        raise ValueError("Distance matrices must be minimum of 3x3 in size).")
+    if num_hosts != interaction.shape[1]:
+        raise ValueError("Number of interaction matrix columns must match "
+                         "number of hosts in host_dist")
+    if num_pars != interaction.shape[0]:
+        raise ValueError("Number of interaction matrix rows must match "
+                         "number of parasites in par_dist")
+    if permutations < 0:
+        raise ValueError("Number of permutations must be greater than or "
+                         "equal to zero.")
+    if interaction.sum() < 3:
+        raise ValueError("Must have at least 3 host-parasite interactions")
+
+    # Shortcut to eliminate nested for loops specifying pairwise interaction
+    # partners as randomizeable indices
+    pars, hosts = np.nonzero(interaction)
+    pars_k_labels, pars_t_labels = _gen_lists(pars)
+    hosts_k_labels, hosts_t_labels = _gen_lists(hosts)
+
+    # get a vector of pairwise distances for each interaction edge
+    x = _get_dist(hosts_k_labels, hosts_t_labels, host_dist.data,
+                  np.arange(num_hosts))
+    y = _get_dist(pars_k_labels, pars_t_labels, par_dist.data,
+                  np.arange(num_pars))
+
+    # calculate sorting index to ensure consistency from pearsonr
+    sort = (x + y).argsort()
+
+    # calculate the observed correlation coefficient for this host/symbionts
+    r = pearsonr(x[sort], y[sort])[0]
+
+    # now do permutatitons. Initialize index lists of the appropriate size.
+    mp = np.arange(num_pars)
+    mh = np.arange(num_hosts)
+
+    # initialize list of shuffled correlation vals
+    perm_stats = np.empty(permutations)
+
+    if permutations == 0 or np.isnan(r):
+        p_val = np.nan
+        perm_stats[:] = np.nan
+    else:
+        for i in range(permutations):
+            # Generate a shuffled list of indexes for each permutation. This
+            # effectively randomizes which host is associated with which
+            # symbiont, but maintains the distribution of genetic distances.
+            np.random.shuffle(mp)
+            np.random.shuffle(mh)
+
+            # Get pairwise distances in shuffled order
+            y_p = _get_dist(pars_k_labels, pars_t_labels, par_dist.data, mp)
+            x_p = _get_dist(hosts_k_labels, hosts_t_labels, host_dist.data, mh)
+
+            # calculate sorting index to ensure consistency from pearsonr
+            sort = (x_p + y_p).argsort()
+
+            # calculate shuffled correlation.
+            # If greater than observed value, iterate counter below.
+            r_p = pearsonr(x_p[sort], y_p[sort])[0]
+            perm_stats[i] = r_p
+
+        below = (perm_stats >= r).sum()
+
+        p_val = (below + 1) / (permutations + 1)
+
+    return r, p_val, perm_stats
+
+
+def _get_dist(k_labels, t_labels, dists, index):
+    """Function for picking a subset of pairwise distances from a distance
+    matrix according to a set of (randomizable) index labels.
+    Derived from [1]_.
+
+    Parameters
+    ----------
+    k_labels : numpy.array
+        index labels specifying row-wise member of pairwise interaction
+    t_labels : numpy.array
+        index labels specifying column-wise member of pairwise interaction
+    dists : numpy.array
+        pairwise distance matrix
+    index : numpy.array of int
+        permutable indices for changing order in pairwise distance matrix
+
+    Returns
+    -------
+    vec : list of float
+        Returns list of distances associated with host:parasite edges, per
+        description in [1]_.
+
+    References
+    ----------
+    .. [1] Hommola K, Smith JE, Qiu Y, Gilks WR (2009) A Permutation Test of
+       Host-Parasite Cospeciation. Molecular Biology and Evolution, 26,
+       1457-1468.
+    """
+    return dists[index[k_labels], index[t_labels]]
+
+
+def _gen_lists(labels):
+    """Shortcut function for generating matched lists of row and col index
+    labels for the set of pairwise comparisons specified by the list of those
+    indices recovered using np.nonzero(interaction).
+
+    Reproduces values of iterated indices from the nested for loops contained
+    in 'get_dist' function in original code from [1]_.
+
+    Parameters
+    ----------
+    labels : numpy.array
+        array containing the indices of nonzero elements in one dimension of an
+        interaction matrix
+
+    Returns
+    -------
+    k_labels : numpy.array
+        index labels specifying row-wise member of pairwise interaction
+    t_labels : numpy.array
+        index labels specifying column-wise member of pairwise interaction
+
+    References
+    ----------
+    .. [1] Hommola K, Smith JE, Qiu Y, Gilks WR (2009) A Permutation Test of
+       Host-Parasite Cospeciation. Molecular Biology and Evolution, 26,
+       1457-1468.
+    """
+    i_array, j_array = np.transpose(np.tri(len(labels)-1)).nonzero()
+    j_array = j_array + 1
+    k_labels = labels[i_array]
+    t_labels = labels[j_array]
+    return k_labels, t_labels

--- a/skbio/stats/evolve/_hommola.py
+++ b/skbio/stats/evolve/_hommola.py
@@ -16,7 +16,7 @@ from skbio import DistanceMatrix
 
 
 def hommola_cospeciation(host_dist, par_dist, interaction, permutations=999):
-    """Performs a cospeciation test
+    """Perform Hommola et al (2009) host/parasite cospeciation test.
 
     This test for host/parasite cospeciation is as described in [1]_. This test
     is a modification of a Mantel test, expanded to accept the case where
@@ -45,44 +45,48 @@ def hommola_cospeciation(host_dist, par_dist, interaction, permutations=999):
     'cospeciation,' which is that each incidence of host speciation is
     recapitulated in an incidence of symbiont speciation (strict
     co-cladogenesis). Although there may be many factors that could contribute
-    to non-independence of host and symboint phylogenies, this loss of
+    to non-independence of host and symbiont phylogenies, this loss of
     explanatory specificity comes with increased robustness to phylogenetic
     uncertainty. Thus, this test may be especially useful for cases where host
     and/or symbiont phylogenies are poorly resolved, or when simple correlation
-    between host and symbiont evolution is of more interest than strict co-
-    cladogenesis.
+    between host and symbiont evolution is of more interest than strict
+    co-cladogenesis.
 
     This test requires pairwise distance matrices for hosts and symbionts, as
     well as an interaction matrix specifying links between hosts (in columns)
     and symbionts (in rows). This interaction matrix should have the same
     number of columns as the host distance matrix, and the same number of rows
     as the symbiont distance matrix. Interactions between hosts and symbionts
-    should be indicated by values of 1 or True, with non-interactions indicated
-    by values of 0 or False.
+    should be indicated by values of ``1`` or ``True``, with non-interactions
+    indicated by values of ``0`` or ``False``.
 
     Parameters
     ----------
-    host_dist : array_like or DistanceMatrix
-        Symmetric matrix of m x m pairwise distances between hosts
-    par_dist : array_like or DistanceMatrix
-        Symmetric matrix of n x n pairwise distances between parasites
+    host_dist : 2-D array_like or DistanceMatrix
+        Symmetric matrix of m x m pairwise distances between hosts.
+    par_dist : 2-D array_like or DistanceMatrix
+        Symmetric matrix of n x n pairwise distances between parasites.
     interaction : 2-D array_like, bool
         n x m binary matrix of parasite x host interactions. Order of hosts
-        (columns) should be identical to order of hosts in host_dist, as should
-        order of parasites (rows)
+        (columns) should be identical to order of hosts in `host_dist`, as
+        should order of parasites (rows) be identical to order of parasites in
+        `par_dist`.
     permutations : int, optional
-        Number of permutations to run. Default 999. Must be greater than or
+        Number of permutations used to compute p-value. Must be greater than or
         equal to zero. If zero, statistical significance calculations will be
-        skipped and the p-value will be ``np.nan``
+        skipped and the p-value will be ``np.nan``.
 
     Returns
     -------
-    r : float
-        Correlation coefficient of host : parasite association
-    p_val : float
-        Significance of host : parasite association
-    perm_stats : list of floats
-        List of r values observed using permuted host : parasite interactions
+    corr_coeff : float
+        Pearson correlation coefficient of host : parasite association.
+    p_value : float
+        Significance of host : parasite association computed using
+        `permutations` and a one-sided (greater) alternative hypothesis.
+    perm_stats : 1-D numpy.ndarray, float
+        Correlation coefficients observed using permuted host : parasite
+        interactions. Length will be equal to the number of permutations used
+        to compute p-value (see `permutations` parameter above).
 
     See Also
     --------
@@ -91,10 +95,9 @@ def hommola_cospeciation(host_dist, par_dist, interaction, permutations=999):
 
     Notes
     -----
-    It is assumed that the ordering of parasites in par_dist and hosts in
-    host_dist and are identical to their ordering in the rows and columns,
-    respectively, of the interaction matrix. No matching of labels is
-    performed.
+    It is assumed that the ordering of parasites in `par_dist` and hosts in
+    `host_dist` are identical to their ordering in the rows and columns,
+    respectively, of the interaction matrix.
 
     This code is loosely based on the original R code from [1]_.
 
@@ -106,38 +109,38 @@ def hommola_cospeciation(host_dist, par_dist, interaction, permutations=999):
 
     Examples
     --------
-    >>> import numpy as np
     >>> from skbio.stats.evolve import hommola_cospeciation
 
-    Import arrays for host distances, parasite distances, and the interactions.
-    (Test data from example in [1]_.)
+    Create arrays for host distances, parasite distances, and their
+    interactions (data taken from example in [1]_):
 
-    >>> hdist = np.array([[0,3,8,8,9],[3,0,7,7,8],[8,7,0,6,7],[8,7,6,0,3],
-    ...                  [9,8,7,3,0]])
-    >>> pdist = np.array([[0,5,8,8,8],[5,0,7,7,7],[8,7,0,4,4],[8,7,4,0,2],
-    ...                  [8,7,4,2,0]])
-    >>> interaction = np.array([[1,0,0,0,0],[0,1,0,0,0],[0,0,1,0,0],
-    ...                        [0,0,0,1,0],[0,0,0,1,1]])
+    >>> hdist = [[0,3,8,8,9], [3,0,7,7,8], [8,7,0,6,7], [8,7,6,0,3],
+    ...          [9,8,7,3,0]]
+    >>> pdist = [[0,5,8,8,8], [5,0,7,7,7], [8,7,0,4,4], [8,7,4,0,2],
+    ...          [8,7,4,2,0]]
+    >>> interaction = [[1,0,0,0,0], [0,1,0,0,0], [0,0,1,0,0], [0,0,0,1,0],
+    ...                [0,0,0,1,1]]
 
-    Run the permutation test. Note that the correlation coefficient for the
-    observed values counts against the final reported p value.
+    Run the cospeciation test with 99 permutations. Note that the correlation
+    coefficient for the observed values counts against the final reported
+    p-value:
 
-    >>> r_val, p_val, perm_stats = hommola_cospeciation(hdist, pdist,
-    ...                                                 interaction, 99)
-    >>> r_val
-    0.83170965463247937
+    >>> corr_coeff, p_value, perm_stats = hommola_cospeciation(
+    ...     hdist, pdist, interaction, permutations=99)
+    >>> corr_coeff
+    0.83170965463247903
 
     In this case, the host distances have a fairly strong positive correlation
     with the symbiont distances. However, this may also reflect structure
     inherent in the phylogeny, and is not itself indicative of significance.
 
-    >>> p_val <= 0.05
+    >>> p_value <= 0.05
     True
 
     After permuting host : parasite interactions, we find that the observed
     correlation is indeed greater than we would expect by chance.
+
     """
-    # Regularize input objects
     host_dist = DistanceMatrix(host_dist)
     par_dist = DistanceMatrix(par_dist)
     interaction = np.asarray(interaction, dtype=bool)
@@ -145,22 +148,22 @@ def hommola_cospeciation(host_dist, par_dist, interaction, permutations=999):
     num_hosts = host_dist.shape[0]
     num_pars = par_dist.shape[0]
 
-    # Sanity check inputs
     if num_hosts < 3 or num_pars < 3:
-        raise ValueError("Distance matrices must be minimum of 3x3 in size).")
+        raise ValueError("Distance matrices must be a minimum of 3x3 in size.")
     if num_hosts != interaction.shape[1]:
         raise ValueError("Number of interaction matrix columns must match "
-                         "number of hosts in host_dist")
+                         "number of hosts in `host_dist`.")
     if num_pars != interaction.shape[0]:
         raise ValueError("Number of interaction matrix rows must match "
-                         "number of parasites in par_dist")
+                         "number of parasites in `par_dist`.")
     if permutations < 0:
         raise ValueError("Number of permutations must be greater than or "
                          "equal to zero.")
     if interaction.sum() < 3:
-        raise ValueError("Must have at least 3 host-parasite interactions")
+        raise ValueError("Must have at least 3 host-parasite interactions in "
+                         "`interaction`.")
 
-    # Shortcut to eliminate nested for loops specifying pairwise interaction
+    # shortcut to eliminate nested for-loops specifying pairwise interaction
     # partners as randomizeable indices
     pars, hosts = np.nonzero(interaction)
     pars_k_labels, pars_t_labels = _gen_lists(pars)
@@ -172,53 +175,41 @@ def hommola_cospeciation(host_dist, par_dist, interaction, permutations=999):
     y = _get_dist(pars_k_labels, pars_t_labels, par_dist.data,
                   np.arange(num_pars))
 
-    # calculate sorting index to ensure consistency from pearsonr
-    sort = (x + y).argsort()
+    # calculate the observed correlation coefficient for these hosts/symbionts
+    corr_coeff = pearsonr(x, y)[0]
 
-    # calculate the observed correlation coefficient for this host/symbionts
-    r = pearsonr(x[sort], y[sort])[0]
-
-    # now do permutatitons. Initialize index lists of the appropriate size.
+    # now do permutatitons. initialize index lists of the appropriate size
     mp = np.arange(num_pars)
     mh = np.arange(num_hosts)
 
     # initialize list of shuffled correlation vals
     perm_stats = np.empty(permutations)
 
-    if permutations == 0 or np.isnan(r):
-        p_val = np.nan
-        perm_stats[:] = np.nan
+    if permutations == 0 or np.isnan(corr_coeff):
+        p_value = np.nan
+        perm_stats.fill(np.nan)
     else:
         for i in range(permutations):
-            # Generate a shuffled list of indexes for each permutation. This
+            # generate a shuffled list of indexes for each permutation. this
             # effectively randomizes which host is associated with which
-            # symbiont, but maintains the distribution of genetic distances.
+            # symbiont, but maintains the distribution of genetic distances
             np.random.shuffle(mp)
             np.random.shuffle(mh)
 
-            # Get pairwise distances in shuffled order
+            # get pairwise distances in shuffled order
             y_p = _get_dist(pars_k_labels, pars_t_labels, par_dist.data, mp)
             x_p = _get_dist(hosts_k_labels, hosts_t_labels, host_dist.data, mh)
 
-            # calculate sorting index to ensure consistency from pearsonr
-            sort = (x_p + y_p).argsort()
+            # calculate shuffled correlation coefficient
+            perm_stats[i] = pearsonr(x_p, y_p)[0]
 
-            # calculate shuffled correlation.
-            # If greater than observed value, iterate counter below.
-            r_p = pearsonr(x_p[sort], y_p[sort])[0]
-            perm_stats[i] = r_p
+        p_value = ((perm_stats >= corr_coeff).sum() + 1) / (permutations + 1)
 
-        below = (perm_stats >= r).sum()
-
-        p_val = (below + 1) / (permutations + 1)
-
-    return r, p_val, perm_stats
+    return corr_coeff, p_value, perm_stats
 
 
 def _get_dist(k_labels, t_labels, dists, index):
-    """Function for picking a subset of pairwise distances from a distance
-    matrix according to a set of (randomizable) index labels.
-    Derived from [1]_.
+    """Subset a distance matrix using a set of (randomizable) index labels.
 
     Parameters
     ----------
@@ -234,25 +225,21 @@ def _get_dist(k_labels, t_labels, dists, index):
     Returns
     -------
     vec : list of float
-        Returns list of distances associated with host:parasite edges, per
-        description in [1]_.
+        List of distances associated with host:parasite edges.
 
-    References
-    ----------
-    .. [1] Hommola K, Smith JE, Qiu Y, Gilks WR (2009) A Permutation Test of
-       Host-Parasite Cospeciation. Molecular Biology and Evolution, 26,
-       1457-1468.
     """
     return dists[index[k_labels], index[t_labels]]
 
 
 def _gen_lists(labels):
-    """Shortcut function for generating matched lists of row and col index
-    labels for the set of pairwise comparisons specified by the list of those
-    indices recovered using np.nonzero(interaction).
+    """Generate matched lists of row and column index labels.
 
-    Reproduces values of iterated indices from the nested for loops contained
-    in 'get_dist' function in original code from [1]_.
+    Shortcut function for generating matched lists of row and col index
+    labels for the set of pairwise comparisons specified by the list of those
+    indices recovered using ``np.nonzero(interaction)``.
+
+    Reproduces values of iterated indices from the nested for-loops contained
+    in ``get_dist`` function in original code from [1]_.
 
     Parameters
     ----------
@@ -272,9 +259,8 @@ def _gen_lists(labels):
     .. [1] Hommola K, Smith JE, Qiu Y, Gilks WR (2009) A Permutation Test of
        Host-Parasite Cospeciation. Molecular Biology and Evolution, 26,
        1457-1468.
+
     """
     i_array, j_array = np.transpose(np.tri(len(labels)-1)).nonzero()
     j_array = j_array + 1
-    k_labels = labels[i_array]
-    t_labels = labels[j_array]
-    return k_labels, t_labels
+    return labels[i_array], labels[j_array]

--- a/skbio/stats/evolve/tests/__init__.py
+++ b/skbio/stats/evolve/tests/__init__.py
@@ -1,0 +1,7 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2013--, scikit-bio development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+# ----------------------------------------------------------------------------

--- a/skbio/stats/evolve/tests/test_hommola.py
+++ b/skbio/stats/evolve/tests/test_hommola.py
@@ -7,18 +7,17 @@
 # ----------------------------------------------------------------------------
 
 from __future__ import absolute_import, division, print_function
+import unittest
 
 import numpy as np
-from numpy.testing import assert_allclose, assert_equal
-from nose.tools import assert_almost_equal
-from unittest import TestCase
+import numpy.testing as npt
 
 from skbio.stats.distance import mantel
 from skbio.stats.evolve import hommola_cospeciation
 from skbio.stats.evolve._hommola import _get_dist, _gen_lists
 
 
-class HommolaCospeciationTests(TestCase):
+class HommolaCospeciationTests(unittest.TestCase):
     def setUp(self):
         # Test matrices, as presented in original paper by Hommola et al.
         self.hdist = np.array([[0, 3, 8, 8, 9], [3, 0, 7, 7, 8], [
@@ -65,10 +64,10 @@ class HommolaCospeciationTests(TestCase):
         exp_perm_stats = np.array([-0.14928122, 0.26299538, -0.21125858,
                                    0.24143838, 0.61557855, -0.24258293,
                                    0.09885203, 0.02858, 0.42742399])
-        assert_almost_equal(obs_p, exp_p)
-        assert_almost_equal(obs_r, exp_r)
+        self.assertAlmostEqual(obs_p, exp_p)
+        self.assertAlmostEqual(obs_r, exp_r)
 
-        assert_allclose(obs_perm_stats, exp_perm_stats)
+        npt.assert_allclose(obs_perm_stats, exp_perm_stats)
 
     def test_hommola_cospeciation_asymmetric(self):
         np.random.seed(1)
@@ -82,10 +81,10 @@ class HommolaCospeciationTests(TestCase):
                                    0.183711730709,  0.056057631956,
                                    0.945732487487,  0.056057631956,
                                    -0.020412414523])
-        assert_almost_equal(obs_p, exp_p)
-        assert_almost_equal(obs_r, exp_r)
+        self.assertAlmostEqual(obs_p, exp_p)
+        self.assertAlmostEqual(obs_r, exp_r)
 
-        assert_allclose(obs_perm_stats, exp_perm_stats)
+        npt.assert_allclose(obs_perm_stats, exp_perm_stats)
 
     def test_hommola_cospeciation_no_sig(self):
         np.random.seed(1)
@@ -97,33 +96,23 @@ class HommolaCospeciationTests(TestCase):
         exp_perm_stats = np.array([-0.22216543, -0.14836061, -0.04434843,
                                    0.1478281, -0.29105645, 0.56395839,
                                    0.47304992, 0.79125657, 0.06804138])
-        assert_almost_equal(obs_p, exp_p)
-        assert_almost_equal(obs_r, exp_r)
-        assert_allclose(obs_perm_stats, exp_perm_stats)
+        self.assertAlmostEqual(obs_p, exp_p)
+        self.assertAlmostEqual(obs_r, exp_r)
+        npt.assert_allclose(obs_perm_stats, exp_perm_stats)
 
     def test_hommola_vs_mantel(self):
-        z = 1
+        # we don't compare p-values because the two methods use different
+        # permutation strategies
+        r_mantel, p_mantel, _ = mantel(
+            self.hdist, self.pdist, method='pearson', permutations=0,
+            alternative='greater'
+        )
+        r_hommola, p_hommola, _ = hommola_cospeciation(
+            self.hdist, self.pdist, self.interact_1to1, permutations=0
+        )
 
-        obs_r_mantel = np.zeros(z)
-        obs_r_hommola = np.zeros(z)
-        obs_p_mantel = np.zeros(z)
-        obs_p_hommola = np.zeros(z)
-
-        for i in range(z):
-            np.random.seed(i)
-            obs_r_mantel[i], obs_p_mantel[i], n = mantel(
-                self.hdist, self.pdist, method='pearson', permutations=999,
-                alternative='greater'
-            )
-            np.random.seed(i)
-            obs_r_hommola[i], obs_p_hommola[i], s = hommola_cospeciation(
-                self.hdist, self.pdist, self.interact_1to1, permutations=999
-            )
-
-        assert_allclose(obs_r_mantel, obs_r_hommola)
-
-        assert_almost_equal(obs_p_mantel.mean(), obs_p_hommola.mean(),
-                            places=2)
+        self.assertAlmostEqual(r_hommola, r_mantel)
+        npt.assert_equal(p_hommola, p_mantel)
 
     def test_zero_permutations(self):
         obs_r, obs_p, obs_perm_stats = hommola_cospeciation(
@@ -133,9 +122,9 @@ class HommolaCospeciationTests(TestCase):
         exp_r = 0.83170965463247915
         exp_perm_stats = np.array([])
 
-        assert_equal(obs_p, exp_p)
-        assert_almost_equal(obs_r, exp_r)
-        assert_allclose(obs_perm_stats, exp_perm_stats)
+        npt.assert_equal(obs_p, exp_p)
+        self.assertAlmostEqual(obs_r, exp_r)
+        npt.assert_equal(obs_perm_stats, exp_perm_stats)
 
     def test_get_dist(self):
         labels = np.array([0, 1, 1, 2, 3])
@@ -147,7 +136,7 @@ class HommolaCospeciationTests(TestCase):
         expected_vec = np.array([7, 7, 5, 6, 0, 4, 3, 4, 3, 2])
         actual_vec = _get_dist(k_labels, t_labels, dists, index)
 
-        assert_allclose(actual_vec, expected_vec)
+        npt.assert_allclose(actual_vec, expected_vec)
 
     def test_gen_lists(self):
         exp_pars_k_labels = np.array([0, 0, 0, 0, 0, 1, 1, 1,
@@ -164,10 +153,10 @@ class HommolaCospeciationTests(TestCase):
         obs_pars_k_labels, obs_pars_t_labels = _gen_lists(pars)
         obs_hosts_k_labels, obs_hosts_t_labels = _gen_lists(hosts)
 
-        assert_allclose(exp_pars_k_labels, obs_pars_k_labels)
-        assert_allclose(exp_pars_t_labels, obs_pars_t_labels)
-        assert_allclose(exp_host_k_labels, obs_hosts_k_labels)
-        assert_allclose(exp_host_t_labels, obs_hosts_t_labels)
+        npt.assert_allclose(exp_pars_k_labels, obs_pars_k_labels)
+        npt.assert_allclose(exp_pars_t_labels, obs_pars_t_labels)
+        npt.assert_allclose(exp_host_k_labels, obs_hosts_k_labels)
+        npt.assert_allclose(exp_host_t_labels, obs_hosts_t_labels)
 
     def test_dm_too_small(self):
         with self.assertRaises(ValueError):
@@ -196,5 +185,4 @@ class HommolaCospeciationTests(TestCase):
 
 
 if __name__ == '__main__':
-    import nose
-    nose.runmodule()
+    unittest.main()

--- a/skbio/stats/evolve/tests/test_hommola.py
+++ b/skbio/stats/evolve/tests/test_hommola.py
@@ -1,0 +1,200 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2013--, scikit-bio development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+# ----------------------------------------------------------------------------
+
+from __future__ import absolute_import, division, print_function
+
+import numpy as np
+from numpy.testing import assert_allclose, assert_equal
+from nose.tools import assert_almost_equal
+from unittest import TestCase
+
+from skbio.stats.distance import mantel
+from skbio.stats.evolve import hommola_cospeciation
+from skbio.stats.evolve._hommola import _get_dist, _gen_lists
+
+
+class HommolaCospeciationTests(TestCase):
+    def setUp(self):
+        # Test matrices, as presented in original paper by Hommola et al.
+        self.hdist = np.array([[0, 3, 8, 8, 9], [3, 0, 7, 7, 8], [
+            8, 7, 0, 6, 7], [8, 7, 6, 0, 3], [9, 8, 7, 3, 0]])
+        self.pdist = np.array([[0, 5, 8, 8, 8], [5, 0, 7, 7, 7], [
+            8, 7, 0, 4, 4], [8, 7, 4, 0, 2], [8, 7, 4, 2, 0]])
+        self.interact = np.array([[1, 0, 0, 0, 0], [0, 1, 0, 0, 0], [
+            0, 0, 1, 0, 0], [0, 0, 0, 1, 0], [0, 0, 0, 1, 1]])
+
+        # Reduced-size host matrix for testing asymmetric interaction matrix
+        self.hdist_4x4 = np.array([[0, 3, 8, 8], [3, 0, 7, 7], [8, 7, 0, 6],
+                                  [8, 7, 6, 0]])
+        self.interact_5x4 = np.array([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0],
+                                      [0, 0, 0, 1], [0, 0, 0, 1]])
+
+        # One to one interaction matrix for comparing against Mantel output
+        self.interact_1to1 = np.array([[1, 0, 0, 0, 0], [0, 1, 0, 0, 0], [
+            0, 0, 1, 0, 0], [0, 0, 0, 1, 0], [0, 0, 0, 0, 1]])
+
+        # interaction matrix yielding non-significant results.
+        # this matrix was picked because it will generate an r value that's
+        # less than a standard deviation away from the mean of the normal
+        # distribution of r vals
+        self.interact_ns = np.array(
+            [[0, 0, 0, 1, 0], [0, 0, 0, 0, 1], [1, 0, 0, 0, 0],
+             [1, 0, 0, 0, 0], [0, 0, 0, 0, 1]])
+
+        # minimal size matrices for sanity checks of inputs
+        self.h_dist_3x3 = np.array([[0, 1, 2], [1, 0, 1], [2, 1, 0]])
+        self.h_dist_2x2 = np.array([[0, 3], [3, 0]])
+        self.p_dist_3x3 = np.array([[0, 3, 2], [3, 0, 1], [2, 1, 0]])
+        self.interact_3x3 = np.array([[0, 1, 1], [1, 0, 1], [0, 0, 1]])
+        self.interact_3x2 = np.array([[0, 1], [1, 0], [1, 1]])
+        self.interact_2x3 = np.array([[0, 1, 1], [1, 0, 1]])
+        self.interact_zero = np.array([[0, 0, 0], [0, 0, 0], [0, 0, 0]])
+
+    def test_hommola_cospeciation_sig(self):
+        np.random.seed(1)
+
+        obs_r, obs_p, obs_perm_stats = hommola_cospeciation(
+            self.hdist, self.pdist, self.interact, 9)
+        exp_p = .1
+        exp_r = 0.83170965463247915
+        exp_perm_stats = np.array([-0.14928122, 0.26299538, -0.21125858,
+                                   0.24143838, 0.61557855, -0.24258293,
+                                   0.09885203, 0.02858, 0.42742399])
+        assert_almost_equal(obs_p, exp_p)
+        assert_almost_equal(obs_r, exp_r)
+
+        assert_allclose(obs_perm_stats, exp_perm_stats)
+
+    def test_hommola_cospeciation_asymmetric(self):
+        np.random.seed(1)
+
+        obs_r, obs_p, obs_perm_stats = hommola_cospeciation(
+            self.hdist_4x4, self.pdist, self.interact_5x4, 9)
+        exp_p = 0.2
+        exp_r = 0.85732140997411233
+        exp_perm_stats = np.array([-0.315244162496, -0.039405520312,
+                                   0.093429386594, -0.387835875941,
+                                   0.183711730709,  0.056057631956,
+                                   0.945732487487,  0.056057631956,
+                                   -0.020412414523])
+        assert_almost_equal(obs_p, exp_p)
+        assert_almost_equal(obs_r, exp_r)
+
+        assert_allclose(obs_perm_stats, exp_perm_stats)
+
+    def test_hommola_cospeciation_no_sig(self):
+        np.random.seed(1)
+
+        obs_r, obs_p, obs_perm_stats = hommola_cospeciation(
+            self.hdist, self.pdist, self.interact_ns, 9)
+        exp_p = .6
+        exp_r = -0.013679391379114569
+        exp_perm_stats = np.array([-0.22216543, -0.14836061, -0.04434843,
+                                   0.1478281, -0.29105645, 0.56395839,
+                                   0.47304992, 0.79125657, 0.06804138])
+        assert_almost_equal(obs_p, exp_p)
+        assert_almost_equal(obs_r, exp_r)
+        assert_allclose(obs_perm_stats, exp_perm_stats)
+
+    def test_hommola_vs_mantel(self):
+        z = 1
+
+        obs_r_mantel = np.zeros(z)
+        obs_r_hommola = np.zeros(z)
+        obs_p_mantel = np.zeros(z)
+        obs_p_hommola = np.zeros(z)
+
+        for i in range(z):
+            np.random.seed(i)
+            obs_r_mantel[i], obs_p_mantel[i], n = mantel(
+                self.hdist, self.pdist, method='pearson', permutations=999,
+                alternative='greater'
+            )
+            np.random.seed(i)
+            obs_r_hommola[i], obs_p_hommola[i], s = hommola_cospeciation(
+                self.hdist, self.pdist, self.interact_1to1, permutations=999
+            )
+
+        assert_allclose(obs_r_mantel, obs_r_hommola)
+
+        assert_almost_equal(obs_p_mantel.mean(), obs_p_hommola.mean(),
+                            places=2)
+
+    def test_zero_permutations(self):
+        obs_r, obs_p, obs_perm_stats = hommola_cospeciation(
+            self.hdist, self.pdist, self.interact, 0)
+
+        exp_p = np.nan
+        exp_r = 0.83170965463247915
+        exp_perm_stats = np.array([])
+
+        assert_equal(obs_p, exp_p)
+        assert_almost_equal(obs_r, exp_r)
+        assert_allclose(obs_perm_stats, exp_perm_stats)
+
+    def test_get_dist(self):
+        labels = np.array([0, 1, 1, 2, 3])
+        k_labels, t_labels = _gen_lists(labels)
+        dists = np.array([[0, 2, 6, 3], [2, 0, 5, 4], [6, 5, 0, 7],
+                          [3, 4, 7, 0]])
+        index = np.array([2, 3, 1, 0])
+
+        expected_vec = np.array([7, 7, 5, 6, 0, 4, 3, 4, 3, 2])
+        actual_vec = _get_dist(k_labels, t_labels, dists, index)
+
+        assert_allclose(actual_vec, expected_vec)
+
+    def test_gen_lists(self):
+        exp_pars_k_labels = np.array([0, 0, 0, 0, 0, 1, 1, 1,
+                                      1, 2, 2, 2, 3, 3, 4])
+        exp_pars_t_labels = np.array([1, 2, 3, 4, 4, 2, 3, 4,
+                                      4, 3, 4, 4, 4, 4, 4])
+        exp_host_k_labels = np.array([0, 0, 0, 0, 0, 1, 1, 1,
+                                      1, 2, 2, 2, 3, 3, 3])
+        exp_host_t_labels = np.array([1, 2, 3, 3, 4, 2, 3, 3,
+                                      4, 3, 3, 4, 3, 4, 4])
+
+        pars, hosts = np.nonzero(self.interact)
+
+        obs_pars_k_labels, obs_pars_t_labels = _gen_lists(pars)
+        obs_hosts_k_labels, obs_hosts_t_labels = _gen_lists(hosts)
+
+        assert_allclose(exp_pars_k_labels, obs_pars_k_labels)
+        assert_allclose(exp_pars_t_labels, obs_pars_t_labels)
+        assert_allclose(exp_host_k_labels, obs_hosts_k_labels)
+        assert_allclose(exp_host_t_labels, obs_hosts_t_labels)
+
+    def test_dm_too_small(self):
+        with self.assertRaises(ValueError):
+            hommola_cospeciation(self.h_dist_2x2, self.p_dist_3x3,
+                                 self.interact_3x3)
+
+    def test_host_interaction_not_equal(self):
+        with self.assertRaises(ValueError):
+            hommola_cospeciation(self.h_dist_3x3, self.p_dist_3x3,
+                                 self.interact_2x3)
+
+    def test_par_interaction_not_equal(self):
+        with self.assertRaises(ValueError):
+            hommola_cospeciation(self.h_dist_3x3, self.p_dist_3x3,
+                                 self.interact_3x2)
+
+    def test_interaction_too_few(self):
+        with self.assertRaises(ValueError):
+            hommola_cospeciation(self.h_dist_3x3, self.p_dist_3x3,
+                                 self.interact_zero)
+
+    def test_permutations_too_few(self):
+        with self.assertRaises(ValueError):
+            hommola_cospeciation(self.h_dist_3x3, self.p_dist_3x3,
+                                 self.interact_3x3, -1)
+
+
+if __name__ == '__main__':
+    import nose
+    nose.runmodule()


### PR DESCRIPTION
Includes the commits in #557. I made some minor changes, including:

- a few stylistic/readability changes to the code
- docstring updates for clarity
- subpackage restructuring to match latest scikit-bio codebase
- removed sorting of vectors before Pearson calls (will resolve as part of #810 across the codebase)

@tanaes do you mind taking a look at these changes? @ebolyen and/or @gregcaporaso can you also review?