### PR TITLE
[WIP] Ensure correct DissimilarityMatrix plot dimensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@
 * ``short_method_name`` and ``long_method_name`` are now required arguments of the ``OrdinationResults`` object.
 * ``skbio.diversity.beta.pw_distances`` no longer defines a default metric, and ``metric`` is now the first argument to this function.
 
+### Bug Fixes
+
+* ``DissimilarityMatrix.plot()`` no longer leaves a white border around the
+  heatmap it plots (PR #1070).
+
 ### Deprecated functionality [experimental]
 * ``SequenceCollection.distances`` has been deprecated in favor of ``DistanceMatrix.from_iterable``. Use `key="id"` to exactly match original behavior.
 

--- a/skbio/stats/distance/_base.py
+++ b/skbio/stats/distance/_base.py
@@ -371,6 +371,12 @@ class DissimilarityMatrix(SkbioObject):
 
         ax.set_xticklabels(self.ids, rotation=90, minor=False)
         ax.set_yticklabels(self.ids, minor=False)
+
+        # Ensure there is no white border around the heatmap by manually
+        # setting the limits
+        ax.set_ylim(0, len(self.ids))
+        ax.set_xlim(0, len(self.ids))
+
         ax.set_title(title)
 
         return fig

--- a/skbio/stats/distance/_base.py
+++ b/skbio/stats/distance/_base.py
@@ -365,17 +365,17 @@ class DissimilarityMatrix(SkbioObject):
         ax.set_xticks(ticks, minor=False)
         ax.set_yticks(ticks, minor=False)
 
+        # Ensure there is no white border around the heatmap by manually
+        # setting the limits
+        ax.set_ylim(0, len(self.ids))
+        ax.set_xlim(0, len(self.ids))
+
         # display data as it is stored in the dissimilarity matrix
         # (default is to have y-axis inverted)
         ax.invert_yaxis()
 
         ax.set_xticklabels(self.ids, rotation=90, minor=False)
         ax.set_yticklabels(self.ids, minor=False)
-
-        # Ensure there is no white border around the heatmap by manually
-        # setting the limits
-        ax.set_ylim(0, len(self.ids))
-        ax.set_xlim(0, len(self.ids))
 
         ax.set_title(title)
 


### PR DESCRIPTION
Previously, a white border around the heatmap was plotted as matplotlib
does not reduce the plot area to the matrix size. This manually sets the
axis limits to ensure that no border is shown.