### PR TITLE
ENH: add Sequence.frequencies and Sequence.observed_chars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Added phylogenetic diversity metrics, including weighted UniFrac, unweighted UniFrac, and Faith's Phylogenetic Diversity. These are accessible as ``skbio.diversity.beta.unweighted_unifrac``, ``skbio.diversity.beta.weighted_unifrac``, and ````skbio.diversity.alpha.faith_pd``, respectively.
 * Added ``reverse_transcribe`` class method to ``RNA``.
 * Added `Sequence.observed_chars` property for obtaining the set of observed characters in a sequence. ([#1075](https://github.com/biocore/scikit-bio/issues/1075))
+* Added `Sequence.frequencies` method for computing character frequencies in a sequence. ([#1074](https://github.com/biocore/scikit-bio/issues/1074))
 
 ### Backward-incompatible changes [stable]
 * `Sequence.kmer_frequencies` now returns a `dict`. Previous behavior was to return a `collections.Counter` if `relative=False` was passed, and a `collections.defaultdict` if `relative=True` was passed. In the case of a missing key, the `Counter` would return 0 and the `defaultdict` would return 0.0. Because the return type is now always a `dict`, attempting to access a missing key will raise a `KeyError`. This change *may* break backwards-compatibility depending on how the `Counter`/`defaultdict` is being used. We hope that in most cases this change will not break backwards-compatibility because both `Counter` and `defaultdict` are `dict` subclasses.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * The ``lowercase`` method has been moved up to ``Sequence`` meaning all sequence objects now have a ``lowercase`` method.
 * Added phylogenetic diversity metrics, including weighted UniFrac, unweighted UniFrac, and Faith's Phylogenetic Diversity. These are accessible as ``skbio.diversity.beta.unweighted_unifrac``, ``skbio.diversity.beta.weighted_unifrac``, and ````skbio.diversity.alpha.faith_pd``, respectively.
 * Added ``reverse_transcribe`` class method to ``RNA``.
+* Added `Sequence.observed_chars` property for obtaining the set of observed characters in a sequence. ([#1075](https://github.com/biocore/scikit-bio/issues/1075))
 
 ### Backward-incompatible changes [experimental]
 * Replaced ``PCoA``, ``CCA``, ``CA`` and ``RDA`` in ``skbio.stats.ordination`` with equivalent functions ``pcoa``, ``cca``, ``ca`` and ``rda``. These functions now take ``pd.DataFrame`` objects.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,36 @@
 * Added ``reverse_transcribe`` class method to ``RNA``.
 * Added `Sequence.observed_chars` property for obtaining the set of observed characters in a sequence. ([#1075](https://github.com/biocore/scikit-bio/issues/1075))
 
+### Backward-incompatible changes [stable]
+* `Sequence.kmer_frequencies` now returns a `dict`. Previous behavior was to return a `collections.Counter` if `relative=False` was passed, and a `collections.defaultdict` if `relative=True` was passed. In the case of a missing key, the `Counter` would return 0 and the `defaultdict` would return 0.0. Because the return type is now always a `dict`, attempting to access a missing key will raise a `KeyError`. This change *may* break backwards-compatibility depending on how the `Counter`/`defaultdict` is being used. We hope that in most cases this change will not break backwards-compatibility because both `Counter` and `defaultdict` are `dict` subclasses.
+
+   If the previous behavior is desired, convert the `dict` into a `Counter`/`defaultdict`:
+
+    ```python
+    import collections
+    from skbio import Sequence
+    seq = Sequence('ACCGAGTTTAACCGAATA')
+
+    # Counter
+    freqs_dict = seq.kmer_frequencies(k=8)
+    freqs_counter = collections.Counter(freqs_dict)
+
+    # defaultdict
+    freqs_dict = seq.kmer_frequencies(k=8, relative=True)
+    freqs_default_dict = collections.defaultdict(float, freqs_dict)
+    ```
+
+   **Rationale:** We believe it is safer to return `dict` instead of `Counter`/`defaultdict` as this may prevent error-prone usage of the return value. Previous behavior allowed accessing missing kmers, returning 0 or 0.0 depending on the `relative` parameter. This is convenient in many cases but also potentially misleading. For example, consider the following code:
+
+    ```python
+    from skbio import Sequence
+    seq = Sequence('ACCGAGTTTAACCGAATA')
+    freqs = seq.kmer_frequencies(k=8)
+    freqs['ACCGA']
+    ```
+
+    Previous behavior would return 0 because the kmer `'ACCGA'` is not present in the `Counter`. In one respect this is the correct answer because we asked for kmers of length 8; `'ACCGA'` is a different length so it is not included in the results. However, we believe it is safer to avoid this implicit behavior in case the user assumes there are no `'ACCGA'` kmers in the sequence (which there are!). A `KeyError` in this case is more explicit and forces the user to consider their query. Returning a `dict` will also be consistent with `Sequence.frequencies`.
+
 ### Backward-incompatible changes [experimental]
 * Replaced ``PCoA``, ``CCA``, ``CA`` and ``RDA`` in ``skbio.stats.ordination`` with equivalent functions ``pcoa``, ``cca``, ``ca`` and ``rda``. These functions now take ``pd.DataFrame`` objects.
 * Change ``OrdinationResults`` to have its attributes based on ``pd.DataFrame`` and ``pd.Series`` objects, instead of pairs of identifiers and values. The changes are as follows:

--- a/skbio/alignment/_alignment.py
+++ b/skbio/alignment/_alignment.py
@@ -630,9 +630,9 @@ class SequenceCollection(SkbioObject):
         Returns
         -------
         list
-            List of ``collections.Counter`` objects, one for each sequence
-            in the ``SequenceCollection``, representing the frequency of each
-            k-word in each sequence of the ``SequenceCollection``.
+            List of ``dict`` objects, one for each sequence in the
+            ``SequenceCollection``, representing the frequency of each k-word
+            in each sequence of the ``SequenceCollection``.
 
         See Also
         --------
@@ -645,15 +645,14 @@ class SequenceCollection(SkbioObject):
         ...              DNA('AT', metadata={'id': "seq2"}),
         ...              DNA('TTTT', metadata={'id': "seq3"})]
         >>> s1 = SequenceCollection(sequences)
-        >>> kmer_freqs = list(s1.kmer_frequencies(1))
-        >>> kmer_freqs == [Counter({'A': 1}), Counter({'A': 1, 'T': 1}),
-        ...                Counter({'T': 4})]
+        >>> kmer_freqs = s1.kmer_frequencies(1)
+        >>> kmer_freqs == [{'A': 1}, {'A': 1, 'T': 1}, {'T': 4}]
         True
         >>> for freqs in s1.kmer_frequencies(2):
-        ...     print(freqs)
-        Counter()
-        Counter({'AT': 1})
-        Counter({'TT': 3})
+        ...     freqs
+        {}
+        {'AT': 1}
+        {'TT': 3}
 
         """
         return [s.kmer_frequencies(k, overlap=overlap, relative=relative)
@@ -1143,7 +1142,7 @@ class Alignment(SequenceCollection):
 
         positions_to_keep = []
         for i, f in enumerate(position_frequencies):
-            gap_frequency = sum([f[c] for c in gap_chars])
+            gap_frequency = sum([f[c] if c in f else 0.0 for c in gap_chars])
             if gap_frequency <= maximum_gap_frequency:
                 positions_to_keep.append(i)
         return self.subalignment(positions_to_keep=positions_to_keep)
@@ -1191,7 +1190,7 @@ class Alignment(SequenceCollection):
         gap_chars = self[0].gap_chars
         seqs_to_keep = []
         for seq, f in zip(self, base_frequencies):
-            gap_frequency = sum([f[c] for c in gap_chars])
+            gap_frequency = sum([f[c] if c in f else 0.0 for c in gap_chars])
             if gap_frequency <= maximum_gap_frequency:
                 seqs_to_keep.append(seq.metadata['id'])
         return self.subalignment(seqs_to_keep=seqs_to_keep)

--- a/skbio/sequence/_iupac_sequence.py
+++ b/skbio/sequence/_iupac_sequence.py
@@ -56,7 +56,6 @@ class IUPACSequence(with_metaclass(ABCMeta, Sequence)):
        A Cornish-Bowden
 
     """
-    _number_of_extended_ascii_codes = 256
     __validation_mask = None
     __degenerate_codes = None
     __nondegenerate_codes = None

--- a/skbio/sequence/_sequence.py
+++ b/skbio/sequence/_sequence.py
@@ -1900,11 +1900,9 @@ class Sequence(collections.Sequence, SkbioObject):
 
         Returns
         -------
-        collections.Counter or collections.defaultdict
+        dict
             Frequencies of words of length `k` contained in the biological
-            sequence. This will be a ``collections.Counter`` if `relative` is
-            ``False`` and a ``collections.defaultdict`` if `relative` is
-            ``True``.
+            sequence.
 
         Raises
         ------
@@ -1913,19 +1911,19 @@ class Sequence(collections.Sequence, SkbioObject):
 
         Examples
         --------
-        >>> from collections import defaultdict, Counter
+        >>> from pprint import pprint
         >>> from skbio import Sequence
         >>> s = Sequence('ACACATTTATTA')
         >>> freqs = s.kmer_frequencies(3, overlap=False)
-        >>> freqs == Counter({'TTA': 2, 'ACA': 1, 'CAT': 1})
-        True
+        >>> pprint(freqs) # using pprint to display dict in sorted order
+        {'ACA': 1, 'CAT': 1, 'TTA': 2}
         >>> freqs = s.kmer_frequencies(3, relative=True, overlap=False)
-        >>> freqs == defaultdict(float, {'ACA': 0.25, 'TTA': 0.5, 'CAT': 0.25})
-        True
+        >>> pprint(freqs)
+        {'ACA': 0.25, 'CAT': 0.25, 'TTA': 0.5}
 
         """
         kmers = self.iter_kmers(k, overlap=overlap)
-        freqs = collections.Counter((str(seq) for seq in kmers))
+        freqs = dict(collections.Counter((str(seq) for seq in kmers)))
 
         if relative:
             if overlap:
@@ -1933,7 +1931,7 @@ class Sequence(collections.Sequence, SkbioObject):
             else:
                 num_kmers = len(self) // k
 
-            relative_freqs = collections.defaultdict(float)
+            relative_freqs = {}
             for kmer, count in viewitems(freqs):
                 relative_freqs[kmer] = count / num_kmers
             freqs = relative_freqs

--- a/skbio/sequence/_sequence.py
+++ b/skbio/sequence/_sequence.py
@@ -539,11 +539,11 @@ class Sequence(collections.Sequence, SkbioObject):
         --------
         >>> from skbio import Sequence
         >>> s = Sequence('AACGAC')
-        >>> s.observed_chars == {b'G', b'A', b'C'}
+        >>> s.observed_chars == {'G', 'A', 'C'}
         True
 
         """
-        return set(self.values)
+        return set(str(self))
 
     @property
     def _string(self):
@@ -1782,6 +1782,46 @@ class Sequence(collections.Sequence, SkbioObject):
             return float(self.mismatches(other).mean())
         else:
             return int(self.mismatches(other).sum())
+
+    @experimental(as_of="0.4.0-dev")
+    def frequencies(self, chars=None, relative=False):
+        if isinstance(chars, six.string_types):
+            chars = set([chars])
+
+        if isinstance(chars, set):
+            str_chars = set()
+            for char in chars:
+                if type(char) is bytes or type(char) is np.bytes_:
+                    char = char.decode('ascii')
+                elif isinstance(char, six.string_types):
+                    pass
+                else:
+                    raise TypeError(
+                        "Each element of `chars` must be string-like, not %r" %
+                        type(char).__name__)
+
+                if len(char) != 1:
+                    raise ValueError(
+                        "Each element of `chars` must contain a single "
+                        "character (found %d characters)" % len(char))
+                str_chars.add(char)
+            chars = str_chars
+        elif chars is not None:
+            raise TypeError(
+                "`chars` must be of type `set`, not %r" % type(chars).__name__)
+
+        #freqs = collections.Counter(str(self))
+        freqs = self.kmer_frequencies(k=1, overlap=False, relative=relative)
+
+        if chars is not None:
+            for char in list(freqs.keys()):
+                if char not in chars:
+                    del freqs[char]
+            for char in chars:
+                if char not in freqs:
+                    freqs[char] = 0.0 if relative else 0
+
+        return freqs
 
     @stable(as_of="0.4.0")
     def iter_kmers(self, k, overlap=True):

--- a/skbio/sequence/_sequence.py
+++ b/skbio/sequence/_sequence.py
@@ -1873,28 +1873,27 @@ class Sequence(collections.Sequence, SkbioObject):
         # because we are guaranteed to have indices in the range 0 to 255
         # inclusive.
         obs_chars = obs_bytes[0].astype(np.uint8).tostring().decode('ascii')
-        freqs = dict(zip(obs_chars, freqs[obs_bytes]))
+        obs_counts = freqs[obs_bytes]
+        if relative:
+            obs_counts = obs_counts / len(self)
+        freqs = dict(zip(obs_chars, obs_counts))
 
         if chars is not None:
             # Get a copy of the keys because we're deleting in the loop.
             for obs_char in list(freqs.keys()):
                 if obs_char not in chars:
                     del freqs[obs_char]
+
+            fill_value = 0
+            if relative:
+                if self:
+                    fill_value = 0.0
+                else:
+                    fill_value = np.nan
+
             for char in chars:
                 if char not in freqs:
-                    freqs[char] = 0
-
-        if relative:
-            seq_len = len(self)
-            relative_freqs = {}
-            for obs_char, count in viewitems(freqs):
-                try:
-                    relative_freq = count / seq_len
-                except ZeroDivisionError:
-                    relative_freq = np.nan
-                relative_freqs[obs_char] = relative_freq
-            freqs = relative_freqs
-
+                    freqs[char] = fill_value
         return freqs
 
     def _munge_to_char_set(self, chars):

--- a/skbio/sequence/_sequence.py
+++ b/skbio/sequence/_sequence.py
@@ -69,6 +69,7 @@ class Sequence(collections.Sequence, SkbioObject):
     values
     metadata
     positional_metadata
+    observed_chars
 
     See Also
     --------

--- a/skbio/sequence/_sequence.py
+++ b/skbio/sequence/_sequence.py
@@ -527,6 +527,25 @@ class Sequence(collections.Sequence, SkbioObject):
         self._positional_metadata = None
 
     @property
+    @experimental(as_of="0.4.0-dev")
+    def observed_chars(self):
+        """Set of observed characters in the sequence.
+
+        Notes
+        -----
+        This property is not writeable.
+
+        Examples
+        --------
+        >>> from skbio import Sequence
+        >>> s = Sequence('AACGAC')
+        >>> s.observed_chars == {b'G', b'A', b'C'}
+        True
+
+        """
+        return set(self.values)
+
+    @property
     def _string(self):
         return self._bytes.tostring()
 

--- a/skbio/sequence/tests/test_sequence.py
+++ b/skbio/sequence/tests/test_sequence.py
@@ -766,6 +766,21 @@ class TestSequence(TestCase):
                                        "length of index"):
                 seq.positional_metadata['bar'] = array_like
 
+    def test_observed_chars_property(self):
+        self.assertEqual(Sequence('').observed_chars, set())
+        self.assertEqual(Sequence('x').observed_chars, {b'x'})
+        self.assertEqual(Sequence('xYz').observed_chars, {b'x', b'Y', b'z'})
+        self.assertEqual(Sequence('xYzxxZz').observed_chars,
+                         {b'x', b'Y', b'z', b'Z'})
+        self.assertEqual(Sequence('\t   ').observed_chars, {b' ', b'\t'})
+        self.assertEqual(
+            Sequence('aabbcc', metadata={'foo': 'bar'},
+                     positional_metadata={'foo': range(6)}).observed_chars,
+            {b'a', b'b', b'c'})
+
+        with self.assertRaises(AttributeError):
+            Sequence('ACGT').observed_chars = {b'a', b'b', b'c'}
+
     def test_eq_and_ne(self):
         seq_a = Sequence("A")
         seq_b = Sequence("B")

--- a/skbio/sequence/tests/test_sequence.py
+++ b/skbio/sequence/tests/test_sequence.py
@@ -1998,57 +1998,64 @@ class TestSequence(TestCase):
         ]
         self._compare_kmers_results(seq.iter_kmers(3, overlap=False), expected)
 
+    def test_kmer_frequencies_empty_sequence(self):
+        seq = Sequence('')
+
+        self.assertEqual(seq.kmer_frequencies(1), {})
+        self.assertEqual(seq.kmer_frequencies(1, overlap=False), {})
+        self.assertEqual(seq.kmer_frequencies(1, relative=True), {})
+        self.assertEqual(seq.kmer_frequencies(1, relative=True, overlap=False),
+                         {})
+
     def test_kmer_frequencies(self):
         seq = Sequence('GATTACA', positional_metadata={'quality': range(7)})
+
         # overlap = True
-        expected = Counter('GATTACA')
+        expected = {'G': 1, 'A': 3, 'T': 2, 'C': 1}
         self.assertEqual(seq.kmer_frequencies(1, overlap=True), expected)
-        expected = Counter(['GAT', 'ATT', 'TTA', 'TAC', 'ACA'])
+
+        expected = {'GAT': 1, 'ATT': 1, 'TTA': 1, 'TAC': 1, 'ACA': 1}
         self.assertEqual(seq.kmer_frequencies(3, overlap=True), expected)
-        expected = Counter([])
+
+        expected = {}
         self.assertEqual(seq.kmer_frequencies(8, overlap=True), expected)
 
         # overlap = False
-        expected = Counter(['GAT', 'TAC'])
+        expected = {'GAT': 1, 'TAC': 1}
         self.assertEqual(seq.kmer_frequencies(3, overlap=False), expected)
-        expected = Counter(['GATTACA'])
+
+        expected = {'GATTACA': 1}
         self.assertEqual(seq.kmer_frequencies(7, overlap=False), expected)
-        expected = Counter([])
+
+        expected = {}
         self.assertEqual(seq.kmer_frequencies(8, overlap=False), expected)
 
     def test_kmer_frequencies_relative(self):
         seq = Sequence('GATTACA', positional_metadata={'quality': range(7)})
+
         # overlap = True
-        expected = defaultdict(float)
-        expected['A'] = 3/7.
-        expected['C'] = 1/7.
-        expected['G'] = 1/7.
-        expected['T'] = 2/7.
+        expected = {'A': 3/7, 'C': 1/7, 'G': 1/7, 'T': 2/7}
         self.assertEqual(seq.kmer_frequencies(1, overlap=True, relative=True),
                          expected)
-        expected = defaultdict(float)
-        expected['GAT'] = 1/5.
-        expected['ATT'] = 1/5.
-        expected['TTA'] = 1/5.
-        expected['TAC'] = 1/5.
-        expected['ACA'] = 1/5.
+
+        expected = {'GAT': 1/5, 'ATT': 1/5, 'TTA': 1/5, 'TAC': 1/5, 'ACA': 1/5}
         self.assertEqual(seq.kmer_frequencies(3, overlap=True, relative=True),
                          expected)
-        expected = defaultdict(float)
+
+        expected = {}
         self.assertEqual(seq.kmer_frequencies(8, overlap=True, relative=True),
                          expected)
 
         # overlap = False
-        expected = defaultdict(float)
-        expected['GAT'] = 1/2.
-        expected['TAC'] = 1/2.
+        expected = {'GAT': 1/2, 'TAC': 1/2}
         self.assertEqual(seq.kmer_frequencies(3, overlap=False, relative=True),
                          expected)
-        expected = defaultdict(float)
-        expected['GATTACA'] = 1.0
+
+        expected = {'GATTACA': 1.0}
         self.assertEqual(seq.kmer_frequencies(7, overlap=False, relative=True),
                          expected)
-        expected = defaultdict(float)
+
+        expected = {}
         self.assertEqual(seq.kmer_frequencies(8, overlap=False, relative=True),
                          expected)
 
@@ -2069,8 +2076,7 @@ class TestSequence(TestCase):
         # 1.0. This occurs because 1/10 cannot be represented exactly as a
         # floating point number.
         seq = Sequence('AAAAAAAAAA')
-        self.assertEqual(seq.kmer_frequencies(1, relative=True),
-                         defaultdict(float, {'A': 1.0}))
+        self.assertEqual(seq.kmer_frequencies(1, relative=True), {'A': 1.0})
 
     def test_find_with_regex(self):
         seq = Sequence('GATTACA', positional_metadata={'quality': range(7)})

--- a/skbio/sequence/tests/test_sequence.py
+++ b/skbio/sequence/tests/test_sequence.py
@@ -1745,6 +1745,25 @@ class TestSequence(TestCase):
             self.assertEqual(seq.frequencies(chars=chars, relative=True),
                              {'x': 0.0, 'z': 5/11})
 
+    def test_frequencies_chars_out_of_ascii_range(self):
+        seq = Sequence('abcabc')
+        self.assertEqual(seq.frequencies(chars={'a', u'\u1F30'}),
+                         {'a': 2, u'\u1F30': 0})
+        self.assertEqual(
+            seq.frequencies(chars={'a', u'\u1F30'}, relative=True),
+            {'a': 2/6, u'\u1F30': 0.0})
+
+    def test_frequencies_equivalent_to_kmer_frequencies_k_of_1(self):
+        seq = Sequence('abcabc')
+
+        exp = {'a': 2, 'b': 2, 'c': 2}
+        self.assertEqual(seq.frequencies(chars=None), exp)
+        self.assertEqual(seq.kmer_frequencies(k=1), exp)
+
+        exp = {'a': 2/6, 'b': 2/6, 'c': 2/6}
+        self.assertEqual(seq.frequencies(chars=None, relative=True), exp)
+        self.assertEqual(seq.kmer_frequencies(k=1, relative=True), exp)
+
     def test_frequencies_passing_observed_chars_equivalent_to_default(self):
         seq = Sequence('abcabc')
 

--- a/skbio/sequence/tests/test_sequence.py
+++ b/skbio/sequence/tests/test_sequence.py
@@ -1731,27 +1731,39 @@ class TestSequence(TestCase):
         seq = Sequence('zabczzzabcz')
 
         # single character case (shortcut)
-        for chars in b'z', u'z', np.fromstring('z', dtype='|S1')[0]:
-            self.assertEqual(seq.frequencies(chars=chars), {'z': 5})
-            self.assertEqual(seq.frequencies(chars=chars, relative=True),
-                             {'z': 5/11})
+        chars = b'z'
+        self.assertEqual(seq.frequencies(chars=chars), {b'z': 5})
+        self.assertEqual(seq.frequencies(chars=chars, relative=True),
+                         {b'z': 5/11})
+
+        chars = u'z'
+        self.assertEqual(seq.frequencies(chars=chars), {u'z': 5})
+        self.assertEqual(seq.frequencies(chars=chars, relative=True),
+                         {u'z': 5/11})
+
+        chars = np.fromstring('z', dtype='|S1')[0]
+        self.assertEqual(seq.frequencies(chars=chars), {b'z': 5})
+        self.assertEqual(seq.frequencies(chars=chars, relative=True),
+                         {b'z': 5/11})
 
         # set of characters, some present, some not
-        for chars in ({b'x', b'z'}, {u'x', u'z'},
-                      {np.fromstring('x', dtype='|S1')[0],
-                       np.fromstring('z', dtype='|S1')[0]}):
-            self.assertEqual(seq.frequencies(chars=chars),
-                             {'x': 0, 'z': 5})
-            self.assertEqual(seq.frequencies(chars=chars, relative=True),
-                             {'x': 0.0, 'z': 5/11})
+        chars = {b'x', b'z'}
+        self.assertEqual(seq.frequencies(chars=chars), {b'x': 0, b'z': 5})
+        self.assertEqual(seq.frequencies(chars=chars, relative=True),
+                         {b'x': 0.0, b'z': 5/11})
 
-    def test_frequencies_chars_out_of_ascii_range(self):
-        seq = Sequence('abcabc')
-        self.assertEqual(seq.frequencies(chars={'a', u'\u1F30'}),
-                         {'a': 2, u'\u1F30': 0})
-        self.assertEqual(
-            seq.frequencies(chars={'a', u'\u1F30'}, relative=True),
-            {'a': 2/6, u'\u1F30': 0.0})
+        chars = {u'x', u'z'}
+        self.assertEqual(seq.frequencies(chars=chars), {u'x': 0, u'z': 5})
+        self.assertEqual(seq.frequencies(chars=chars, relative=True),
+                         {u'x': 0.0, u'z': 5/11})
+
+        chars = {
+            np.fromstring('x', dtype='|S1')[0],
+            np.fromstring('z', dtype='|S1')[0]
+        }
+        self.assertEqual(seq.frequencies(chars=chars), {b'x': 0, b'z': 5})
+        self.assertEqual(seq.frequencies(chars=chars, relative=True),
+                         {b'x': 0.0, b'z': 5/11})
 
     def test_frequencies_equivalent_to_kmer_frequencies_k_of_1(self):
         seq = Sequence('abcabc')
@@ -1794,6 +1806,12 @@ class TestSequence(TestCase):
 
         with six.assertRaisesRegex(self, TypeError, 'string.*NoneType'):
             seq.frequencies(chars={'a', None})
+
+        with six.assertRaisesRegex(self, ValueError, 'outside the range'):
+            seq.frequencies(chars=u'\u1F30')
+
+        with six.assertRaisesRegex(self, ValueError, 'outside the range'):
+            seq.frequencies(chars={'c', u'\u1F30'})
 
         with six.assertRaisesRegex(self, TypeError, 'set.*int'):
             seq.frequencies(chars=42)


### PR DESCRIPTION
Added `Sequence.frequencies` method for computing character frequencies in a sequence.

Added `Sequence.observed_chars` property for obtaining the set of observed characters in a sequence. 

`Sequence.kmer_frequencies` now returns a `dict` instead of `Counter` or `defaultdict`. See changelog for detailed explanation of this backward-incompatible stable API change.

Fixes #1074. Fixes #1075.