### PR TITLE
BUG: fixed sniff for compressed files

### DIFF
--- a/skbio/io/registry.py
+++ b/skbio/io/registry.py
@@ -394,8 +394,8 @@ class IORegistry(object):
             matches = []
             backup = fh.tell()
             if is_binary_file and kwargs.get('encoding', 'binary') == 'binary':
-                    matches = self._find_matches(fh, self._binary_formats,
-                                                 **kwargs)
+                matches = self._find_matches(fh, self._binary_formats,
+                                             **kwargs)
 
             if kwargs.get('encoding', None) != 'binary':
                 # We can always turn a binary file into a text file, but the
@@ -423,6 +423,7 @@ class IORegistry(object):
         for format in lookup.values():
             if format.sniffer_function is not None:
                 is_format, skwargs = format.sniffer_function(file, **kwargs)
+                file.seek(0)
                 if is_format:
                     matches.append((format.name, skwargs))
         return matches

--- a/skbio/io/tests/test_registry.py
+++ b/skbio/io/tests/test_registry.py
@@ -764,6 +764,40 @@ class TestSniff(RegistryTest):
         self.assertTrue(self._check_binf)
         self.assertTrue(self._check_textf)
 
+    def test_sniff_gzip(self):
+        expected = u"This is some content\nIt occurs on more than one line\n"
+
+        formata = self.registry.create_format('formata', encoding='binary')
+        formatb = self.registry.create_format('formatb')
+        formatc = self.registry.create_format('formatc')
+
+        @formata.sniffer()
+        def formata_sniffer(fh):
+            self._check_f1 = True
+            self.assertEqual(fh.read(), expected.encode('ascii'))
+            return False, {}
+
+        @formatb.sniffer()
+        def formatb_sniffer(fh):
+            self._check_f2 = True
+            self.assertEqual(fh.read(), expected)
+            return True, {}
+
+        @formatc.sniffer()
+        def formatc_sniffer(fh):
+            self._check_f3 = True
+            self.assertEqual(fh.read(), expected)
+            return False, {}
+
+        self._check_f1 = False
+        self._check_f2 = False
+        self._check_f3 = False
+        self.registry.sniff(get_data_path('example_file.gz'))
+        self.assertTrue(self._check_f1)
+        self.assertTrue(self._check_f2)
+        self.assertTrue(self._check_f3)
+
+
     def test_text_skip_binary(self):
         binf = self.registry.create_format('binf', encoding='binary')
         textf = self.registry.create_format('textf', encoding=None)

--- a/skbio/io/tests/test_registry.py
+++ b/skbio/io/tests/test_registry.py
@@ -797,7 +797,6 @@ class TestSniff(RegistryTest):
         self.assertTrue(self._check_f2)
         self.assertTrue(self._check_f3)
 
-
     def test_text_skip_binary(self):
         binf = self.registry.create_format('binf', encoding='binary')
         textf = self.registry.create_format('textf', encoding=None)


### PR DESCRIPTION
Was missing a `seek` call. Test added to detect this issue.