### PR TITLE
MAINT: misc. updates for better Py3 compatibility

### DIFF
--- a/skbio/draw/tests/test_distributions.py
+++ b/skbio/draw/tests/test_distributions.py
@@ -340,7 +340,13 @@ class DistributionsTests(TestCase):
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
             grouped_distributions(*args)
-            self.assertTrue(issubclass(w[-1].category, RuntimeWarning))
+
+            expected_warning_raised = False
+            for warning in w:
+                if issubclass(warning.category, RuntimeWarning):
+                    expected_warning_raised = True
+                    break
+            self.assertTrue(expected_warning_raised)
 
     def test_grouped_distributions_scatter(self):
         fig = grouped_distributions('scatter', self.ValidTypicalData,
@@ -365,7 +371,13 @@ class DistributionsTests(TestCase):
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
             grouped_distributions(*args)
-            self.assertTrue(issubclass(w[-1].category, RuntimeWarning))
+
+            expected_warning_raised = False
+            for warning in w:
+                if issubclass(warning.category, RuntimeWarning):
+                    expected_warning_raised = True
+                    break
+            self.assertTrue(expected_warning_raised)
 
     def test_grouped_distributions_empty_marker_list(self):
         grouped_distributions('scatter', self.ValidTypicalData,

--- a/skbio/stats/ordination/tests/test_util.py
+++ b/skbio/stats/ordination/tests/test_util.py
@@ -32,7 +32,7 @@ class TestUtils(TestCase):
         npt.assert_almost_equal((3.5, 1.707825127), obs)
 
         obs = mean_and_std(self.x, with_std=False)
-        self.assertEquals((3.5, None), obs)
+        self.assertEqual((3.5, None), obs)
 
         obs = mean_and_std(self.x, ddof=2)
         npt.assert_almost_equal((3.5, 2.091650066), obs)

--- a/skbio/stats/tests/test_gradient.py
+++ b/skbio/stats/tests/test_gradient.py
@@ -409,10 +409,10 @@ class GroupResultsTests(BaseTests):
             obs_out_f.close()
             obs_raw_f.close()
 
-            with open(get_data_path(out_fp), 'U') as f:
+            with open(get_data_path(out_fp)) as f:
                 exp_out = f.read()
 
-            with open(get_data_path(raw_fp), 'U') as f:
+            with open(get_data_path(raw_fp)) as f:
                 exp_raw = f.read()
 
             self.assertEqual(obs_out, exp_out)
@@ -433,10 +433,10 @@ class CategoryResultsTests(BaseTests):
             obs_out_f.close()
             obs_raw_f.close()
 
-            with open(get_data_path(out_fp), 'U') as f:
+            with open(get_data_path(out_fp)) as f:
                 exp_out = f.read()
 
-            with open(get_data_path(raw_fp), 'U') as f:
+            with open(get_data_path(raw_fp)) as f:
                 exp_raw = f.read()
 
             self.assertEqual(obs_out, exp_out)
@@ -457,10 +457,10 @@ class GradientANOVAResultsTests(BaseTests):
             obs_out_f.close()
             obs_raw_f.close()
 
-            with open(get_data_path(out_fp), 'U') as f:
+            with open(get_data_path(out_fp)) as f:
                 exp_out = f.read()
 
-            with open(get_data_path(raw_fp), 'U') as f:
+            with open(get_data_path(raw_fp)) as f:
                 exp_raw = f.read()
 
             self.assertEqual(obs_out, exp_out)

--- a/skbio/tests/test_base.py
+++ b/skbio/tests/test_base.py
@@ -7,6 +7,7 @@
 # ----------------------------------------------------------------------------
 
 from __future__ import absolute_import, division, print_function
+import six
 from six import binary_type, text_type
 
 import unittest
@@ -16,7 +17,7 @@ import numpy as np
 import numpy.testing as npt
 import pandas as pd
 from IPython.core.display import Image, SVG
-from nose.tools import assert_is_instance, assert_raises_regexp, assert_true
+from nose.tools import assert_is_instance, assert_true
 
 from skbio import OrdinationResults
 from skbio._base import SkbioObject
@@ -156,7 +157,7 @@ class TestOrdinationResults(unittest.TestCase):
         self.check_basic_figure_sanity(fig, 1, 'a title', True, '2', '0', '1')
 
     def test_plot_with_invalid_axis_labels(self):
-        with assert_raises_regexp(ValueError, 'axis_labels.*4'):
+        with six.assertRaisesRegex(self, ValueError, 'axis_labels.*4'):
             self.min_ord_results.plot(axes=[2, 0, 1],
                                       axis_labels=('a', 'b', 'c', 'd'))
 
@@ -168,27 +169,27 @@ class TestOrdinationResults(unittest.TestCase):
 
     def test_validate_plot_axes_invalid_input(self):
         # not enough dimensions
-        with assert_raises_regexp(ValueError, '2 dimension\(s\)'):
+        with six.assertRaisesRegex(self, ValueError, '2 dimension\(s\)'):
             self.min_ord_results._validate_plot_axes(
                 np.asarray([[0.1, 0.2, 0.3], [0.2, 0.3, 0.4]]), (0, 1, 2))
 
         coord_matrix = self.min_ord_results.samples.values.T
 
         # wrong number of axes
-        with assert_raises_regexp(ValueError, 'exactly three.*found 0'):
+        with six.assertRaisesRegex(self, ValueError, 'exactly three.*found 0'):
             self.min_ord_results._validate_plot_axes(coord_matrix, [])
-        with assert_raises_regexp(ValueError, 'exactly three.*found 4'):
+        with six.assertRaisesRegex(self, ValueError, 'exactly three.*found 4'):
             self.min_ord_results._validate_plot_axes(coord_matrix,
                                                      (0, 1, 2, 3))
 
         # duplicate axes
-        with assert_raises_regexp(ValueError, 'must be unique'):
+        with six.assertRaisesRegex(self, ValueError, 'must be unique'):
             self.min_ord_results._validate_plot_axes(coord_matrix, (0, 1, 0))
 
         # out of range axes
-        with assert_raises_regexp(ValueError, 'axes\[1\].*3'):
+        with six.assertRaisesRegex(self, ValueError, 'axes\[1\].*3'):
             self.min_ord_results._validate_plot_axes(coord_matrix, (0, -1, 2))
-        with assert_raises_regexp(ValueError, 'axes\[2\].*3'):
+        with six.assertRaisesRegex(self, ValueError, 'axes\[2\].*3'):
             self.min_ord_results._validate_plot_axes(coord_matrix, (0, 2, 3))
 
     def test_get_plot_point_colors_invalid_input(self):
@@ -203,17 +204,17 @@ class TestOrdinationResults(unittest.TestCase):
                                                         ['B', 'C'], 'jet')
 
         # column not in df
-        with assert_raises_regexp(ValueError, 'missingcol'):
+        with six.assertRaisesRegex(self, ValueError, 'missingcol'):
             self.min_ord_results._get_plot_point_colors(self.df, 'missingcol',
                                                         ['B', 'C'], 'jet')
 
         # id not in df
-        with assert_raises_regexp(ValueError, 'numeric'):
+        with six.assertRaisesRegex(self, ValueError, 'numeric'):
             self.min_ord_results._get_plot_point_colors(
                 self.df, 'numeric', ['B', 'C', 'missingid', 'A'], 'jet')
 
         # missing data in df
-        with assert_raises_regexp(ValueError, 'nancolumn'):
+        with six.assertRaisesRegex(self, ValueError, 'nancolumn'):
             self.min_ord_results._get_plot_point_colors(self.df, 'nancolumn',
                                                         ['B', 'C', 'A'], 'jet')
 


### PR DESCRIPTION
Changes:

- `assertEquals` -> `assertEqual`
- `assert_raises_regexp` -> `six.assertRaisesRegex`
- remove 'U' mode from gradient code tests
- make `skbio.draw` `RuntimeWarning` tests more lenient to order of warnings (these were failing for me with a fresh conda install)