### PR TITLE
BUG: Fixed creation of non-symmetric matrices from `randdm`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 ### Bug fixes
 * Changed `BiologicalSequence.distance` to raise an error any time two sequences are passed of different lengths regardless of the `distance_fn` being passed. [(#514)](https://github.com/biocore/scikit-bio/issues/514)
 * Fixed issue with ``TreeNode.extend`` where if given the children of another ``TreeNode`` object (``tree.children``), both trees would be left in an incorrect and unpredictable state. ([#889](https://github.com/biocore/scikit-bio/issues/889))
-* Fixed issue where non-symmetric distance matrices were being created by `randdm`.
+* Fixed issue where `randdm` was attempting to create asymmetric distance matrices.This was causing an error to be raised by the `DistanceMatrix` constructor inside of the `randdm` function, so that `randdm` would fail when attempting to create large distance matrices.
 ([#943](https://github.com/biocore/scikit-bio/issues/943))
 
 ### Deprecated functionality

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 ### Bug fixes
 * Changed `BiologicalSequence.distance` to raise an error any time two sequences are passed of different lengths regardless of the `distance_fn` being passed. [(#514)](https://github.com/biocore/scikit-bio/issues/514)
 * Fixed issue with ``TreeNode.extend`` where if given the children of another ``TreeNode`` object (``tree.children``), both trees would be left in an incorrect and unpredictable state. ([#889](https://github.com/biocore/scikit-bio/issues/889))
+* Fixed issue where non-symmetric distance matrices were being created by `randdm`.
+([#943](https://github.com/biocore/scikit-bio/issues/943))
 
 ### Deprecated functionality
 * Deprecated `skbio.util.flatten`. This function will be removed in scikit-bio 0.3.1. Please use standard python library functionality

--- a/skbio/stats/distance/_base.py
+++ b/skbio/stats/distance/_base.py
@@ -748,7 +748,7 @@ def randdm(num_objects, ids=None, constructor=None, random_fn=None):
         random_fn = np.random.rand
 
     data = np.tril(random_fn(num_objects, num_objects), -1)
-    data += data.T
+    data = data + data.T
 
     if not ids:
         ids = map(str, range(1, num_objects + 1))

--- a/skbio/stats/distance/tests/test_base.py
+++ b/skbio/stats/distance/tests/test_base.py
@@ -542,8 +542,9 @@ class RandomDistanceMatrixTests(TestCase):
 
         self.assertTrue(found_diff)
 
+    def test_large_matrix_for_symmetry(self):
         obs3 = randdm(100)
-        self.assertTrue(obs3 == obs3.T)
+        self.assertEqual(obs3, obs3.T)
 
     def test_ids(self):
         ids = ['foo', 'bar', 'baz']

--- a/skbio/stats/distance/tests/test_base.py
+++ b/skbio/stats/distance/tests/test_base.py
@@ -542,6 +542,9 @@ class RandomDistanceMatrixTests(TestCase):
 
         self.assertTrue(found_diff)
 
+        obs3 = randdm(100)
+        self.assertTrue(obs3 == obs3.T)
+
     def test_ids(self):
         ids = ['foo', 'bar', 'baz']
         obs = randdm(3, ids=ids)


### PR DESCRIPTION
Fixes #943 Pair programmed with @johnchase 
Added test to `test_base.py` for detection of whether large distance matrices were symmetric.
Modified `_base.py` to stop creation of non-symmetric distance matrices and to pass test.
Updated `CHANGELOG.md`