### PR TITLE
Alignment._score not set to None

### DIFF
--- a/skbio/alignment/_alignment.py
+++ b/skbio/alignment/_alignment.py
@@ -750,6 +750,8 @@ class Alignment(SequenceCollection):
 
         if score is not None:
             self._score = float(score)
+        else:
+            self._score = None
         self._start_end_positions = start_end_positions
 
     @experimental(as_of="0.4.0")

--- a/skbio/alignment/tests/test_alignment.py
+++ b/skbio/alignment/tests/test_alignment.py
@@ -473,6 +473,9 @@ class AlignmentTests(TestCase):
         self.assertEqual(self.a3.score(), 42.0)
         self.assertEqual(self.a4.score(), -42.0)
 
+    def test_score_unset_returns_none(self):
+        self.assertEqual(self.a1, None)
+
     def test_start_end_positions(self):
         self.assertEqual(self.a3.start_end_positions(), [(0, 3), (5, 9)])
         self.assertEqual(self.a4.start_end_positions(), [(1, 4), (6, 10)])

--- a/skbio/alignment/tests/test_alignment.py
+++ b/skbio/alignment/tests/test_alignment.py
@@ -474,7 +474,8 @@ class AlignmentTests(TestCase):
         self.assertEqual(self.a4.score(), -42.0)
 
     def test_score_unset_returns_none(self):
-        self.assertEqual(self.a1, None)
+        self.assertEqual(self.a1.score(), None)
+        self.assertEqual(self.a2.score(), None)
 
     def test_start_end_positions(self):
         self.assertEqual(self.a3.start_end_positions(), [(0, 3), (5, 9)])


### PR DESCRIPTION
fixes this
```python

from skbio.alignment import Alignment
from skbio.sequence import DNA
sequences = [DNA('A--CCGT', id="seq1"),
             DNA('AACCGGT', id="seq2")]
a1 = Alignment(sequences)
a1

Out[1]: <Alignment: n=2; mean +/- std length=7.00 +/- 0.00>

a1.score()
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-2-e8aa06dbbab1> in <module>()
----> 1 a1.score()

/home/AMED/michael.panciera/projects/.ngs_mapper/lib/python2.7/site-packages/skbio/alignment/_alignment.py in score(self)
   1067 
   1068         """
-> 1069         return self._score
   1070 
   1071     def start_end_positions(self):

AttributeError: 'Alignment' object has no attribute '_score'
```

