### PR TITLE
STY: Add `#  noqa` to __init__.py line

### DIFF
--- a/skbio/__init__.py
+++ b/skbio/__init__.py
@@ -11,7 +11,7 @@ from __future__ import absolute_import, division, print_function
 from skbio.util import TestRunner
 
 # Add skbio.io to sys.modules to prevent cycles in our imports
-import skbio.io
+import skbio.io  # noqa
 # imports included for convenience
 from skbio.sequence import (
     BiologicalSequence, NucleotideSequence, DNA, DNASequence, RNA, RNASequence,
@@ -22,8 +22,6 @@ from skbio.alignment import (
 from skbio.tree import (
     TreeNode, nj)
 from skbio.io import read, write
-
-skbio.io  # Stop flake8 error
 
 __all__ = ['BiologicalSequence', 'NucleotideSequence', 'DNA', 'DNASequence',
            'RNA', 'RNASequence', 'Protein', 'ProteinSequence',


### PR DESCRIPTION
Use `#  noqa` to supress an error instead of adding a "spurious
statement" to silence flake8.