### PR TITLE
ENH: add Sequence.copy method

### DIFF
--- a/skbio/alignment/_alignment.py
+++ b/skbio/alignment/_alignment.py
@@ -546,22 +546,9 @@ class SequenceCollection(SkbioObject):
 
         new_seqs = []
         for new_id, seq in zip(new_ids, self):
-            # HACK: Sequence objects are currently immutable. We used to have a
-            # Sequence.copy/to method that created a new Sequence object,
-            # optionally with attribute(s) set to new values. Here we want to
-            # retain all state in the Sequence object and only update the ID.
-            # There is a private method `_to` that accomplishes this for us.
-            # This method used to be public and is fully tested and documented.
-            # In the future, Sequence objects will have a `copy` method and
-            # their attributes will be reassignable. When that happens, this
-            # code can be updated to something like:
-            #
-            #     new_seq = seq.copy()
-            #     new_seq.id = new_id
-            #     new_seqs.append(new_seq)
-            metadata = seq.metadata.copy()
-            metadata['id'] = new_id
-            new_seqs.append(seq._to(metadata=metadata))
+            new_seq = seq.copy()
+            new_seq.metadata['id'] = new_id
+            new_seqs.append(new_seq)
 
         return self.__class__(new_seqs), new_to_old_ids
 

--- a/skbio/alignment/_pairwise.py
+++ b/skbio/alignment/_pairwise.py
@@ -623,10 +623,9 @@ def _coerce_alignment_input_type(seq, disallow_alignment):
         if 'id' in seq.metadata:
             return Alignment([seq])
         else:
-            # HACK: Update to use Sequence.copy() method once it exists.
-            metadata = seq.metadata.copy()
-            metadata['id'] = ''
-            return Alignment([seq._to(metadata=metadata)])
+            seq = seq.copy()
+            seq.metadata['id'] = ''
+            return Alignment([seq])
     elif isinstance(seq, Alignment):
         if disallow_alignment:
             # This will disallow aligning either a pair of alignments, or an

--- a/skbio/io/tests/test_fasta.py
+++ b/skbio/io/tests/test_fasta.py
@@ -411,11 +411,8 @@ class ReaderTests(TestCase):
                 obs = list(_fasta_to_generator(fasta_fp, **kwargs))
                 self.assertEqual(len(obs), len(exp))
                 for o, e in zip(obs, exp):
-                    # ignore positional metadata by creating a copy of the
-                    # expected sequence without positional metadata
-                    # TODO use Sequence.copy and setter when copy is
-                    # implemented
-                    e = e._to(positional_metadata=None)
+                    e = e.copy()
+                    del e.positional_metadata
                     self.assertEqual(o, e)
 
                 for qual_fp in qual_fps:
@@ -468,13 +465,13 @@ class ReaderTests(TestCase):
             for fasta_fp in fasta_fps:
                 exp = constructor(
                     'ACGT-acgt.',
-                    metadata={'id': 'seq1', 'description': 'desc1'},
-                    positional_metadata={'quality': [10, 20, 30, 10, 0, 0, 0,
-                                                     88888, 1, 3456]})
+                    metadata={'id': 'seq1', 'description': 'desc1'})
 
                 obs = reader_fn(fasta_fp)
-                self.assertEqual(obs, exp._to(positional_metadata=None))
+                self.assertEqual(obs, exp)
 
+                exp.positional_metadata = {
+                    'quality': [10, 20, 30, 10, 0, 0, 0, 88888, 1, 3456]}
                 qual_fps = list(map(get_data_path,
                                     ['qual_single_seq', 'qual_max_width_1']))
                 for qual_fp in qual_fps:
@@ -490,28 +487,26 @@ class ReaderTests(TestCase):
                 # get first
                 exp = constructor(
                     'ACGT-acgt.',
-                    metadata={'id': 'seq1', 'description': 'desc1'},
-                    positional_metadata={'quality': [10, 20, 30, 10, 0, 0, 0,
-                                                     88888, 1, 3456]})
+                    metadata={'id': 'seq1', 'description': 'desc1'})
 
                 obs = reader_fn(fasta_fp)
-                self.assertEqual(obs, exp._to(positional_metadata=None))
+                self.assertEqual(obs, exp)
 
+                exp.positional_metadata = {
+                    'quality': [10, 20, 30, 10, 0, 0, 0, 88888, 1, 3456]}
                 for qual_fp in qual_fps:
                     obs = reader_fn(fasta_fp, qual=qual_fp)
                     self.assertEqual(obs, exp)
 
                 # get middle
                 exp = constructor('ACGTTGCAccGG',
-                                  metadata={'id': '', 'description': ''},
-                                  positional_metadata={'quality': [55, 10, 0,
-                                                                   999, 1, 1,
-                                                                   8, 775, 40,
-                                                                   10, 10, 0]})
+                                  metadata={'id': '', 'description': ''})
 
                 obs = reader_fn(fasta_fp, seq_num=4)
-                self.assertEqual(obs, exp._to(positional_metadata=None))
+                self.assertEqual(obs, exp)
 
+                exp.positional_metadata = {
+                    'quality': [55, 10, 0, 999, 1, 1, 8, 775, 40, 10, 10, 0]}
                 for qual_fp in qual_fps:
                     obs = reader_fn(fasta_fp, seq_num=4, qual=qual_fp)
                     self.assertEqual(obs, exp)
@@ -521,13 +516,13 @@ class ReaderTests(TestCase):
                     'pQqqqPPQQQ',
                     metadata={'id': 'proteinseq',
                               'description':
-                                  'detailed description \t\twith  new  lines'},
-                    positional_metadata={'quality': [42, 42, 442, 442, 42, 42,
-                                                     42, 42, 42, 43]})
+                                  'detailed description \t\twith  new  lines'})
 
                 obs = reader_fn(fasta_fp, seq_num=6)
-                self.assertEqual(obs, exp._to(positional_metadata=None))
+                self.assertEqual(obs, exp)
 
+                exp.positional_metadata = {
+                    'quality': [42, 42, 442, 442, 42, 42, 42, 42, 42, 43]}
                 for qual_fp in qual_fps:
                     obs = reader_fn(fasta_fp, seq_num=6, qual=qual_fp)
                     self.assertEqual(obs, exp)
@@ -564,7 +559,9 @@ class ReaderTests(TestCase):
 
                     self.assertEqual(len(obs), len(exp))
                     for o, e in zip(obs, exp):
-                        self.assertEqual(o, e._to(positional_metadata=None))
+                        e = e.copy()
+                        del e.positional_metadata
+                        self.assertEqual(o, e)
 
                     for qual_fp in qual_fps:
                         obs = reader_fn(fasta_fp, qual=qual_fp, **kwargs)

--- a/skbio/sequence/_sequence.py
+++ b/skbio/sequence/_sequence.py
@@ -1594,47 +1594,15 @@ class Sequence(collections.Sequence, SkbioObject):
 
         Notes
         -----
-        This is a shallow copy, but since biological sequences are immutable,
-        it is conceptually the same as a deep copy.
+        By default, `metadata` and `positional_metadata` are shallow-copied and
+        the reference to `sequence` is used (without copying) for efficiency
+        since `sequence` is immutable. This differs from the behavior of
+        `Sequence.copy`, which will actually copy `sequence`.
 
         This method is the preferred way of creating new instances from an
         existing biological sequence, instead of calling
         ``self.__class__(...)``, as the latter can be error-prone (e.g.,
         it's easy to forget to propagate attributes to the new instance).
-
-        Examples
-        --------
-        Create a biological sequence:
-
-        >>> from skbio import Sequence
-        >>> seq = Sequence('AACCGGTT',
-        ...                metadata={'id':'id1'},
-        ...                positional_metadata={
-        ...                    'quality':[4, 2, 22, 23, 1, 1, 1, 9]
-        ...                })
-
-        Create a copy of ``seq``, keeping the same underlying sequence of
-        characters and quality scores, while updating the metadata:
-
-        >>> new_seq = seq._to(metadata={'id':'new-id'})
-
-        Note that the copied biological sequence's underlying sequence and
-        positional metadata are the same as ``seq``:
-
-        >>> str(new_seq)
-        'AACCGGTT'
-        >>> new_seq.positional_metadata['quality'].values
-        array([ 4,  2, 22, 23,  1,  1,  1,  9])
-
-        The metadata has been updated:
-
-        >>> new_seq.metadata['id']
-        'new-id'
-
-        The original biological sequence's metadata has not been changed:
-
-        >>> seq.metadata['id']
-        'id1'
 
         """
         defaults = {'sequence': self._bytes,

--- a/skbio/sequence/_sequence.py
+++ b/skbio/sequence/_sequence.py
@@ -945,6 +945,34 @@ class Sequence(collections.Sequence, SkbioObject):
             return "%s ... %s" % (s[:7], s[-7:])
         return s
 
+    def __copy__(self):
+        """Return a shallow copy of the biological sequence.
+
+        See Also
+        --------
+        copy
+
+        Notes
+        -----
+        This method is equivalent to ``seq.copy(deep=False)``.
+
+        """
+        return self.copy(deep=False)
+
+    def __deepcopy__(self, memo):
+        """Return a deep copy of the biological sequence.
+
+        See Also
+        --------
+        copy
+
+        Notes
+        -----
+        This method is equivalent to ``seq.copy(deep=True)``.
+
+        """
+        return self._copy(True, memo)
+
     def has_metadata(self):
         """Determine if the sequence contains metadata.
 
@@ -1105,6 +1133,9 @@ class Sequence(collections.Sequence, SkbioObject):
         3   []        5
 
         """
+        return self._copy(deep, {})
+
+    def _copy(self, deep, memo):
         # strategy: copy the sequence without metadata first, then set metadata
         # attributes with copies. we take this approach instead of simply
         # passing the metadata through the Sequence constructor because we
@@ -1113,7 +1144,7 @@ class Sequence(collections.Sequence, SkbioObject):
         # also directly set the private metadata attributes instead of using
         # their public setters to avoid an unnecessary copy
         if deep:
-            bytes = copy.deepcopy(self._bytes)
+            bytes = copy.deepcopy(self._bytes, memo)
         else:
             bytes = np.copy(self._bytes)
 
@@ -1123,7 +1154,7 @@ class Sequence(collections.Sequence, SkbioObject):
         if self.has_metadata():
             metadata = self.metadata
             if deep:
-                metadata = copy.deepcopy(metadata)
+                metadata = copy.deepcopy(metadata, memo)
             else:
                 metadata = metadata.copy()
             seq_copy._metadata = metadata
@@ -1131,7 +1162,7 @@ class Sequence(collections.Sequence, SkbioObject):
         if self.has_positional_metadata():
             positional_metadata = self.positional_metadata
             if deep:
-                positional_metadata = copy.deepcopy(positional_metadata)
+                positional_metadata = copy.deepcopy(positional_metadata, memo)
             else:
                 # deep=True makes a shallow copy of the underlying data buffer
                 positional_metadata = positional_metadata.copy(deep=True)

--- a/skbio/sequence/_sequence.py
+++ b/skbio/sequence/_sequence.py
@@ -787,49 +787,6 @@ class Sequence(collections.Sequence, SkbioObject):
 
         return self._to(sequence=seq, positional_metadata=positional_metadata)
 
-    def has_metadata(self):
-        """Determine if the sequence contains metadata.
-
-        Returns
-        -------
-        bool
-            Indicates whether the sequence has metadata
-
-        Examples
-        --------
-        >>> from skbio import DNA
-        >>> s = DNA('ACACGACGTT')
-        >>> s.has_metadata()
-        False
-        >>> t = DNA('ACACGACGTT', metadata={'id': 'seq-id'})
-        >>> t.has_metadata()
-        True
-
-        """
-        return self._metadata is not None and bool(self.metadata)
-
-    def has_positional_metadata(self):
-        """Determine if the sequence contains positional metadata.
-
-        Returns
-        -------
-        bool
-            Indicates whether the sequence has positional metadata
-
-        Examples
-        --------
-        >>> from skbio import DNA
-        >>> s = DNA('ACACGACGTT')
-        >>> s.has_positional_metadata()
-        False
-        >>> t = DNA('ACACGACGTT', positional_metadata={'quality': range(10)})
-        >>> t.has_positional_metadata()
-        True
-
-        """
-        return (self._positional_metadata is not None and
-                len(self.positional_metadata.columns) > 0)
-
     def _slice_positional_metadata(self, indexable):
         if self.has_positional_metadata():
             if _is_single_index(indexable):
@@ -986,6 +943,49 @@ class Sequence(collections.Sequence, SkbioObject):
         if len(s) > 20:
             return "%s ... %s" % (s[:7], s[-7:])
         return s
+
+    def has_metadata(self):
+        """Determine if the sequence contains metadata.
+
+        Returns
+        -------
+        bool
+            Indicates whether the sequence has metadata
+
+        Examples
+        --------
+        >>> from skbio import DNA
+        >>> s = DNA('ACACGACGTT')
+        >>> s.has_metadata()
+        False
+        >>> t = DNA('ACACGACGTT', metadata={'id': 'seq-id'})
+        >>> t.has_metadata()
+        True
+
+        """
+        return self._metadata is not None and bool(self.metadata)
+
+    def has_positional_metadata(self):
+        """Determine if the sequence contains positional metadata.
+
+        Returns
+        -------
+        bool
+            Indicates whether the sequence has positional metadata
+
+        Examples
+        --------
+        >>> from skbio import DNA
+        >>> s = DNA('ACACGACGTT')
+        >>> s.has_positional_metadata()
+        False
+        >>> t = DNA('ACACGACGTT', positional_metadata={'quality': range(10)})
+        >>> t.has_positional_metadata()
+        True
+
+        """
+        return (self._positional_metadata is not None and
+                len(self.positional_metadata.columns) > 0)
 
     def count(self, subsequence, start=None, end=None):
         """Count occurrences of a subsequence in the biological sequence.

--- a/skbio/sequence/_sequence.py
+++ b/skbio/sequence/_sequence.py
@@ -1143,10 +1143,11 @@ class Sequence(collections.Sequence, SkbioObject):
         # deep copy here and then shallow copy in the Sequence constructor). we
         # also directly set the private metadata attributes instead of using
         # their public setters to avoid an unnecessary copy
-        if deep:
-            bytes = copy.deepcopy(self._bytes, memo)
-        else:
-            bytes = np.copy(self._bytes)
+
+        # we don't make a distinction between deep vs. shallow copy of bytes
+        # because dtype=np.uint8. we only need to make the distinction when
+        # dealing with object dtype
+        bytes = np.copy(self._bytes)
 
         seq_copy = self._constructor(sequence=bytes, metadata=None,
                                      positional_metadata=None)

--- a/skbio/sequence/tests/test_sequence.py
+++ b/skbio/sequence/tests/test_sequence.py
@@ -1962,10 +1962,9 @@ class TestSequence(TestCase):
         self.assertTrue(seq.has_positional_metadata())
 
     def test_copy_without_metadata(self):
-        # shallow vs deep copy with sequence only should be equivalent
-        # (deepcopy vs copy of a numpy array is only different for object
-        # dtype). thus, copy.copy, copy.deepcopy, and
-        # Sequence.copy(deep=True|False) should all be equivalent
+        # shallow vs deep copy with sequence only should be equivalent. thus,
+        # copy.copy, copy.deepcopy, and Sequence.copy(deep=True|False) should
+        # all be equivalent
         for copy_method in (lambda seq: seq.copy(deep=False),
                             lambda seq: seq.copy(deep=True),
                             copy.copy, copy.deepcopy):
@@ -2062,7 +2061,7 @@ class TestSequence(TestCase):
     def test_deepcopy_memo_is_respected(self):
         # basic test to ensure deepcopy's memo is passed through to recursive
         # deepcopy calls
-        seq = Sequence('ACGT')
+        seq = Sequence('ACGT', metadata={'foo': 'bar'})
         memo = {}
         copy.deepcopy(seq, memo)
         self.assertGreater(len(memo), 2)

--- a/skbio/sequence/tests/test_sequence.py
+++ b/skbio/sequence/tests/test_sequence.py
@@ -2033,7 +2033,8 @@ class TestSequence(TestCase):
             self.assertIsNot(seq_copy, seq)
             self.assertIsNot(seq_copy._bytes, seq._bytes)
             self.assertIsNot(seq_copy._metadata, seq._metadata)
-            self.assertIsNot(seq_copy._positional_metadata, seq._positional_metadata)
+            self.assertIsNot(seq_copy._positional_metadata,
+                             seq._positional_metadata)
             self.assertIsNot(seq_copy._positional_metadata.values,
                              seq._positional_metadata.values)
             self.assertIsNot(seq_copy._metadata['foo'], seq._metadata['foo'])

--- a/skbio/sequence/tests/test_sequence.py
+++ b/skbio/sequence/tests/test_sequence.py
@@ -1960,6 +1960,95 @@ class TestSequence(TestCase):
         seq = Sequence('ACGT', positional_metadata={'foo': [1, 2, 3, 4]})
         self.assertTrue(seq.has_positional_metadata())
 
+    def test_copy_without_metadata(self):
+        # shallow vs deep copy with sequence only should be equivalent
+        # (deepcopy vs copy of a numpy array is only different for object
+        # dtype)
+        for deep in False, True:
+            seq = Sequence('ACGT')
+            copy = seq.copy(deep=deep)
+
+            self.assertEqual(copy, seq)
+            self.assertIsNot(copy, seq)
+            self.assertIsNot(copy._bytes, seq._bytes)
+
+            # metadata attributes should be None and not initialized to a
+            # "missing" representation
+            self.assertIsNone(seq._metadata)
+            self.assertIsNone(seq._positional_metadata)
+            self.assertIsNone(copy._metadata)
+            self.assertIsNone(copy._positional_metadata)
+
+    def test_copy_with_metadata_shallow(self):
+        seq = Sequence('ACGT', metadata={'foo': [1]},
+                       positional_metadata={'bar': [[], [], [], []],
+                                            'baz': [42, 42, 42, 42]})
+        copy = seq.copy()
+
+        self.assertEqual(copy, seq)
+        self.assertIsNot(copy, seq)
+        self.assertIsNot(copy._bytes, seq._bytes)
+        self.assertIsNot(copy._metadata, seq._metadata)
+        self.assertIsNot(copy._positional_metadata, seq._positional_metadata)
+        self.assertIsNot(copy._positional_metadata.values,
+                         seq._positional_metadata.values)
+        self.assertIs(copy._metadata['foo'], seq._metadata['foo'])
+        self.assertIs(copy._positional_metadata.loc[0, 'bar'],
+                      seq._positional_metadata.loc[0, 'bar'])
+
+        copy.metadata['foo'].append(2)
+        copy.metadata['foo2'] = 42
+
+        self.assertEqual(copy.metadata, {'foo': [1, 2], 'foo2': 42})
+        self.assertEqual(seq.metadata, {'foo': [1, 2]})
+
+        copy.positional_metadata.loc[0, 'bar'].append(1)
+        copy.positional_metadata.loc[0, 'baz'] = 43
+
+        assert_data_frame_almost_equal(
+            copy.positional_metadata,
+            pd.DataFrame({'bar': [[1], [], [], []],
+                          'baz': [43, 42, 42, 42]}))
+        assert_data_frame_almost_equal(
+            seq.positional_metadata,
+            pd.DataFrame({'bar': [[1], [], [], []],
+                          'baz': [42, 42, 42, 42]}))
+
+    def test_copy_with_metadata_deep(self):
+        seq = Sequence('ACGT', metadata={'foo': [1]},
+                       positional_metadata={'bar': [[], [], [], []],
+                                            'baz': [42, 42, 42, 42]})
+        copy = seq.copy(deep=True)
+
+        self.assertEqual(copy, seq)
+        self.assertIsNot(copy, seq)
+        self.assertIsNot(copy._bytes, seq._bytes)
+        self.assertIsNot(copy._metadata, seq._metadata)
+        self.assertIsNot(copy._positional_metadata, seq._positional_metadata)
+        self.assertIsNot(copy._positional_metadata.values,
+                         seq._positional_metadata.values)
+        self.assertIsNot(copy._metadata['foo'], seq._metadata['foo'])
+        self.assertIsNot(copy._positional_metadata.loc[0, 'bar'],
+                         seq._positional_metadata.loc[0, 'bar'])
+
+        copy.metadata['foo'].append(2)
+        copy.metadata['foo2'] = 42
+
+        self.assertEqual(copy.metadata, {'foo': [1, 2], 'foo2': 42})
+        self.assertEqual(seq.metadata, {'foo': [1]})
+
+        copy.positional_metadata.loc[0, 'bar'].append(1)
+        copy.positional_metadata.loc[0, 'baz'] = 43
+
+        assert_data_frame_almost_equal(
+            copy.positional_metadata,
+            pd.DataFrame({'bar': [[1], [], [], []],
+                          'baz': [43, 42, 42, 42]}))
+        assert_data_frame_almost_equal(
+            seq.positional_metadata,
+            pd.DataFrame({'bar': [[], [], [], []],
+                          'baz': [42, 42, 42, 42]}))
+
     def test_munge_to_index_array_valid_index_array(self):
         s = Sequence('123456')
 


### PR DESCRIPTION
Adds `Sequence.copy(deep=False)` method for performing shallow and deep copies. Adds `Sequence.__copy__`/`__deepcopy__` for interoperability with `copy.copy`/`copy.deepcopy`.

Also updates codebase to use `Sequence.copy` instead of `Sequence._to`.

Addresses part of #949.

@ebolyen can you review?