### PR TITLE
WEB: add shortlink to cookbook: http://scikit-bio.org/cookbook

### DIFF
--- a/cookbook/index.html
+++ b/cookbook/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE HTML>
+<html lang="en-US">
+    <head>
+        <meta charset="UTF-8">
+        <meta http-equiv="refresh" content="1;url=http://nbviewer.ipython.org/github/biocore/scikit-bio-cookbook/blob/master/Index.ipynb">
+        <script type="text/javascript">
+            window.location.href = "http://nbviewer.ipython.org/github/biocore/scikit-bio-cookbook/blob/master/Index.ipynb"
+        </script>
+        <title>Page Redirection to scikit-bio Cookbook</title>
+    </head>
+    <body>
+        If you are not redirected automatically, follow the <a href='http://nbviewer.ipython.org/github/biocore/scikit-bio-cookbook/blob/master/Index.ipynb'>link to the scikit-bio cookbook</a>
+    </body>
+</html>


### PR DESCRIPTION
This is convenient for whiteboards and poster presentations. 
It is a client-side redirect which isn't *awesome*, but it will work.