### PR TITLE
[master] BUG: fixed TreeNode.extend when given tree.children; fixes #889

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Bug fixes
 * Changed `BiologicalSequence.distance` to raise an error any time two sequences are passed of different lengths regardless of the `distance_fn` being passed. [(#514)](https://github.com/biocore/scikit-bio/issues/514)
+* Fixed issue with ``TreeNode.extend`` where if given the children of another ``TreeNode`` object (``tree.children``), both trees would be left in an incorrect and unpredictable state. ([#889](https://github.com/biocore/scikit-bio/issues/889))
 
 ### Deprecated functionality
 * Deprecated `skbio.util.flatten`. This function will be removed in scikit-bio 0.3.1. Please use standard python library functionality

--- a/skbio/tree/_tree.py
+++ b/skbio/tree/_tree.py
@@ -233,7 +233,7 @@ class TreeNode(SkbioObject):
         <BLANKLINE>
 
         """
-        self.children.extend([self._adopt(n) for n in nodes])
+        self.children.extend([self._adopt(n) for n in nodes[:]])
 
     def pop(self, index=-1):
         r"""Remove a `TreeNode` from `self`.

--- a/skbio/tree/tests/test_tree.py
+++ b/skbio/tree/tests/test_tree.py
@@ -90,7 +90,16 @@ class TreeTests(TestCase):
         """Extend a few nodes"""
         second_tree = TreeNode.read(StringIO(u"(x1,y1)z1;"))
         third_tree = TreeNode.read(StringIO(u"(x2,y2)z2;"))
+        first_tree = TreeNode.read(StringIO(u"(x1,y1)z1;"))
+        fourth_tree = TreeNode.read(StringIO(u"(x2,y2)z2;"))
         self.simple_t.extend([second_tree, third_tree])
+
+        first_tree.extend(fourth_tree.children)
+        self.assertEqual(0, len(fourth_tree.children))
+        self.assertEqual(first_tree.children[0].name, 'x1')
+        self.assertEqual(first_tree.children[1].name, 'y1')
+        self.assertEqual(first_tree.children[2].name, 'x2')
+        self.assertEqual(first_tree.children[3].name, 'y2')
 
         self.assertEqual(self.simple_t.children[0].name, 'i1')
         self.assertEqual(self.simple_t.children[1].name, 'i2')


### PR DESCRIPTION
This fixes an issue where doing `tree1.extend(tree2.children)` or `TreeNode(.... children=tree2.children)` would leave both trees broken.