### PR TITLE
[DO NOT MERGE] Replace Sequence.quality with ranged_metadata

### DIFF
--- a/skbio/io/_base.py
+++ b/skbio/io/_base.py
@@ -178,12 +178,15 @@ def _format_fasta_like_records(generator, id_whitespace_replacement,
         else:
             header = id_
 
-        if require_qual and seq.quality is None:
+        if require_qual and 'quality' not in seq.ranged_metadata:
             raise ValueError(
                 "Cannot write %s sequence because it does not have quality "
                 "scores associated with it." % cardinal_to_ordinal(idx + 1))
 
-        yield header, str(seq), seq.quality
+        qual = None
+        if 'quality' in seq.ranged_metadata:
+            qual = seq.ranged_metadata['quality'].values
+        yield header, str(seq), qual
 
 
 def _line_generator(fh, skip_blanks=False):

--- a/skbio/io/fasta.py
+++ b/skbio/io/fasta.py
@@ -468,7 +468,7 @@ generator-based reader as we did above, providing both FASTA and QUAL files:
 
 >>> for seq in skbio.io.read(fasta_fh, qual=qual_fh, format='fasta'):
 ...     seq # doctest: +NORMALIZE_WHITESPACE
-...     seq.quality # doctest: +NORMALIZE_WHITESPACE
+...     seq.ranged_metadata['quality'].values # doctest: +NORMALIZE_WHITESPACE
 Sequence('CGATGTC', length=7, id='seq1', description='db-acc ... 149855',
          quality=[40, 39, 39, 4, 50, 1, 100])
 array([ 40,  39,  39,   4,  50,   1, 100])

--- a/skbio/sequence/_nucleotide_sequence.py
+++ b/skbio/sequence/_nucleotide_sequence.py
@@ -108,11 +108,13 @@ class NucleotideSequence(with_metaclass(ABCMeta, IUPACSequence)):
 
         """
         result = self._complement_lookup[self._bytes]
-        quality = self.quality
+        quality = None
+        if self._has_quality():
+            quality = self.ranged_metadata['quality']
         if reverse:
             result = result[::-1]
             if self._has_quality():
-                quality = self.quality[::-1]
+                quality = self.ranged_metadata['quality'][::-1]
 
         return self._to(sequence=result, quality=quality)
 

--- a/skbio/sequence/tests/test_iupac_sequence.py
+++ b/skbio/sequence/tests/test_iupac_sequence.py
@@ -55,7 +55,7 @@ class TestIUPACSequence(TestCase):
         npt.assert_equal(seq.sequence, np.array('.-ABCXYZ', dtype='c'))
         self.assertEqual(seq.id, "")
         self.assertEqual(seq.description, "")
-        self.assertIsNone(seq.quality)
+        self.assertNotIn('quality', seq.ranged_metadata)
 
     def test_init_nondefault_parameters(self):
         seq = ExampleIUPACSequence('.-ABCXYZ', id='foo', description='bar baz',
@@ -64,7 +64,8 @@ class TestIUPACSequence(TestCase):
         npt.assert_equal(seq.sequence, np.array('.-ABCXYZ', dtype='c'))
         self.assertEqual(seq.id, 'foo')
         self.assertEqual(seq.description, 'bar baz')
-        npt.assert_equal(seq.quality, np.array(range(8), dtype='int'))
+        npt.assert_equal(seq.ranged_metadata['quality'], np.array(range(8),
+                         dtype='int'))
 
     def test_init_valid_empty_sequence(self):
         # just make sure we can instantiate an empty sequence regardless of


### PR DESCRIPTION
There are several items to discuss before finalizing how this will work. At least:

- [ ] Currently removed the test that quality is not copied when initializing a sequence. How do we want this to work?

- [ ] Should we try to make quality read-only? It was before but isn't in this commit.

- [ ] Certain quality-specific logic maybe should be removed in favor of more generic metadata logic. For example there are places where `_has_quality` should probably be replaced with `_has_metadata`, etc.

- [ ] Not entirely sure I'm happy the the overall cleanliness of these changes. Open to suggestions.

- [ ] We likely will need additional new tests now that we're using a Pandas DataFrame to hold the quality data.

- [ ] How will metadata fit in to sequence equality comparisons?

EDIT: Added metadata equality item.