### PR TITLE
Multifurcating tree to Bifurcating tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Version 0.4.1-dev (changes since 0.4.1 go here)
 
 ### Features
+* Added `skbio.tree._tree.bifurcate` for converting multifurcating trees into bifurcating trees.
 * Added `skbio.io.format.stockholm` for reading Stockholm files into a `TabularMSA`. ([#967](https://github.com/biocore/scikit-bio/issues/967))
 * scikit-bio `Sequence` objects have better compatibility with numpy. For example, calling `np.asarray(sequence)` now converts the sequence to a numpy array of characters (the same as calling `sequence.values`).
 * Added `skbio.sequence.distance` subpackage for computing distances between scikit-bio `Sequence` objects ([#913](https://github.com/biocore/scikit-bio/issues/913))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Version 0.4.1-dev (changes since 0.4.1 go here)
 
 ### Features
-* Added `skbio.tree.TreeNode.bifurcate` for converting multifurcating trees into bifurcating trees. [#896](https://github.com/biocore/scikit-bio/issues/896))
+* Added `skbio.tree.TreeNode.bifurcate` for converting multifurcating trees into bifurcating trees. ([#896](https://github.com/biocore/scikit-bio/issues/896))
 * Added `skbio.io.format.stockholm` for reading Stockholm files into a `TabularMSA`. ([#967](https://github.com/biocore/scikit-bio/issues/967))
 * scikit-bio `Sequence` objects have better compatibility with numpy. For example, calling `np.asarray(sequence)` now converts the sequence to a numpy array of characters (the same as calling `sequence.values`).
 * Added `skbio.sequence.distance` subpackage for computing distances between scikit-bio `Sequence` objects ([#913](https://github.com/biocore/scikit-bio/issues/913))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Version 0.4.1-dev (changes since 0.4.1 go here)
 
 ### Features
-* Added `skbio.tree.TreeNode.bifurcate` for converting multifurcating trees into bifurcating trees.
+* Added `skbio.tree.TreeNode.bifurcate` for converting multifurcating trees into bifurcating trees. [#904](https://github.com/biocore/scikit-bio/issues/904))
 * Added `skbio.io.format.stockholm` for reading Stockholm files into a `TabularMSA`. ([#967](https://github.com/biocore/scikit-bio/issues/967))
 * scikit-bio `Sequence` objects have better compatibility with numpy. For example, calling `np.asarray(sequence)` now converts the sequence to a numpy array of characters (the same as calling `sequence.values`).
 * Added `skbio.sequence.distance` subpackage for computing distances between scikit-bio `Sequence` objects ([#913](https://github.com/biocore/scikit-bio/issues/913))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Version 0.4.1-dev (changes since 0.4.1 go here)
 
 ### Features
-* Added `skbio.tree._tree.bifurcate` for converting multifurcating trees into bifurcating trees.
+* Added `skbio.tree.TreeNode.bifurcate` for converting multifurcating trees into bifurcating trees.
 * Added `skbio.io.format.stockholm` for reading Stockholm files into a `TabularMSA`. ([#967](https://github.com/biocore/scikit-bio/issues/967))
 * scikit-bio `Sequence` objects have better compatibility with numpy. For example, calling `np.asarray(sequence)` now converts the sequence to a numpy array of characters (the same as calling `sequence.values`).
 * Added `skbio.sequence.distance` subpackage for computing distances between scikit-bio `Sequence` objects ([#913](https://github.com/biocore/scikit-bio/issues/913))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Version 0.4.1-dev (changes since 0.4.1 go here)
 
 ### Features
-* Added `skbio.tree.TreeNode.bifurcate` for converting multifurcating trees into bifurcating trees. [#904](https://github.com/biocore/scikit-bio/issues/904))
+* Added `skbio.tree.TreeNode.bifurcate` for converting multifurcating trees into bifurcating trees. [#896](https://github.com/biocore/scikit-bio/issues/896))
 * Added `skbio.io.format.stockholm` for reading Stockholm files into a `TabularMSA`. ([#967](https://github.com/biocore/scikit-bio/issues/967))
 * scikit-bio `Sequence` objects have better compatibility with numpy. For example, calling `np.asarray(sequence)` now converts the sequence to a numpy array of characters (the same as calling `sequence.values`).
 * Added `skbio.sequence.distance` subpackage for computing distances between scikit-bio `Sequence` objects ([#913](https://github.com/biocore/scikit-bio/issues/913))

--- a/skbio/tree/_tree.py
+++ b/skbio/tree/_tree.py
@@ -2716,10 +2716,9 @@ class TreeNode(SkbioObject):
 
         return dist_f(self_matrix, other_matrix)
 
-    @experimental(as_of="0.4.0")
-    def bifurcate(self, insert_length=None, remove_singles=True):
-        r"""Reorders the tree into a bifurcating tree, so that
-        every internal node will have at most two children.
+    @experimental(as_of="0.4.1-dev")
+    def bifurcate(self, insert_length=None):
+        r"""Reorders the tree into a bifurcating tree.
 
         All nodes that have more than 2 children will
         have additional intermediate nodes inserted to ensure that
@@ -2730,23 +2729,44 @@ class TreeNode(SkbioObject):
         insert_length : int, optional
             The branch length assigned to all inserted nodes.
 
-        remove_singles : bool, optional
-            Removes all nodes that have only a single child and relink
-            of their childrent to their parent node.
+        See Also
+        --------
+        prune
+
+        Notes
+        -----
+        Any nodes that have a single child can be collapsed using the
+        prune method to create strictly bifurcating trees.
 
         Examples
         --------
         >>> from skbio import TreeNode
         >>> tree = TreeNode.read(["((a,b,g,h)c,(d,e)f)root;"])
+        >>> print(tree.ascii_art())
+                            /-a
+                           |
+                           |--b
+                  /c-------|
+                 |         |--g
+                 |         |
+        -root----|          \-h
+                 |
+                 |          /-d
+                  \f-------|
+                            \-e
         >>> tree.bifurcate()
-        >>> print(tree)
-        ((h,(g,(a,b)))c,(d,e)f)root;
-        <BLANKLINE>
-
-
-        Notes
-        -----
-        Any nodes that have a single child will be collapsed.
+        >>> print(tree.ascii_art())
+                            /-h
+                  /c-------|
+                 |         |          /-g
+                 |          \--------|
+                 |                   |          /-a
+        -root----|                    \--------|
+                 |                              \-b
+                 |
+                 |          /-d
+                  \f-------|
+                            \-e
         """
         for n in self.traverse(include_self=True):
             if len(n.children) > 2:
@@ -2760,9 +2780,8 @@ class TreeNode(SkbioObject):
                     for k in stack:
                         n.remove(k)
                     n.extend([ind, intermediate])
-        if remove_singles:
-            self.prune()
 
+    @experimental(as_of="0.4.0")
     def index_tree(self):
         """Index a tree for rapid lookups within a tree array
 

--- a/skbio/tree/_tree.py
+++ b/skbio/tree/_tree.py
@@ -2717,6 +2717,52 @@ class TreeNode(SkbioObject):
         return dist_f(self_matrix, other_matrix)
 
     @experimental(as_of="0.4.0")
+    def bifurcate(self, insert_length=None, remove_singles=True):
+        r"""Reorders the tree into a bifurcating tree, so that
+        every internal node will have at most two children.
+
+        All nodes that have more than 2 children will
+        have additional intermediate nodes inserted to ensure that
+        every node has only 2 children.
+
+        Parameters
+        ----------
+        insert_length : int, optional
+            The branch length assigned to all inserted nodes.
+
+        remove_singles : bool, optional
+            Removes all nodes that have only a single child and relink
+            of their childrent to their parent node.
+
+        Examples
+        --------
+        >>> from skbio import TreeNode
+        >>> tree = TreeNode.read(["((a,b,g,h)c,(d,e)f)root;"])
+        >>> tree.bifurcate()
+        >>> print(tree)
+        ((h,(g,(a,b)))c,(d,e)f)root;
+        <BLANKLINE>
+
+
+        Notes
+        -----
+        Any nodes that have a single child will be collapsed.
+        """
+        for n in self.traverse(include_self=True):
+            if len(n.children) > 2:
+                stack = n.children
+                while len(stack) > 2:
+                    ind = stack.pop()
+                    intermediate = TreeNode()
+                    intermediate.length = insert_length
+                    intermediate.extend(stack)
+                    n.append(intermediate)
+                    for k in stack:
+                        n.remove(k)
+                    n.extend([ind, intermediate])
+        if remove_singles:
+            self.prune()
+
     def index_tree(self):
         """Index a tree for rapid lookups within a tree array
 

--- a/skbio/tree/tests/test_tree.py
+++ b/skbio/tree/tests/test_tree.py
@@ -821,7 +821,7 @@ class TreeTests(TestCase):
         t1 = TreeNode.read(StringIO(u'(((a,b),c),(d,e));'))
         t2 = TreeNode.read(StringIO(u'((a,b,c));'))
         t3 = t2.copy()
-        t4 = TreeNode.read(StringIO(u'((a,b,c));'))
+
         t1.bifurcate()
         t2.bifurcate()
         t3.bifurcate(insert_length=0)

--- a/skbio/tree/tests/test_tree.py
+++ b/skbio/tree/tests/test_tree.py
@@ -817,6 +817,42 @@ class TreeTests(TestCase):
         obs = [n.name for n in self.simple_t.levelorder()]
         self.assertEqual(obs, exp)
 
+    def test_bifurcate(self):
+        t1 = TreeNode.read(StringIO(u'(((a,b),c),(d,e));'))
+        t2 = TreeNode.read(StringIO(u'((((((a,b),(c,d)),(e,f))J)Q)K);'))
+        t3 = TreeNode.read(StringIO(u'(((a,b,c),(d)),(e,f));'))
+        t4 = t3.copy()
+        t5 = TreeNode.read(StringIO(u'(((c,(f)d,(g,h)e)b)a);'))
+        t6 = TreeNode.read(StringIO(u'((((g,h)e,(f)d,c)b)a);'))
+        t7 = TreeNode.read(StringIO(u'((c,((g,h)e,f))b);\n'))
+        t8 = TreeNode.read(StringIO(u'((((g,h)e,c,(f)d)b)a);'))
+        t9 = t8.copy()
+        t10 = TreeNode.read(StringIO(u'((a,b,c));'))
+        t1.bifurcate()
+        t2.bifurcate()
+        t3.bifurcate()
+
+        self.assertEqual(str(t1), '(((a,b),c),(d,e));\n')
+        self.assertEqual(str(t2), '((((a,b),(c,d)),(e,f))J);\n')
+        self.assertEqual(str(t3), '(((c,(a,b)),d),(e,f));\n')
+
+        t4.bifurcate(insert_length=0)
+        self.assertEqual(str(t4), '(((c,(a,b):0),d),(e,f));\n')
+
+        t5.bifurcate()
+        self.assertEqual(str(t5), '(((g,h)e,(c,f))b);\n')
+        t6.bifurcate()
+        self.assertEqual(str(t6), '((c,((g,h)e,f))b);\n')
+
+        t7.bifurcate()
+        t8.bifurcate()
+        t9.bifurcate(remove_singles=False)
+        t10.bifurcate()
+        self.assertEqual(str(t6), str(t7))
+        self.assertEqual(str(t8), '((((g,h)e,c),f)b);\n')
+        self.assertEqual(str(t9), '((((f)d,((g,h)e,c))b)a);\n')
+        self.assertEqual(str(t10), '((c,(a,b)));\n')
+
     def test_index_tree_single_node(self):
         """index_tree handles single node tree"""
         t1 = TreeNode.read(StringIO(u'root;'))

--- a/skbio/tree/tests/test_tree.py
+++ b/skbio/tree/tests/test_tree.py
@@ -819,39 +819,16 @@ class TreeTests(TestCase):
 
     def test_bifurcate(self):
         t1 = TreeNode.read(StringIO(u'(((a,b),c),(d,e));'))
-        t2 = TreeNode.read(StringIO(u'((((((a,b),(c,d)),(e,f))J)Q)K);'))
-        t3 = TreeNode.read(StringIO(u'(((a,b,c),(d)),(e,f));'))
-        t4 = t3.copy()
-        t5 = TreeNode.read(StringIO(u'(((c,(f)d,(g,h)e)b)a);'))
-        t6 = TreeNode.read(StringIO(u'((((g,h)e,(f)d,c)b)a);'))
-        t7 = TreeNode.read(StringIO(u'((c,((g,h)e,f))b);\n'))
-        t8 = TreeNode.read(StringIO(u'((((g,h)e,c,(f)d)b)a);'))
-        t9 = t8.copy()
-        t10 = TreeNode.read(StringIO(u'((a,b,c));'))
+        t2 = TreeNode.read(StringIO(u'((a,b,c));'))
+        t3 = t2.copy()
+        t4 = TreeNode.read(StringIO(u'((a,b,c));'))
         t1.bifurcate()
         t2.bifurcate()
-        t3.bifurcate()
+        t3.bifurcate(insert_length=0)
 
         self.assertEqual(str(t1), '(((a,b),c),(d,e));\n')
-        self.assertEqual(str(t2), '((((a,b),(c,d)),(e,f))J);\n')
-        self.assertEqual(str(t3), '(((c,(a,b)),d),(e,f));\n')
-
-        t4.bifurcate(insert_length=0)
-        self.assertEqual(str(t4), '(((c,(a,b):0),d),(e,f));\n')
-
-        t5.bifurcate()
-        self.assertEqual(str(t5), '(((g,h)e,(c,f))b);\n')
-        t6.bifurcate()
-        self.assertEqual(str(t6), '((c,((g,h)e,f))b);\n')
-
-        t7.bifurcate()
-        t8.bifurcate()
-        t9.bifurcate(remove_singles=False)
-        t10.bifurcate()
-        self.assertEqual(str(t6), str(t7))
-        self.assertEqual(str(t8), '((((g,h)e,c),f)b);\n')
-        self.assertEqual(str(t9), '((((f)d,((g,h)e,c))b)a);\n')
-        self.assertEqual(str(t10), '((c,(a,b)));\n')
+        self.assertEqual(str(t2), '((c,(a,b)));\n')
+        self.assertEqual(str(t3), '((c,(a,b):0));\n')
 
     def test_index_tree_single_node(self):
         """index_tree handles single node tree"""


### PR DESCRIPTION
This PR is to address https://github.com/biocore/scikit-bio/issues/896

Some of the analyses I've been doing has required strictly bifurcating trees, so this method 
1. Introduces additional internal nodes to ensure that all the internal nodes have exactly 2 children
2. Removes nodes that have exactly one child (if `remove_singles=True`)

The order in which these internal nodes are injected or how the single child nodes are removed are a little arbitrary at the moment.

Todo
- [x] squash commits