### PR TITLE
ENH: TreeNode.tip_tip_distance altered to warn with RepresentationWarnin...

### DIFF
--- a/skbio/tree/_tree.py
+++ b/skbio/tree/_tree.py
@@ -8,6 +8,7 @@
 
 from __future__ import absolute_import, division, print_function
 
+import warnings
 from operator import or_
 from copy import deepcopy
 from itertools import combinations
@@ -23,6 +24,7 @@ from skbio._base import SkbioObject
 from skbio.stats.distance import DistanceMatrix
 from ._exception import (NoLengthError, DuplicateNodeError, NoParentError,
                          MissingNodeError, TreeError)
+from skbio.util import RepresentationWarning
 
 
 def distance_from_r(m1, m2):
@@ -2430,10 +2432,14 @@ class TreeNode(SkbioObject):
             starts, stops = [], []  # to calc ._start and ._stop for curr node
             for child in node.children:
                 if child.length is None:
-                    raise NoLengthError("Node with name '%s' doesn't have a "
-                                        "length." % child.name)
+                    warnings.warn("Node with name '%s' doesn't have a "
+                                  "length." % child.name,
+                                  RepresentationWarning)
 
-                distances[child.__start:child.__stop] += child.length
+                    distances[child.__start:child.__stop] += 0
+
+                else:
+                    distances[child.__start:child.__stop] += child.length
 
                 starts.append(child.__start)
                 stops.append(child.__stop)

--- a/skbio/util/__init__.py
+++ b/skbio/util/__init__.py
@@ -50,6 +50,7 @@ Warnings
    :toctree: generated/
 
    EfficiencyWarning
+   RepresentationWarning
 
 """
 
@@ -61,13 +62,13 @@ Warnings
 # The full license is in the file COPYING.txt, distributed with this software.
 # ----------------------------------------------------------------------------
 
-from ._warning import EfficiencyWarning
+from ._warning import EfficiencyWarning, RepresentationWarning
 from ._exception import TestingUtilError
 from ._misc import (cardinal_to_ordinal, create_dir, find_duplicates, flatten,
                     is_casava_v180_or_later, remove_files, safe_md5)
 from ._testing import get_data_path, TestRunner
 
-__all__ = ['EfficiencyWarning', 'TestingUtilError',
+__all__ = ['EfficiencyWarning', 'RepresentationWarning', 'TestingUtilError',
            'cardinal_to_ordinal', 'create_dir', 'find_duplicates', 'flatten',
            'is_casava_v180_or_later', 'remove_files', 'safe_md5',
            'get_data_path', 'TestRunner']

--- a/skbio/util/_warning.py
+++ b/skbio/util/_warning.py
@@ -20,3 +20,14 @@ class EfficiencyWarning(Warning):
 
     """
     pass
+
+
+class RepresentationWarning(Warning):
+    """Warn about substitions, assumptions, or particular alterations
+       that were made for the successful completion of a process.
+
+    For example, if a value that is required for a task is not present
+    the best guess or least deleterious value will be used where necessary.
+
+    """
+    pass


### PR DESCRIPTION
TreeNode.tip_tip_distance altered to warn with RepresentationWarning when substituting None lengths with 0(zero).

fixes #791 