### PR TITLE
CI/REL: validate MANIFEST.in using check-manifest package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 ### Miscellaneous
 * Doctests are now written in Python 3.
+* ``make test`` now validates MANIFEST.in using [check-manifest](https://github.com/mgedmin/check-manifest). ([#461](https://github.com/biocore/scikit-bio/issues/461))
 
 ## Version 0.4.0 (2015-07-08)
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
+include .coveragerc
 include CHANGELOG.md
 include CONTRIBUTING.md
 include COPYING.txt
@@ -7,12 +8,16 @@ include RELEASE.md
 include checklist.py
 
 graft assets
+graft ci
 graft doc
 graft ipynbs
 graft licenses
 graft skbio
 
 prune doc/build
+prune doc/source/generated
 
 global-exclude *.pyc
 global-exclude *.pyo
+global-exclude *.so
+global-exclude .*.swp

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,6 @@ endif
 
 test:
 	$(TEST_COMMAND)
-	pep8 skbio setup.py checklist.py
 	flake8 skbio setup.py checklist.py
 	./checklist.py
+	check-manifest

--- a/ci/pip_requirements.txt
+++ b/ci/pip_requirements.txt
@@ -6,3 +6,4 @@ coveralls
 natsort
 CacheControl[FileCache]
 git+git://github.com/numpy/numpydoc.git
+check-manifest

--- a/setup.py
+++ b/setup.py
@@ -120,7 +120,7 @@ setup(name='scikit-bio',
           'six >= 1.9.0'
       ],
       extras_require={'test': ["HTTPretty", "nose", "pep8", "flake8",
-                               "python-dateutil"],
+                               "python-dateutil", "check-manifest"],
                       'doc': ["Sphinx == 1.2.2", "sphinx-bootstrap-theme"]},
       classifiers=classifiers,
       package_data={


### PR DESCRIPTION
Running ``make test`` now invokes [check-manifest](https://github.com/mgedmin/check-manifest) to validate MANIFEST.in.

Fixes #461.