### PR TITLE
[0.2.4] BUG: fixed TreeNode.extend when given tree.children; fixes #889

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # scikit-bio changelog
 
+## Version 0.2.3-dev
+
+### Bug fixes
+* Fixed issue with ``TreeNode.extend`` where if given the children of another ``TreeNode`` object (``tree.children``), both trees would be left in an incorrect and unpredictable state. ([#889](https://github.com/biocore/scikit-bio/issues/889))
+
 ## Version 0.2.3 (2015-02-13)
 
 ### Features

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ from setuptools.extension import Extension
 
 import numpy as np
 
-__version__ = "0.2.3"
+__version__ = "0.2.4"
 
 classes = """
     Development Status :: 1 - Planning

--- a/skbio/__init__.py
+++ b/skbio/__init__.py
@@ -40,7 +40,7 @@ __all__ = ['BiologicalSequence', 'NucleotideSequence', 'DNA', 'DNASequence',
 test = Tester().test
 
 __credits__ = "https://github.com/biocore/scikit-bio/graphs/contributors"
-__version__ = "0.2.3"
+__version__ = "0.2.4"
 
 mottos = [
     # 03/15/2014

--- a/skbio/tree/_tree.py
+++ b/skbio/tree/_tree.py
@@ -236,7 +236,7 @@ class TreeNode(SkbioObject):
         <BLANKLINE>
 
         """
-        self.children.extend([self._adopt(n) for n in nodes])
+        self.children.extend([self._adopt(n) for n in nodes[:]])
 
     def pop(self, index=-1):
         r"""Remove a `TreeNode` from `self`.

--- a/skbio/tree/tests/test_tree.py
+++ b/skbio/tree/tests/test_tree.py
@@ -92,7 +92,16 @@ class TreeTests(TestCase):
         """Extend a few nodes"""
         second_tree = TreeNode.from_newick("(x1,y1)z1;")
         third_tree = TreeNode.from_newick("(x2,y2)z2;")
+        first_tree = TreeNode.from_newick("(x1,y1)z1;")
+        fourth_tree = TreeNode.from_newick("(x2,y2)z2;")
         self.simple_t.extend([second_tree, third_tree])
+
+        first_tree.extend(fourth_tree.children)
+        self.assertEqual(0, len(fourth_tree.children))
+        self.assertEqual(first_tree.children[0].name, 'x1')
+        self.assertEqual(first_tree.children[1].name, 'y1')
+        self.assertEqual(first_tree.children[2].name, 'x2')
+        self.assertEqual(first_tree.children[3].name, 'y2')
 
         self.assertEqual(self.simple_t.children[0].name, 'i1')
         self.assertEqual(self.simple_t.children[1].name, 'i2')


### PR DESCRIPTION
**This is not a duplicate**
This is a PR for 0.2.4, this is a new thing for us so hold on to your pants!