### PR TITLE
DistanceMatrix.from_iterable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,9 @@
 * Added ``skbio.util.assert_ordination_results_equal`` function for comparing ``OrdinationResults`` objects in unit tests.
 * Added ``skbio.util.RepresentationWarning`` for warning about substitutions, assumptions, or particular alterations that were made for the successful completion of a process.
 * ``TreeNode.tip_tip_distances`` now supports nodes without an associated length. In this case, a length of 0.0 is assumed and an ``skbio.util.RepresentationWarning`` is raised. Previous behavior was to raise a ``NoLengthError``. ([#791](https://github.com/biocore/scikit-bio/issues/791))
+* ``DistanceMatrix`` now has a new constructor method called `from_iterable`.
 
-### Backward-incompatible changes (experimental functionality)
+### Backward-incompatible changes [experimental]
 * Replaced ``PCoA``, ``CCA``, ``CA`` and ``RDA`` in ``skbio.stats.ordination`` with equivalent functions ``pcoa``, ``cca``, ``ca`` and ``rda``. These functions now take ``pd.DataFrame`` objects.
 * Change ``OrdinationResults`` to have its attributes based on ``pd.DataFrame`` and ``pd.Series`` objects, instead of pairs of identifiers and values. The changes are as follows:
     - ``species`` and ``species_ids`` have been replaced by a ``pd.DataFrame`` named ``features``.
@@ -18,6 +19,9 @@
     - ``biplot`` is now a ``pd.DataFrame`` object named ``biplot_scores``.
     - ``site_constraints`` is now a ``pd.DataFrame`` object named ``sample_constraints``.
 * ``short_method_name`` and ``long_method_name`` are now required arguments of the ``OrdinationResults`` object.
+
+### Deprecated functionality [experimental]
+* ``SequenceCollection.distances`` has been deprecated in favor of ``DistanceMatrix.from_iterable``. Use `key="id"` to exactly match original behavior.
 
 ### Miscellaneous
 * Doctests are now written in Python 3.

--- a/skbio/alignment/_alignment.py
+++ b/skbio/alignment/_alignment.py
@@ -20,7 +20,7 @@ from skbio._base import SkbioObject
 from skbio.sequence import Sequence
 from skbio.stats.distance import DistanceMatrix
 from ._exception import (SequenceCollectionError, AlignmentError)
-from skbio.util._decorator import experimental
+from skbio.util._decorator import experimental, deprecated
 
 
 class SequenceCollection(SkbioObject):
@@ -289,7 +289,9 @@ class SequenceCollection(SkbioObject):
         """
         return str(''.join(self.write([], format='fasta')))
 
-    @experimental(as_of="0.4.0")
+    @deprecated(as_of="0.4.0-dev", until='0.4.2',
+                reason=('Use `skbio.DistanceMatrix.from_iterable` with'
+                        ' key="id" instead.'))
     def distances(self, distance_fn):
         """Compute distances between all pairs of sequences
 

--- a/skbio/stats/distance/_base.py
+++ b/skbio/stats/distance/_base.py
@@ -674,6 +674,12 @@ class DistanceMatrix(DissimilarityMatrix):
         DistanceMatrix
             The `metric` applied to all pairwise elements in the `iterable`.
 
+        Notes
+        -----
+        Symmetry and hollowness are assumed when calculating the distances via
+        `metric`. Therefore, distances are only computed for the strictly
+        upper/lower triangle.
+
         """
         iterable = list(iterable)
 

--- a/skbio/stats/distance/_base.py
+++ b/skbio/stats/distance/_base.py
@@ -691,6 +691,7 @@ class DistanceMatrix(DissimilarityMatrix):
         for i, a in enumerate(iterable):
             for j, b in enumerate(iterable[:i]):
                 dm[i, j] = dm[j, i] = metric(a, b)
+
         return cls(dm, keys)
 
     @experimental(as_of="0.4.0")

--- a/skbio/stats/distance/tests/test_base.py
+++ b/skbio/stats/distance/tests/test_base.py
@@ -460,6 +460,36 @@ class DistanceMatrixTests(DissimilarityMatrixTestData):
         with self.assertRaises(DissimilarityMatrixError):
             DistanceMatrix([[1, 2, 3]], ['a'])
 
+    def test_from_iterable_no_key(self):
+        iterable = (x for x in range(4))
+
+        exp = DistanceMatrix([[0, 1, 2, 3],
+                              [1, 0, 1, 2],
+                              [2, 1, 0, 1],
+                              [3, 2, 1, 0]])
+        res = DistanceMatrix.from_iterable(iterable, lambda a, b: abs(b - a))
+        self.assertEqual(res, exp)
+
+    def test_from_iterable_with_key(self):
+        iterable = (x for x in range(4))
+
+        exp = DistanceMatrix([[0, 1, 2, 3],
+                              [1, 0, 1, 2],
+                              [2, 1, 0, 1],
+                              [3, 2, 1, 0]], ['0', '1', '4', '9'])
+        res = DistanceMatrix.from_iterable(iterable, lambda a, b: abs(b - a),
+                                           key=lambda x: str(x**2))
+        self.assertEqual(res, exp)
+
+    def test_from_iterable_empty(self):
+        with self.assertRaises(DissimilarityMatrixError):
+            DistanceMatrix.from_iterable([], lambda x: x)
+
+    def test_from_iterable_single(self):
+        exp = DistanceMatrix([[0]])
+        res = DistanceMatrix.from_iterable(["boo"], lambda _: 100)
+        self.assertEqual(res, exp)
+
     def test_condensed_form(self):
         for dm, condensed in zip(self.dms, self.dm_condensed_forms):
             obs = dm.condensed_form()

--- a/skbio/util/_misc.py
+++ b/skbio/util/_misc.py
@@ -17,6 +17,17 @@ import inspect
 from ._decorator import experimental, deprecated
 
 
+def resolve_key(obj, key):
+    """Resolve key given a object and key."""
+    if callable(key):
+        return key(obj)
+    elif hasattr(obj, 'metadata'):
+        return obj.metadata[key]
+    raise TypeError("Could not resolve key %r. Key must be callable or %s must"
+                    " have `metadata` attribute." % (key,
+                                                     obj.__class__.__name__))
+
+
 def make_sentinel(name):
     return type(name, (object, ), {
         '__repr__': lambda s: name,

--- a/skbio/util/tests/test_misc.py
+++ b/skbio/util/tests/test_misc.py
@@ -20,7 +20,8 @@ from uuid import uuid4
 from skbio.util import (cardinal_to_ordinal, safe_md5, remove_files,
                         create_dir, find_duplicates, flatten,
                         is_casava_v180_or_later)
-from skbio.util._misc import _handle_error_codes, MiniRegistry, chunk_str
+from skbio.util._misc import (
+    _handle_error_codes, MiniRegistry, chunk_str, resolve_key)
 
 
 class TestMiniRegistry(unittest.TestCase):
@@ -129,6 +130,33 @@ class TestMiniRegistry(unittest.TestCase):
                          "First line\n\n                Some description of th"
                          "ings, also this:\n\n                Other things are"
                          " happening now.\n                ")
+
+
+class ResolveKeyTests(unittest.TestCase):
+    def test_callable(self):
+        def func(x):
+            return str(x)
+
+        self.assertEqual(resolve_key(1, func), "1")
+        self.assertEqual(resolve_key(4, func), "4")
+
+    def test_index(self):
+        class MetadataHaver(dict):
+            metadata = {}
+
+            @property
+            def metadata(self):
+                return self
+
+        obj = MetadataHaver({'foo': 123})
+        self.assertEqual(resolve_key(obj, 'foo'), 123)
+
+        obj = MetadataHaver({'foo': 123, 'bar': 'baz'})
+        self.assertEqual(resolve_key(obj, 'bar'), 'baz')
+
+    def test_wrong_type(self):
+        with self.assertRaises(TypeError):
+            resolve_key({'foo': 1}, 'foo')
 
 
 class ChunkStrTests(unittest.TestCase):


### PR DESCRIPTION
This serves as a replacement for the `SequenceCollection.distance` method which was the only method on `SequenceCollection` which could not be implemented as a simple list comprehension.

Hopefully we can remove `SequenceCollection` in favor of standard Python types such as `list` and `dict` in the near future.