### PR TITLE
MAINT: remove most Py3 warnings

### DIFF
--- a/skbio/alignment/_pairwise.py
+++ b/skbio/alignment/_pairwise.py
@@ -685,13 +685,6 @@ def make_identity_substitution_matrix(match_score, mismatch_score,
         score.
 
     """
-
-    warn("make_identity_substitution_matrix is deprecated and will soon be "
-         "replaced, though at the time of this writing the new name has not "
-         "been finalized. Updates will be posted to issue #161: "
-         "https://github.com/biocore/scikit-bio/issues/161",
-         DeprecationWarning)
-
     result = {}
     for c1 in alphabet:
         row = {}

--- a/skbio/alignment/tests/test_alignment.py
+++ b/skbio/alignment/tests/test_alignment.py
@@ -8,6 +8,8 @@
 
 from __future__ import absolute_import, division, print_function
 
+import six
+
 from unittest import TestCase, main
 from collections import Counter, defaultdict
 
@@ -52,9 +54,9 @@ class SequenceCollectionTests(TestCase):
 
     def test_init_fail_no_id(self):
         seq = Sequence('ACGTACGT')
-        with self.assertRaisesRegexp(SequenceCollectionError,
-                                     "'id' must be included in the sequence "
-                                     "metadata"):
+        with six.assertRaisesRegex(self, SequenceCollectionError,
+                                   "'id' must be included in the sequence "
+                                   "metadata"):
             SequenceCollection([seq])
 
     def test_contains(self):
@@ -358,26 +360,27 @@ class SequenceCollectionTests(TestCase):
         self.assertEqual(obs_id_map, exp_id_map)
 
     def test_update_ids_invalid_parameter_combos(self):
-        with self.assertRaisesRegexp(SequenceCollectionError, 'ids and func'):
+        with six.assertRaisesRegex(self, SequenceCollectionError,
+                                   'ids and func'):
             self.s1.update_ids(func=lambda e: e, ids=['foo', 'bar'])
 
-        with self.assertRaisesRegexp(SequenceCollectionError, 'prefix'):
+        with six.assertRaisesRegex(self, SequenceCollectionError, 'prefix'):
             self.s1.update_ids(ids=['foo', 'bar'], prefix='abc')
 
-        with self.assertRaisesRegexp(SequenceCollectionError, 'prefix'):
+        with six.assertRaisesRegex(self, SequenceCollectionError, 'prefix'):
             self.s1.update_ids(func=lambda e: e, prefix='abc')
 
     def test_update_ids_invalid_ids(self):
         # incorrect number of new ids
-        with self.assertRaisesRegexp(SequenceCollectionError, '3 != 2'):
+        with six.assertRaisesRegex(self, SequenceCollectionError, '3 != 2'):
             self.s1.update_ids(ids=['foo', 'bar', 'baz'])
-        with self.assertRaisesRegexp(SequenceCollectionError, '4 != 2'):
+        with six.assertRaisesRegex(self, SequenceCollectionError, '4 != 2'):
             self.s1.update_ids(func=lambda e: ['foo', 'bar', 'baz', 'abc'])
 
         # duplicates
-        with self.assertRaisesRegexp(SequenceCollectionError, 'foo'):
+        with six.assertRaisesRegex(self, SequenceCollectionError, 'foo'):
             self.s2.update_ids(ids=['foo', 'bar', 'foo'])
-        with self.assertRaisesRegexp(SequenceCollectionError, 'bar'):
+        with six.assertRaisesRegex(self, SequenceCollectionError, 'bar'):
             self.s2.update_ids(func=lambda e: ['foo', 'bar', 'bar'])
 
     def test_is_empty(self):

--- a/skbio/alignment/tests/test_ssw.py
+++ b/skbio/alignment/tests/test_ssw.py
@@ -601,8 +601,8 @@ class TestAlignStripedSmithWaterman(TestSSW):
         align2 = local_pairwise_align_ssw(query_sequence, target_sequence,
                                           constructor=DNA)
 
-        self.assertEquals(type(align1[0]), Sequence)
-        self.assertEquals(type(align2[0]), DNA)
+        self.assertEqual(type(align1[0]), Sequence)
+        self.assertEqual(type(align2[0]), DNA)
 
 
 class TestAlignmentStructure(TestSSW):

--- a/skbio/io/tests/test_base.py
+++ b/skbio/io/tests/test_base.py
@@ -7,6 +7,8 @@
 # ----------------------------------------------------------------------------
 
 from __future__ import absolute_import, division, print_function
+
+import six
 from future.builtins import range, zip
 
 import unittest
@@ -297,11 +299,11 @@ class TestFormatFASTALikeRecords(unittest.TestCase):
             npt.assert_equal(o, e)
 
     def test_newline_character_in_id_whitespace_replacement(self):
-        with self.assertRaisesRegexp(ValueError, 'Newline character'):
+        with six.assertRaisesRegex(self, ValueError, 'Newline character'):
             list(_format_fasta_like_records(self.gen, '-\n--', ' ', False))
 
     def test_newline_character_in_description_newline_replacement(self):
-        with self.assertRaisesRegexp(ValueError, 'Newline character'):
+        with six.assertRaisesRegex(self, ValueError, 'Newline character'):
             list(_format_fasta_like_records(self.gen, None, 'a\nb', False))
 
     def test_empty_sequence(self):
@@ -310,7 +312,7 @@ class TestFormatFASTALikeRecords(unittest.TestCase):
                         RNA('GG')):
                 yield seq
 
-        with self.assertRaisesRegexp(ValueError, '2nd.*empty'):
+        with six.assertRaisesRegex(self, ValueError, '2nd.*empty'):
             list(_format_fasta_like_records(blank_seq_gen(), None, None,
                                             False))
 
@@ -321,8 +323,8 @@ class TestFormatFASTALikeRecords(unittest.TestCase):
                         DNA('GG', positional_metadata={'quality': [41, 40]})):
                 yield seq
 
-        with self.assertRaisesRegexp(ValueError,
-                                     '2nd sequence.*quality scores'):
+        with six.assertRaisesRegex(self, ValueError,
+                                   '2nd sequence.*quality scores'):
             list(_format_fasta_like_records(missing_qual_gen(), '-', '-',
                                             True))
 

--- a/skbio/io/tests/test_clustal.py
+++ b/skbio/io/tests/test_clustal.py
@@ -22,7 +22,7 @@ from skbio.io import ClustalFormatError
 class ClustalHelperTests(TestCase):
     def test_label_line_parser(self):
         self.assertEqual(_label_line_parser(StringIO('abc\tucag')),
-                          ({"abc": ["ucag"]}, ['abc']))
+                         ({"abc": ["ucag"]}, ['abc']))
 
         with self.assertRaises(ClustalFormatError):
             _label_line_parser(StringIO('abctucag'))

--- a/skbio/io/tests/test_clustal.py
+++ b/skbio/io/tests/test_clustal.py
@@ -21,7 +21,7 @@ from skbio.io import ClustalFormatError
 
 class ClustalHelperTests(TestCase):
     def test_label_line_parser(self):
-        self.assertEquals(_label_line_parser(StringIO('abc\tucag')),
+        self.assertEqual(_label_line_parser(StringIO('abc\tucag')),
                           ({"abc": ["ucag"]}, ['abc']))
 
         with self.assertRaises(ClustalFormatError):
@@ -227,7 +227,7 @@ UGCUGCAUCA---------------- 33
             testfile.close()
             testfile = open(fname, 'r')
             result_after = _clustal_to_alignment(testfile)
-            self.assertEquals(result_before, result_after)
+            self.assertEqual(result_before, result_after)
         os.remove(fname)
 
     def test_invalid_alignment_to_clustal_and_clustal_to_alignment(self):

--- a/skbio/io/tests/test_fasta.py
+++ b/skbio/io/tests/test_fasta.py
@@ -8,6 +8,7 @@
 
 from __future__ import absolute_import, division, print_function
 from future.builtins import map, range, zip
+import six
 from six import StringIO
 
 from unittest import TestCase, main
@@ -441,7 +442,7 @@ class ReaderTests(TestCase):
 
     def test_fasta_to_generator_invalid_files(self):
         for fp, kwargs, error_type, error_msg_regex in self.invalid_fps:
-            with self.assertRaisesRegexp(error_type, error_msg_regex):
+            with six.assertRaisesRegex(self, error_type, error_msg_regex):
                 list(_fasta_to_generator(fp, **kwargs))
 
     # light testing of fasta -> object readers to ensure interface is present
@@ -468,9 +469,9 @@ class ReaderTests(TestCase):
 
             # empty file
             empty_fp = get_data_path('empty')
-            with self.assertRaisesRegexp(ValueError, '1st sequence'):
+            with six.assertRaisesRegex(self, ValueError, '1st sequence'):
                 reader_fn(empty_fp)
-            with self.assertRaisesRegexp(ValueError, '1st sequence'):
+            with six.assertRaisesRegex(self, ValueError, '1st sequence'):
                 reader_fn(empty_fp, qual=empty_fp)
 
             # the sequences in the following files don't necessarily make sense
@@ -560,17 +561,19 @@ class ReaderTests(TestCase):
                     self.assertEqual(obs, exp)
 
                 # seq_num too large
-                with self.assertRaisesRegexp(ValueError, '8th sequence'):
+                with six.assertRaisesRegex(self, ValueError, '8th sequence'):
                     reader_fn(fasta_fp, seq_num=8)
                 for qual_fp in qual_fps:
-                    with self.assertRaisesRegexp(ValueError, '8th sequence'):
+                    with six.assertRaisesRegex(self, ValueError,
+                                               '8th sequence'):
                         reader_fn(fasta_fp, seq_num=8, qual=qual_fp)
 
                 # seq_num too small
-                with self.assertRaisesRegexp(ValueError, '`seq_num`=0'):
+                with six.assertRaisesRegex(self, ValueError, '`seq_num`=0'):
                     reader_fn(fasta_fp, seq_num=0)
                 for qual_fp in qual_fps:
-                    with self.assertRaisesRegexp(ValueError, '`seq_num`=0'):
+                    with six.assertRaisesRegex(self, ValueError,
+                                               '`seq_num`=0'):
                         reader_fn(fasta_fp, seq_num=0, qual=qual_fp)
 
     def test_fasta_to_sequence_collection_and_alignment(self):
@@ -822,17 +825,17 @@ class WriterTests(TestCase):
     def test_generator_to_fasta_invalid_input(self):
         for obj, kwargs, error_type, error_msg_regexp in self.invalid_objs:
             fh = StringIO()
-            with self.assertRaisesRegexp(error_type, error_msg_regexp):
+            with six.assertRaisesRegex(self, error_type, error_msg_regexp):
                 _generator_to_fasta(obj, fh, **kwargs)
             fh.close()
 
     def test_generator_to_fasta_sequence_lowercase_exception(self):
         seq = Sequence('ACgt', metadata={'id': ''})
         fh = StringIO()
-        with self.assertRaisesRegexp(AttributeError,
-                                     "lowercase specified but class Sequence "
-                                     "does not support lowercase "
-                                     "functionality"):
+        with six.assertRaisesRegex(self, AttributeError,
+                                   "lowercase specified but class Sequence "
+                                   "does not support lowercase "
+                                   "functionality"):
             _generator_to_fasta(SequenceCollection([seq]), fh,
                                 lowercase='introns')
 
@@ -940,19 +943,19 @@ class WriterTests(TestCase):
             self.assertEqual(obs_qual, exp_qual)
 
             fh2 = StringIO()
-            with self.assertRaisesRegexp(AttributeError,
-                                         "lowercase specified but class "
-                                         "Sequence does not support lowercase "
-                                         "functionality"):
+            with six.assertRaisesRegex(self, AttributeError,
+                                       "lowercase specified but class "
+                                       "Sequence does not support lowercase "
+                                       "functionality"):
                 fn(obj, fh2, lowercase='introns')
             fh2.close()
 
             fasta_fh2 = StringIO()
             qual_fh2 = StringIO()
-            with self.assertRaisesRegexp(AttributeError,
-                                         "lowercase specified but class "
-                                         "Sequence does not support lowercase "
-                                         "functionality"):
+            with six.assertRaisesRegex(self, AttributeError,
+                                       "lowercase specified but class "
+                                       "Sequence does not support lowercase "
+                                       "functionality"):
                 fn(obj, fasta_fh2, id_whitespace_replacement='*',
                    description_newline_replacement='+', max_width=3,
                    qual=qual_fh2, lowercase='introns')

--- a/skbio/io/tests/test_fastq.py
+++ b/skbio/io/tests/test_fastq.py
@@ -8,6 +8,7 @@
 
 from __future__ import absolute_import, division, print_function
 from future.builtins import zip
+import six
 from six import StringIO
 
 import unittest
@@ -324,11 +325,11 @@ class TestReaders(unittest.TestCase):
         # phred offsets
         for fp, error_type, error_msg_regex in self.invalid_files:
             for variant in 'sanger', 'illumina1.3', 'illumina1.8':
-                with self.assertRaisesRegexp(error_type, error_msg_regex):
+                with six.assertRaisesRegex(self, error_type, error_msg_regex):
                     list(_fastq_to_generator(fp, variant=variant))
 
             for offset in 33, 64, 40, 77:
-                with self.assertRaisesRegexp(error_type, error_msg_regex):
+                with six.assertRaisesRegex(self, error_type, error_msg_regex):
                     list(_fastq_to_generator(fp, phred_offset=offset))
 
     def test_fastq_to_generator_invalid_files_illumina(self):
@@ -338,9 +339,11 @@ class TestReaders(unittest.TestCase):
                'solexa_full_range_original_solexa.fastq']]
 
         for fp in fps:
-            with self.assertRaisesRegexp(ValueError, 'out of range \[0, 62\]'):
+            with six.assertRaisesRegex(self, ValueError,
+                                       'out of range \[0, 62\]'):
                 list(_fastq_to_generator(fp, variant='illumina1.3'))
-            with self.assertRaisesRegexp(ValueError, 'out of range \[0, 62\]'):
+            with six.assertRaisesRegex(self, ValueError,
+                                       'out of range \[0, 62\]'):
                 list(_fastq_to_generator(fp, variant='illumina1.8'))
 
     def test_fastq_to_generator_solexa(self):
@@ -574,7 +577,7 @@ class TestWriters(unittest.TestCase):
                            positional_metadata={'quality': range(4)})
             yield Sequence('ACG', metadata={'id': 'foo', 'description': 'bar'})
 
-        with self.assertRaisesRegexp(ValueError, '2nd.*quality scores'):
+        with six.assertRaisesRegex(self, ValueError, '2nd.*quality scores'):
             _generator_to_fastq(gen(), StringIO(), variant='illumina1.8')
 
 

--- a/skbio/io/tests/test_lsmat.py
+++ b/skbio/io/tests/test_lsmat.py
@@ -7,6 +7,7 @@
 # ----------------------------------------------------------------------------
 
 from __future__ import absolute_import, division, print_function
+import six
 from six import StringIO
 
 from unittest import TestCase, main
@@ -120,8 +121,8 @@ class DissimilarityAndDistanceMatrixReaderWriterTests(LSMatTestData):
     def test_read_invalid_files(self):
         for fn in _lsmat_to_dissimilarity_matrix, _lsmat_to_distance_matrix:
             for invalid_fh, error_msg_regexp in self.invalid_fhs:
-                with self.assertRaisesRegexp(LSMatFormatError,
-                                             error_msg_regexp):
+                with six.assertRaisesRegex(self, LSMatFormatError,
+                                           error_msg_regexp):
                     invalid_fh.seek(0)
                     fn(invalid_fh)
 

--- a/skbio/io/tests/test_newick.py
+++ b/skbio/io/tests/test_newick.py
@@ -349,7 +349,7 @@ class TestNewick(unittest.TestCase):
         tree = _newick_to_tree_node(fh, convert_underscores=False)
         fh2 = StringIO()
         _tree_node_to_newick(tree, fh2)
-        self.assertEquals(fh2.getvalue(), "('_':0.1,'_a','_b')'__';\n")
+        self.assertEqual(fh2.getvalue(), "('_':0.1,'_a','_b')'__';\n")
         fh2.close()
         fh.close()
 

--- a/skbio/io/tests/test_ordination.py
+++ b/skbio/io/tests/test_ordination.py
@@ -7,6 +7,7 @@
 # ----------------------------------------------------------------------------
 
 from __future__ import absolute_import, division, print_function
+import six
 from six import StringIO
 
 from unittest import TestCase, main
@@ -176,8 +177,8 @@ class OrdinationResultsReaderWriterTests(OrdinationTestData):
 
     def test_read_invalid_files(self):
         for invalid_fp, error_msg_regexp, _ in self.invalid_fps:
-            with self.assertRaisesRegexp(OrdinationFormatError,
-                                         error_msg_regexp):
+            with six.assertRaisesRegex(self, OrdinationFormatError,
+                                       error_msg_regexp):
                 _ordination_to_ordination_results(invalid_fp)
 
     def test_write(self):

--- a/skbio/io/tests/test_phylip.py
+++ b/skbio/io/tests/test_phylip.py
@@ -7,6 +7,7 @@
 # ----------------------------------------------------------------------------
 
 from __future__ import absolute_import, division, print_function
+import six
 from six import StringIO
 
 from unittest import TestCase, main
@@ -88,7 +89,8 @@ class AlignmentWriterTests(TestCase):
     def test_write_invalid_alignment(self):
         for invalid_obj, error_msg_regexp in self.invalid_objs:
             fh = StringIO()
-            with self.assertRaisesRegexp(PhylipFormatError, error_msg_regexp):
+            with six.assertRaisesRegex(self, PhylipFormatError,
+                                       error_msg_regexp):
                 _alignment_to_phylip(invalid_obj, fh)
 
             # ensure nothing was written to the file before the error was

--- a/skbio/io/tests/test_util.py
+++ b/skbio/io/tests/test_util.py
@@ -125,7 +125,7 @@ class TestFilePathsOpening(unittest.TestCase):
             with open_files(['http://google.com/foo-seqs.fna']) as fhs:
                 for f in fhs:
                     f.read()
-        self.assertEquals(str(e.exception), '404 Client Error: Not Found')
+        self.assertEqual(str(e.exception), '404 Client Error: Not Found')
 
     def test_remote_fna(self):
         url = ('http://www.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?retmax=1'

--- a/skbio/sequence/tests/test_iupac_sequence.py
+++ b/skbio/sequence/tests/test_iupac_sequence.py
@@ -7,6 +7,7 @@
 # ----------------------------------------------------------------------------
 
 from __future__ import absolute_import, division, print_function
+import six
 
 from unittest import TestCase, main
 
@@ -98,7 +99,7 @@ class TestIUPACSequence(TestCase):
     def test_init_validate_parameter_single_character(self):
         seq = 'w'
 
-        with self.assertRaisesRegexp(ValueError, "character.*'w'"):
+        with six.assertRaisesRegex(self, ValueError, "character.*'w'"):
             ExampleIUPACSequence(seq)
 
         # test that we can instantiate an invalid sequence. we don't guarantee
@@ -110,7 +111,7 @@ class TestIUPACSequence(TestCase):
         # alphabet characters
         seq = 'CBCBBbawCbbwBXYZ-.x'
 
-        with self.assertRaisesRegexp(ValueError, "\['a', 'b', 'w', 'x'\]"):
+        with six.assertRaisesRegex(self, ValueError, "\['a', 'b', 'w', 'x'\]"):
             ExampleIUPACSequence(seq)
 
         ExampleIUPACSequence(seq, validate=False)
@@ -118,8 +119,8 @@ class TestIUPACSequence(TestCase):
     def test_init_lowercase_all_lowercase(self):
         s = 'cbcbbbazcbbzbxyz-.x'
 
-        with self.assertRaisesRegexp(ValueError,
-                                     "\['a', 'b', 'c', 'x', 'y', 'z'\]"):
+        with six.assertRaisesRegex(self, ValueError,
+                                   "\['a', 'b', 'c', 'x', 'y', 'z'\]"):
             ExampleIUPACSequence(s)
 
         seq = ExampleIUPACSequence(s, lowercase=True)
@@ -128,7 +129,7 @@ class TestIUPACSequence(TestCase):
     def test_init_lowercase_mixed_case(self):
         s = 'CBCBBbazCbbzBXYZ-.x'
 
-        with self.assertRaisesRegexp(ValueError, "\['a', 'b', 'x', 'z'\]"):
+        with six.assertRaisesRegex(self, ValueError, "\['a', 'b', 'x', 'z'\]"):
             ExampleIUPACSequence(s)
 
         seq = ExampleIUPACSequence(s, lowercase=True)
@@ -137,10 +138,10 @@ class TestIUPACSequence(TestCase):
     def test_init_lowercase_no_validation(self):
         s = 'car'
 
-        with self.assertRaisesRegexp(ValueError, "\['a', 'c', 'r'\]"):
+        with six.assertRaisesRegex(self, ValueError, "\['a', 'c', 'r'\]"):
             ExampleIUPACSequence(s)
 
-        with self.assertRaisesRegexp(ValueError, "character.*'R'"):
+        with six.assertRaisesRegex(self, ValueError, "character.*'R'"):
             ExampleIUPACSequence(s, lowercase=True)
 
         ExampleIUPACSequence(s, lowercase=True, validate=False)
@@ -148,7 +149,7 @@ class TestIUPACSequence(TestCase):
     def test_init_lowercase_byte_ownership(self):
         bytes = np.array([97, 98, 97], dtype=np.uint8)
 
-        with self.assertRaisesRegexp(ValueError, "\['a', 'b'\]"):
+        with six.assertRaisesRegex(self, ValueError, "\['a', 'b'\]"):
             ExampleIUPACSequence(bytes)
 
         seq = ExampleIUPACSequence(bytes, lowercase=True)
@@ -164,10 +165,10 @@ class TestIUPACSequence(TestCase):
     def test_init_lowercase_invalid_keys(self):
         for invalid_key in ((), [], 2):
             invalid_type = type(invalid_key)
-            with self.assertRaisesRegexp(TypeError,
-                                         "lowercase keyword argument expected "
-                                         "a bool or string, but got %s" %
-                                         invalid_type):
+            with six.assertRaisesRegex(self, TypeError,
+                                       "lowercase keyword argument expected "
+                                       "a bool or string, but got %s" %
+                                       invalid_type):
                 ExampleIUPACSequence('ACGTacgt', lowercase=invalid_key)
 
     def test_lowercase_mungeable_key(self):
@@ -176,7 +177,7 @@ class TestIUPACSequence(TestCase):
         # changes to no longer use _munge_to_index_array, this test may need
         # to be updated to cover cases currently covered by
         # _munge_to_index_array
-        self.assertEquals('AAAAaaaa', self.lowercase_seq.lowercase('key'))
+        self.assertEqual('AAAAaaaa', self.lowercase_seq.lowercase('key'))
 
     def test_lowercase_array_key(self):
         # NOTE: This test relies on Sequence._munge_to_index_array working
@@ -184,12 +185,12 @@ class TestIUPACSequence(TestCase):
         # changes to no longer use _munge_to_index_array, this test may need
         # to be updated to cover cases currently covered by
         # _munge_to_index_array
-        self.assertEquals('aaAAaaaa',
-                          self.lowercase_seq.lowercase(
-                              np.array([True, True, False, False, True, True,
-                                        True, True])))
-        self.assertEquals('AaAAaAAA',
-                          self.lowercase_seq.lowercase([1, 4]))
+        self.assertEqual('aaAAaaaa',
+                         self.lowercase_seq.lowercase(
+                             np.array([True, True, False, False, True, True,
+                                       True, True])))
+        self.assertEqual('AaAAaAAA',
+                         self.lowercase_seq.lowercase([1, 4]))
 
     def test_degenerate_chars(self):
         expected = set("XYZ")
@@ -355,13 +356,13 @@ class TestIUPACSequence(TestCase):
             },
         }
 
-        self.assertEquals(
+        self.assertEqual(
             ExampleIUPACSequence("", positional_metadata={'qual': []},
                                  **kw).degap(),
             ExampleIUPACSequence("", positional_metadata={'qual': []},
                                  **kw))
 
-        self.assertEquals(
+        self.assertEqual(
             ExampleIUPACSequence(
                 "ABCXYZ",
                 positional_metadata={'qual': np.arange(6)},
@@ -371,7 +372,7 @@ class TestIUPACSequence(TestCase):
                 positional_metadata={'qual': np.arange(6)},
                 **kw))
 
-        self.assertEquals(
+        self.assertEqual(
             ExampleIUPACSequence(
                 "ABC-XYZ",
                 positional_metadata={'qual': np.arange(7)},
@@ -381,7 +382,7 @@ class TestIUPACSequence(TestCase):
                 positional_metadata={'qual': [0, 1, 2, 4, 5, 6]},
                 **kw))
 
-        self.assertEquals(
+        self.assertEqual(
             ExampleIUPACSequence(
                 ".-ABC-XYZ.",
                 positional_metadata={'qual': np.arange(10)},
@@ -391,7 +392,7 @@ class TestIUPACSequence(TestCase):
                 positional_metadata={'qual': [2, 3, 4, 6, 7, 8]},
                 **kw))
 
-        self.assertEquals(
+        self.assertEqual(
             ExampleIUPACSequence(
                 "---.-.-.-.-.",
                 positional_metadata={'quality': np.arange(12)},

--- a/skbio/sequence/tests/test_sequence.py
+++ b/skbio/sequence/tests/test_sequence.py
@@ -7,6 +7,7 @@
 # ----------------------------------------------------------------------------
 
 from __future__ import absolute_import, division, print_function
+import six
 from six.moves import zip_longest
 
 import copy
@@ -392,23 +393,23 @@ class TestSequence(TestCase):
             Sequence(np.array([1, {}, ()]))
 
         # invalid input type (non-numpy.ndarray input)
-        with self.assertRaisesRegexp(TypeError, 'tuple'):
+        with six.assertRaisesRegex(self, TypeError, 'tuple'):
             Sequence(('a', 'b', 'c'))
-        with self.assertRaisesRegexp(TypeError, 'list'):
+        with six.assertRaisesRegex(self, TypeError, 'list'):
             Sequence(['a', 'b', 'c'])
-        with self.assertRaisesRegexp(TypeError, 'set'):
+        with six.assertRaisesRegex(self, TypeError, 'set'):
             Sequence({'a', 'b', 'c'})
-        with self.assertRaisesRegexp(TypeError, 'dict'):
+        with six.assertRaisesRegex(self, TypeError, 'dict'):
             Sequence({'a': 42, 'b': 43, 'c': 44})
-        with self.assertRaisesRegexp(TypeError, 'int'):
+        with six.assertRaisesRegex(self, TypeError, 'int'):
             Sequence(42)
-        with self.assertRaisesRegexp(TypeError, 'float'):
+        with six.assertRaisesRegex(self, TypeError, 'float'):
             Sequence(4.2)
-        with self.assertRaisesRegexp(TypeError, 'int64'):
+        with six.assertRaisesRegex(self, TypeError, 'int64'):
             Sequence(np.int_(50))
-        with self.assertRaisesRegexp(TypeError, 'float64'):
+        with six.assertRaisesRegex(self, TypeError, 'float64'):
             Sequence(np.float_(50))
-        with self.assertRaisesRegexp(TypeError, 'Foo'):
+        with six.assertRaisesRegex(self, TypeError, 'Foo'):
             class Foo(object):
                 pass
             Sequence(Foo())
@@ -419,38 +420,38 @@ class TestSequence(TestCase):
 
     def test_init_invalid_metadata(self):
         for md in (0, 'a', ('f', 'o', 'o'), np.array([]), pd.DataFrame()):
-            with self.assertRaisesRegexp(TypeError,
-                                         'metadata must be a dict'):
+            with six.assertRaisesRegex(self, TypeError,
+                                       'metadata must be a dict'):
                 Sequence('abc', metadata=md)
 
     def test_init_invalid_positional_metadata(self):
         # not consumable by Pandas
-        with self.assertRaisesRegexp(TypeError,
-                                     'Positional metadata invalid. Must be '
-                                     'consumable by pd.DataFrame. '
-                                     'Original pandas error message: '):
+        with six.assertRaisesRegex(self, TypeError,
+                                   'Positional metadata invalid. Must be '
+                                   'consumable by pd.DataFrame. '
+                                   'Original pandas error message: '):
             Sequence('ACGT', positional_metadata=2)
         # 0 elements
-        with self.assertRaisesRegexp(ValueError, '\(0\).*\(4\)'):
+        with six.assertRaisesRegex(self, ValueError, '\(0\).*\(4\)'):
             Sequence('ACGT', positional_metadata=[])
         # not enough elements
-        with self.assertRaisesRegexp(ValueError, '\(3\).*\(4\)'):
+        with six.assertRaisesRegex(self, ValueError, '\(3\).*\(4\)'):
             Sequence('ACGT', positional_metadata=[2, 3, 4])
         # too many elements
-        with self.assertRaisesRegexp(ValueError, '\(5\).*\(4\)'):
+        with six.assertRaisesRegex(self, ValueError, '\(5\).*\(4\)'):
             Sequence('ACGT', positional_metadata=[2, 3, 4, 5, 6])
         # Series not enough rows
-        with self.assertRaisesRegexp(ValueError, '\(3\).*\(4\)'):
+        with six.assertRaisesRegex(self, ValueError, '\(3\).*\(4\)'):
             Sequence('ACGT', positional_metadata=pd.Series(range(3)))
         # Series too many rows
-        with self.assertRaisesRegexp(ValueError, '\(5\).*\(4\)'):
+        with six.assertRaisesRegex(self, ValueError, '\(5\).*\(4\)'):
             Sequence('ACGT', positional_metadata=pd.Series(range(5)))
         # DataFrame not enough rows
-        with self.assertRaisesRegexp(ValueError, '\(3\).*\(4\)'):
+        with six.assertRaisesRegex(self, ValueError, '\(3\).*\(4\)'):
             Sequence('ACGT',
                      positional_metadata=pd.DataFrame({'quality': range(3)}))
         # DataFrame too many rows
-        with self.assertRaisesRegexp(ValueError, '\(5\).*\(4\)'):
+        with six.assertRaisesRegex(self, ValueError, '\(5\).*\(4\)'):
             Sequence('ACGT',
                      positional_metadata=pd.DataFrame({'quality': range(5)}))
 
@@ -519,8 +520,8 @@ class TestSequence(TestCase):
 
         for md in (None, 0, 'a', ('f', 'o', 'o'), np.array([]),
                    pd.DataFrame()):
-            with self.assertRaisesRegexp(TypeError,
-                                         'metadata must be a dict'):
+            with six.assertRaisesRegex(self, TypeError,
+                                       'metadata must be a dict'):
                 seq.metadata = md
 
             # object should still be usable and its original metadata shouldn't
@@ -632,10 +633,10 @@ class TestSequence(TestCase):
         seq = Sequence('abc', positional_metadata={'foo': [1, 2, 42]})
 
         # not consumable by Pandas
-        with self.assertRaisesRegexp(TypeError,
-                                     'Positional metadata invalid. Must be '
-                                     'consumable by pd.DataFrame. '
-                                     'Original pandas error message: '):
+        with six.assertRaisesRegex(self, TypeError,
+                                   'Positional metadata invalid. Must be '
+                                   'consumable by pd.DataFrame. '
+                                   'Original pandas error message: '):
             seq.positional_metadata = 2
 
         # object should still be usable and its original metadata shouldn't
@@ -644,14 +645,14 @@ class TestSequence(TestCase):
                                        pd.DataFrame({'foo': [1, 2, 42]}))
 
         # wrong length
-        with self.assertRaisesRegexp(ValueError, '\(2\).*\(3\)'):
+        with six.assertRaisesRegex(self, ValueError, '\(2\).*\(3\)'):
             seq.positional_metadata = {'foo': [1, 2]}
 
         assert_data_frame_almost_equal(seq.positional_metadata,
                                        pd.DataFrame({'foo': [1, 2, 42]}))
 
         # None isn't valid when using setter (differs from constructor)
-        with self.assertRaisesRegexp(ValueError, '\(0\).*\(3\)'):
+        with six.assertRaisesRegex(self, ValueError, '\(0\).*\(3\)'):
             seq.positional_metadata = None
 
         assert_data_frame_almost_equal(seq.positional_metadata,
@@ -759,9 +760,9 @@ class TestSequence(TestCase):
         # array-like objects will fail if wrong size
         for array_like in (np.array(range(l-1)), range(l-1),
                            np.array(range(l+1)), range(l+1)):
-            with self.assertRaisesRegexp(ValueError,
-                                         "Length of values does not match "
-                                         "length of index"):
+            with six.assertRaisesRegex(self, ValueError,
+                                       "Length of values does not match "
+                                       "length of index"):
                 seq.positional_metadata['bar'] = array_like
 
     def test_eq_and_ne(self):
@@ -941,49 +942,49 @@ class TestSequence(TestCase):
 
         eseq = Sequence("012", metadata={'id': 'id3', 'description': 'dsc3'},
                         positional_metadata={'quality': np.arange(3)})
-        self.assertEquals(seq[0:3], eseq)
-        self.assertEquals(seq[:3], eseq)
-        self.assertEquals(seq[:3:1], eseq)
+        self.assertEqual(seq[0:3], eseq)
+        self.assertEqual(seq[:3], eseq)
+        self.assertEqual(seq[:3:1], eseq)
 
         eseq = Sequence("def", metadata={'id': 'id3', 'description': 'dsc3'},
                         positional_metadata={'quality': [13, 14, 15]})
-        self.assertEquals(seq[-3:], eseq)
-        self.assertEquals(seq[-3::1], eseq)
+        self.assertEqual(seq[-3:], eseq)
+        self.assertEqual(seq[-3::1], eseq)
 
         eseq = Sequence("02468ace",
                         metadata={'id': 'id3', 'description': 'dsc3'},
                         positional_metadata={'quality': [0, 2, 4, 6, 8, 10,
                                                          12, 14]})
-        self.assertEquals(seq[0:length:2], eseq)
-        self.assertEquals(seq[::2], eseq)
+        self.assertEqual(seq[0:length:2], eseq)
+        self.assertEqual(seq[::2], eseq)
 
         eseq = Sequence(s[::-1], metadata={'id': 'id3', 'description': 'dsc3'},
                         positional_metadata={'quality':
                                              np.arange(length)[::-1]})
-        self.assertEquals(seq[length::-1], eseq)
-        self.assertEquals(seq[::-1], eseq)
+        self.assertEqual(seq[length::-1], eseq)
+        self.assertEqual(seq[::-1], eseq)
 
         eseq = Sequence('fdb97531',
                         metadata={'id': 'id3', 'description': 'dsc3'},
                         positional_metadata={'quality': [15, 13, 11, 9, 7, 5,
                                                          3, 1]})
-        self.assertEquals(seq[length::-2], eseq)
-        self.assertEquals(seq[::-2], eseq)
+        self.assertEqual(seq[length::-2], eseq)
+        self.assertEqual(seq[::-2], eseq)
 
-        self.assertEquals(seq[0:500:], seq)
+        self.assertEqual(seq[0:500:], seq)
 
         eseq = Sequence('', metadata={'id': 'id3', 'description': 'dsc3'},
                         positional_metadata={'quality':
                                              np.array([], dtype=np.int64)})
-        self.assertEquals(seq[length:0], eseq)
-        self.assertEquals(seq[-length:0], eseq)
-        self.assertEquals(seq[1:0], eseq)
+        self.assertEqual(seq[length:0], eseq)
+        self.assertEqual(seq[-length:0], eseq)
+        self.assertEqual(seq[1:0], eseq)
 
         eseq = Sequence("0", metadata={'id': 'id3', 'description': 'dsc3'},
                         positional_metadata={'quality': [0]})
-        self.assertEquals(seq[0:1], eseq)
-        self.assertEquals(seq[0:1:1], eseq)
-        self.assertEquals(seq[-length::-1], eseq)
+        self.assertEqual(seq[0:1], eseq)
+        self.assertEqual(seq[0:1:1], eseq)
+        self.assertEqual(seq[-length::-1], eseq)
 
     def test_getitem_with_slice_no_positional_metadata(self):
         s = "0123456789abcdef"
@@ -992,8 +993,8 @@ class TestSequence(TestCase):
 
         eseq = Sequence("02468ace",
                         metadata={'id': 'id4', 'description': 'no_qual4'})
-        self.assertEquals(seq[0:length:2], eseq)
-        self.assertEquals(seq[::2], eseq)
+        self.assertEqual(seq[0:length:2], eseq)
+        self.assertEqual(seq[::2], eseq)
 
     def test_getitem_with_tuple_of_mixed_with_positional_metadata(self):
         s = "0123456789abcdef"
@@ -1003,30 +1004,30 @@ class TestSequence(TestCase):
 
         eseq = Sequence("00000", metadata={'id': 'id5', 'description': 'dsc5'},
                         positional_metadata={'quality': [0, 0, 0, 0, 0]})
-        self.assertEquals(seq[0, 0, 0, 0, 0], eseq)
-        self.assertEquals(seq[0, 0:1, 0, 0, 0], eseq)
-        self.assertEquals(seq[0, 0:1, 0, -length::-1, 0, 1:0], eseq)
-        self.assertEquals(seq[0:1, 0:1, 0:1, 0:1, 0:1], eseq)
-        self.assertEquals(seq[0:1, 0, 0, 0, 0], eseq)
+        self.assertEqual(seq[0, 0, 0, 0, 0], eseq)
+        self.assertEqual(seq[0, 0:1, 0, 0, 0], eseq)
+        self.assertEqual(seq[0, 0:1, 0, -length::-1, 0, 1:0], eseq)
+        self.assertEqual(seq[0:1, 0:1, 0:1, 0:1, 0:1], eseq)
+        self.assertEqual(seq[0:1, 0, 0, 0, 0], eseq)
 
         eseq = Sequence("0123fed9",
                         metadata={'id': 'id5', 'description': 'dsc5'},
                         positional_metadata={'quality': [0, 1, 2, 3, 15, 14,
                                                          13, 9]})
-        self.assertEquals(seq[0, 1, 2, 3, 15, 14, 13, 9], eseq)
-        self.assertEquals(seq[0, 1, 2, 3, :-4:-1, 9], eseq)
-        self.assertEquals(seq[0:4, :-4:-1, 9, 1:0], eseq)
-        self.assertEquals(seq[0:4, :-4:-1, 9:10], eseq)
+        self.assertEqual(seq[0, 1, 2, 3, 15, 14, 13, 9], eseq)
+        self.assertEqual(seq[0, 1, 2, 3, :-4:-1, 9], eseq)
+        self.assertEqual(seq[0:4, :-4:-1, 9, 1:0], eseq)
+        self.assertEqual(seq[0:4, :-4:-1, 9:10], eseq)
 
     def test_getitem_with_tuple_of_mixed_no_positional_metadata(self):
         seq = Sequence("0123456789abcdef",
                        metadata={'id': 'id6', 'description': 'no_qual6'})
         eseq = Sequence("0123fed9",
                         metadata={'id': 'id6', 'description': 'no_qual6'})
-        self.assertEquals(seq[0, 1, 2, 3, 15, 14, 13, 9], eseq)
-        self.assertEquals(seq[0, 1, 2, 3, :-4:-1, 9], eseq)
-        self.assertEquals(seq[0:4, :-4:-1, 9], eseq)
-        self.assertEquals(seq[0:4, :-4:-1, 9:10], eseq)
+        self.assertEqual(seq[0, 1, 2, 3, 15, 14, 13, 9], eseq)
+        self.assertEqual(seq[0, 1, 2, 3, :-4:-1, 9], eseq)
+        self.assertEqual(seq[0:4, :-4:-1, 9], eseq)
+        self.assertEqual(seq[0:4, :-4:-1, 9:10], eseq)
 
     def test_getitem_with_iterable_of_mixed_has_positional_metadata(self):
         s = "0123456789abcdef"
@@ -1045,10 +1046,10 @@ class TestSequence(TestCase):
                         metadata={'id': 'id7', 'description': 'dsc7'},
                         positional_metadata={'quality': [0, 1, 2, 3, 15, 14,
                                                          13, 9]})
-        self.assertEquals(seq[[0, 1, 2, 3, 15, 14, 13, 9]], eseq)
-        self.assertEquals(seq[generator()], eseq)
-        self.assertEquals(seq[[slice(0, 4), slice(None, -4, -1), 9]], eseq)
-        self.assertEquals(seq[
+        self.assertEqual(seq[[0, 1, 2, 3, 15, 14, 13, 9]], eseq)
+        self.assertEqual(seq[generator()], eseq)
+        self.assertEqual(seq[[slice(0, 4), slice(None, -4, -1), 9]], eseq)
+        self.assertEqual(seq[
             [slice(0, 4), slice(None, -4, -1), slice(9, 10)]], eseq)
 
     def test_getitem_with_iterable_of_mixed_no_positional_metadata(self):
@@ -1063,10 +1064,10 @@ class TestSequence(TestCase):
 
         eseq = Sequence("0123fed9",
                         metadata={'id': 'id7', 'description': 'dsc7'})
-        self.assertEquals(seq[[0, 1, 2, 3, 15, 14, 13, 9]], eseq)
-        self.assertEquals(seq[generator()], eseq)
-        self.assertEquals(seq[[slice(0, 4), slice(None, -4, -1), 9]], eseq)
-        self.assertEquals(seq[
+        self.assertEqual(seq[[0, 1, 2, 3, 15, 14, 13, 9]], eseq)
+        self.assertEqual(seq[generator()], eseq)
+        self.assertEqual(seq[[slice(0, 4), slice(None, -4, -1), 9]], eseq)
+        self.assertEqual(seq[
             [slice(0, 4), slice(None, -4, -1), slice(9, 10)]], eseq)
 
     def test_getitem_with_numpy_index_has_positional_metadata(self):
@@ -1079,7 +1080,7 @@ class TestSequence(TestCase):
                         metadata={'id': 'id9', 'description': 'dsc9'},
                         positional_metadata={'quality': [0, 1, 2, 3, 15, 14,
                                                          13, 9]})
-        self.assertEquals(seq[np.array([0, 1, 2, 3, 15, 14, 13, 9])], eseq)
+        self.assertEqual(seq[np.array([0, 1, 2, 3, 15, 14, 13, 9])], eseq)
 
     def test_getitem_with_numpy_index_no_positional_metadata(self):
         s = "0123456789abcdef"
@@ -1087,7 +1088,7 @@ class TestSequence(TestCase):
 
         eseq = Sequence("0123fed9",
                         metadata={'id': 'id10', 'description': 'dsc10'})
-        self.assertEquals(seq[np.array([0, 1, 2, 3, 15, 14, 13, 9])], eseq)
+        self.assertEqual(seq[np.array([0, 1, 2, 3, 15, 14, 13, 9])], eseq)
 
     def test_getitem_with_empty_indices_empty_seq_no_pos_metadata(self):
         s = ""
@@ -1439,7 +1440,7 @@ class TestSequence(TestCase):
             with self.assertRaises(ValueError):
                 seq.count(c(''))
 
-        self.assertEquals(tested, 4)
+        self.assertEqual(tested, 4)
 
     def test_count_on_subclass(self):
         with self.assertRaises(TypeError) as cm:
@@ -2228,15 +2229,15 @@ class TestSequence(TestCase):
         seq = Sequence(seq_str,
                        positional_metadata={'quality': range(len(seq_str))})
 
-        with self.assertRaisesRegexp(ValueError,
-                                     "No positional metadata associated with "
-                                     "key 'introns'"):
+        with six.assertRaisesRegex(self, ValueError,
+                                   "No positional metadata associated with "
+                                   "key 'introns'"):
             seq._munge_to_index_array('introns')
 
-        with self.assertRaisesRegexp(TypeError,
-                                     "Column 'quality' in positional metadata "
-                                     "does not correspond to a boolean "
-                                     "vector"):
+        with six.assertRaisesRegex(self, TypeError,
+                                   "Column 'quality' in positional metadata "
+                                   "does not correspond to a boolean "
+                                   "vector"):
             seq._munge_to_index_array('quality')
 
     def test_munge_to_bytestring_return_bytes(self):
@@ -2258,10 +2259,10 @@ class TestSequence(TestCase):
         seq = Sequence('')
         all_inputs = (u'\x80', u'abc\x80', u'\x80abc')
         for input_ in all_inputs:
-            with self.assertRaisesRegexp(UnicodeEncodeError,
-                                         "'ascii' codec can't encode character"
-                                         ".*in position.*: ordinal not in"
-                                         " range\(128\)"):
+            with six.assertRaisesRegex(self, UnicodeEncodeError,
+                                       "'ascii' codec can't encode character"
+                                       ".*in position.*: ordinal not in"
+                                       " range\(128\)"):
                 seq._munge_to_bytestring(input_, 'dummy_method')
 
 

--- a/skbio/stats/distance/tests/test_mantel.py
+++ b/skbio/stats/distance/tests/test_mantel.py
@@ -7,6 +7,8 @@
 # ----------------------------------------------------------------------------
 
 from __future__ import absolute_import, division, print_function
+import six
+
 from unittest import TestCase, main
 
 import numpy as np
@@ -541,7 +543,7 @@ class OrderDistanceMatricesTests(MantelTestData):
         # for the first distance matrix.
         lookup = {'0': 'a', '2': 'c'}
 
-        with self.assertRaisesRegexp(KeyError, "first.*(x).*'1'\"$"):
+        with six.assertRaisesRegex(self, KeyError, "first.*(x).*'1'\"$"):
             _order_dms(self.minx_dm, self.miny_dm, lookup=lookup)
 
         # Mapping for 'bar' is missing. Should get an error while remapping IDs
@@ -550,7 +552,7 @@ class OrderDistanceMatricesTests(MantelTestData):
                   'foo': 'a', 'baz': 'c'}
         self.miny_dm.ids = ('foo', 'bar', 'baz')
 
-        with self.assertRaisesRegexp(KeyError, "second.*(y).*'bar'\"$"):
+        with six.assertRaisesRegex(self, KeyError, "second.*(y).*'bar'\"$"):
             _order_dms(self.minx_dm, self.miny_dm, lookup=lookup)
 
     def test_nonmatching_ids_strict_true(self):

--- a/skbio/stats/ordination/tests/test_ordination.py
+++ b/skbio/stats/ordination/tests/test_ordination.py
@@ -7,6 +7,7 @@
 # ----------------------------------------------------------------------------
 
 from __future__ import absolute_import, division, print_function
+import six
 from six import binary_type, text_type
 
 import warnings
@@ -18,7 +19,7 @@ import numpy as np
 import numpy.testing as npt
 import pandas as pd
 from IPython.core.display import Image, SVG
-from nose.tools import assert_is_instance, assert_raises_regexp, assert_true
+from nose.tools import assert_is_instance, assert_true
 from scipy.spatial.distance import pdist
 
 from skbio import DistanceMatrix
@@ -737,7 +738,7 @@ class TestOrdinationResults(unittest.TestCase):
         self.check_basic_figure_sanity(fig, 1, 'a title', True, '2', '0', '1')
 
     def test_plot_with_invalid_axis_labels(self):
-        with assert_raises_regexp(ValueError, 'axis_labels.*4'):
+        with six.assertRaisesRegex(self, ValueError, 'axis_labels.*4'):
             self.min_ord_results.plot(axes=[2, 0, 1],
                                       axis_labels=('a', 'b', 'c', 'd'))
 
@@ -749,27 +750,27 @@ class TestOrdinationResults(unittest.TestCase):
 
     def test_validate_plot_axes_invalid_input(self):
         # not enough dimensions
-        with assert_raises_regexp(ValueError, '2 dimension\(s\)'):
+        with six.assertRaisesRegex(self, ValueError, '2 dimension\(s\)'):
             self.min_ord_results._validate_plot_axes(
                 np.asarray([[0.1, 0.2, 0.3], [0.2, 0.3, 0.4]]), (0, 1, 2))
 
         coord_matrix = self.min_ord_results.site.T
 
         # wrong number of axes
-        with assert_raises_regexp(ValueError, 'exactly three.*found 0'):
+        with six.assertRaisesRegex(self, ValueError, 'exactly three.*found 0'):
             self.min_ord_results._validate_plot_axes(coord_matrix, [])
-        with assert_raises_regexp(ValueError, 'exactly three.*found 4'):
+        with six.assertRaisesRegex(self, ValueError, 'exactly three.*found 4'):
             self.min_ord_results._validate_plot_axes(coord_matrix,
                                                      (0, 1, 2, 3))
 
         # duplicate axes
-        with assert_raises_regexp(ValueError, 'must be unique'):
+        with six.assertRaisesRegex(self, ValueError, 'must be unique'):
             self.min_ord_results._validate_plot_axes(coord_matrix, (0, 1, 0))
 
         # out of range axes
-        with assert_raises_regexp(ValueError, 'axes\[1\].*3'):
+        with six.assertRaisesRegex(self, ValueError, 'axes\[1\].*3'):
             self.min_ord_results._validate_plot_axes(coord_matrix, (0, -1, 2))
-        with assert_raises_regexp(ValueError, 'axes\[2\].*3'):
+        with six.assertRaisesRegex(self, ValueError, 'axes\[2\].*3'):
             self.min_ord_results._validate_plot_axes(coord_matrix, (0, 2, 3))
 
     def test_get_plot_point_colors_invalid_input(self):
@@ -784,17 +785,17 @@ class TestOrdinationResults(unittest.TestCase):
                                                         ['B', 'C'], 'jet')
 
         # column not in df
-        with assert_raises_regexp(ValueError, 'missingcol'):
+        with six.assertRaisesRegex(self, ValueError, 'missingcol'):
             self.min_ord_results._get_plot_point_colors(self.df, 'missingcol',
                                                         ['B', 'C'], 'jet')
 
         # id not in df
-        with assert_raises_regexp(ValueError, 'numeric'):
+        with six.assertRaisesRegex(self, ValueError, 'numeric'):
             self.min_ord_results._get_plot_point_colors(
                 self.df, 'numeric', ['B', 'C', 'missingid', 'A'], 'jet')
 
         # missing data in df
-        with assert_raises_regexp(ValueError, 'nancolumn'):
+        with six.assertRaisesRegex(self, ValueError, 'nancolumn'):
             self.min_ord_results._get_plot_point_colors(self.df, 'nancolumn',
                                                         ['B', 'C', 'A'], 'jet')
 

--- a/skbio/util/_misc.py
+++ b/skbio/util/_misc.py
@@ -12,7 +12,6 @@ import hashlib
 from os import remove, makedirs
 from os.path import exists, isdir
 from functools import partial
-from warnings import warn
 from types import FunctionType
 
 from ._decorator import experimental, deprecated
@@ -359,11 +358,6 @@ def flatten(items):
     ['a', 'b', 'c', 'd', 1, 2, 3, 4, 5, 'x', 'y', 'foo']
 
     """
-    warn("skbio.util.flatten is deprecated. Please refer to the following "
-         "links for solutions from the standard python library: "
-         "http://stackoverflow.com/a/952952/3639023 "
-         "http://stackoverflow.com/a/406199/3639023", DeprecationWarning)
-
     result = []
     for i in items:
         try:

--- a/skbio/util/tests/test_misc.py
+++ b/skbio/util/tests/test_misc.py
@@ -8,6 +8,7 @@
 
 from __future__ import absolute_import, division, print_function
 from future.builtins import range
+import six
 from six import BytesIO
 
 import unittest
@@ -150,10 +151,10 @@ class ChunkStrTests(unittest.TestCase):
         self.assertEqual(chunk_str('abcdefg', 3, ' - '), 'abc - def - g')
 
     def test_invalid_n(self):
-        with self.assertRaisesRegexp(ValueError, 'n=0'):
+        with six.assertRaisesRegex(self, ValueError, 'n=0'):
             chunk_str('abcdef', 0, ' ')
 
-        with self.assertRaisesRegexp(ValueError, 'n=-42'):
+        with six.assertRaisesRegex(self, ValueError, 'n=-42'):
             chunk_str('abcdef', -42, ' ')
 
 
@@ -255,7 +256,7 @@ class CardinalToOrdinalTests(unittest.TestCase):
         self.assertEqual(obs, exp)
 
     def test_invalid_n(self):
-        with self.assertRaisesRegexp(ValueError, '-1'):
+        with six.assertRaisesRegex(self, ValueError, '-1'):
             cardinal_to_ordinal(-1)
 
 


### PR DESCRIPTION
Everything except for I/O-related warnings (those will be fixed in #963). Addresses part of #371.