### PR TITLE
initial TabularMSA implementation

### DIFF
--- a/skbio/__init__.py
+++ b/skbio/__init__.py
@@ -16,7 +16,7 @@ import skbio.io  # noqa
 from skbio.sequence import Sequence, DNA, RNA, Protein, GeneticCode
 from skbio.stats.distance import DistanceMatrix
 from skbio.alignment import (
-    local_pairwise_align_ssw, SequenceCollection, Alignment)
+    local_pairwise_align_ssw, SequenceCollection, Alignment, TabularMSA)
 from skbio.tree import TreeNode, nj
 from skbio.io import read, write
 from skbio._base import OrdinationResults
@@ -24,7 +24,8 @@ from skbio._base import OrdinationResults
 
 __all__ = ['Sequence', 'DNA', 'RNA', 'Protein', 'GeneticCode',
            'DistanceMatrix', 'local_pairwise_align_ssw', 'SequenceCollection',
-           'Alignment', 'TreeNode', 'nj', 'read', 'write', 'OrdinationResults']
+           'Alignment', 'TabularMSA', 'TreeNode', 'nj', 'read', 'write',
+           'OrdinationResults']
 
 __credits__ = "https://github.com/biocore/scikit-bio/graphs/contributors"
 __version__ = "0.4.0-dev"

--- a/skbio/alignment/__init__.py
+++ b/skbio/alignment/__init__.py
@@ -19,6 +19,7 @@ Data Structures
 
    SequenceCollection
    Alignment
+   TabularMSA
 
 Optimized (i.e., production-ready) Alignment Algorithms
 -------------------------------------------------------
@@ -209,6 +210,7 @@ from __future__ import absolute_import, division, print_function
 
 from skbio.util import TestRunner
 
+from ._tabular_msa import TabularMSA
 from ._alignment import Alignment, SequenceCollection
 from ._pairwise import (
     local_pairwise_align_nucleotide, local_pairwise_align_protein,
@@ -220,7 +222,7 @@ from skbio.alignment._ssw_wrapper import (
     StripedSmithWaterman, AlignmentStructure)
 from ._exception import (SequenceCollectionError, AlignmentError)
 
-__all__ = ['Alignment', 'SequenceCollection',
+__all__ = ['TabularMSA', 'Alignment', 'SequenceCollection',
            'StripedSmithWaterman', 'AlignmentStructure',
            'local_pairwise_align_ssw', 'SequenceCollectionError',
            'AlignmentError', 'global_pairwise_align',

--- a/skbio/alignment/_tabular_msa.py
+++ b/skbio/alignment/_tabular_msa.py
@@ -1,0 +1,52 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2013--, scikit-bio development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+# ----------------------------------------------------------------------------
+
+from __future__ import absolute_import, division, print_function
+
+from skbio._base import SkbioObject
+from skbio.sequence._iupac_sequence import IUPACSequence
+from skbio.util import find_duplicates, OperationError, UniqueError
+from skbio.util._misc import resolve_key
+
+
+class TabularMSA(SkbioObject):
+    @property
+    def keys(self):
+        if self._keys is None:
+            raise OperationError("")
+        return self._keys
+
+    def __init__(self, iterable, key=None):
+        iterable = iter(iterable)
+        seq = next(iterable, None)
+
+        self._seqs = []
+        if seq is not None:
+            self._seqs.append(seq)
+            dtype = type(seq)
+            if not issubclass(dtype, IUPACSequence):
+                raise TypeError("")
+            length = len(seq)
+
+            for seq in itertable:
+                if type(seq) is not dtype:
+                    raise TypeError("")
+                if len(seq) != length:
+                    raise ValueError("")
+                self._seqs.append(seq)
+
+        self._keys = None
+        if key is not None:
+            keys = [resolve_key(seq, key) for seq in self._seqs]
+            repeats = find_duplicates(keys)
+            if repeats:
+                raise UniqueError(repeats)
+            self._keys = np.asarray(keys)
+
+    def __str__(self):
+        return super(TabularMSA, self).__str__()

--- a/skbio/alignment/_tabular_msa.py
+++ b/skbio/alignment/_tabular_msa.py
@@ -135,7 +135,8 @@ class TabularMSA(SkbioObject):
 
         Notes
         -----
-        This property can be set and deleted.
+        This property can be set and deleted. Keys are stored as an immutable
+        ``numpy.ndarray``.
 
         Examples
         --------
@@ -157,6 +158,16 @@ class TabularMSA(SkbioObject):
         >>> msa.keys = ['seq1', 'seq2']
         >>> msa.keys # doctest: +NORMALIZE_WHITESPACE
         array(['seq1', 'seq2'],
+              dtype='<U4')
+
+        To make updates to a subset of the keys, first make a copy of the keys,
+        update them, then set them again:
+
+        >>> new_keys = msa.keys.copy()
+        >>> new_keys[0] = 'new1'
+        >>> msa.keys = new_keys
+        >>> msa.keys # doctest: +NORMALIZE_WHITESPACE
+        array(['new1', 'seq2'],
               dtype='<U4')
 
         Delete keys:
@@ -553,6 +564,9 @@ class TabularMSA(SkbioObject):
             if duplicates:
                 raise UniqueError(
                     "Keys must be unique. Duplicate keys: %r" % duplicates)
+            # Create an immutable ndarray to ensure key invariants are
+            # preserved.
             keys_ = np.asarray(keys_)
+            keys_.flags.writeable = False
 
         self._keys = keys_

--- a/skbio/alignment/_tabular_msa.py
+++ b/skbio/alignment/_tabular_msa.py
@@ -8,45 +8,124 @@
 
 from __future__ import absolute_import, division, print_function
 
+import collections
+
+import numpy as np
+
 from skbio._base import SkbioObject
 from skbio.sequence._iupac_sequence import IUPACSequence
 from skbio.util import find_duplicates, OperationError, UniqueError
+from skbio.util._decorator import experimental
 from skbio.util._misc import resolve_key
+
+
+_Shape = collections.namedtuple('Shape', ['sequence', 'position'])
 
 
 class TabularMSA(SkbioObject):
     @property
+    @experimental(as_of='0.4.0-dev')
+    def dtype(self):
+        return self._dtype
+
+    @property
+    @experimental(as_of='0.4.0-dev')
+    def shape(self):
+        return self._shape
+
+    @property
+    @experimental(as_of='0.4.0-dev')
     def keys(self):
         if self._keys is None:
-            raise OperationError("")
+            raise OperationError(
+                "Keys do not exist. Use `reindex` to set them.")
         return self._keys
 
+    @experimental(as_of='0.4.0-dev')
     def __init__(self, iterable, key=None):
         iterable = iter(iterable)
         seq = next(iterable, None)
 
-        self._seqs = []
+        dtype = None
+        length = 0
+        seqs = []
         if seq is not None:
-            self._seqs.append(seq)
+            seqs.append(seq)
             dtype = type(seq)
             if not issubclass(dtype, IUPACSequence):
-                raise TypeError("")
+                raise TypeError(
+                    "`iterable` must contain scikit-bio sequence objects that "
+                    "have an alphabet, not type %r" % dtype.__name__)
             length = len(seq)
 
-            for seq in itertable:
+            for seq in iterable:
                 if type(seq) is not dtype:
-                    raise TypeError("")
+                    raise TypeError(
+                        "`iterable` cannot contain mixed types. Type %r does "
+                        "not match type %r" %
+                        (type(seq).__name__, dtype.__name__))
                 if len(seq) != length:
-                    raise ValueError("")
-                self._seqs.append(seq)
+                    raise ValueError(
+                        "`iterable` must contain sequences of the same "
+                        "length: %r != %r" % (len(seq), length))
+                seqs.append(seq)
 
-        self._keys = None
+        self._seqs = seqs
+        self._dtype = dtype
+        self._shape = _Shape(sequence=len(seqs), position=length)
+        self.reindex(key=key)
+
+    @experimental(as_of='0.4.0-dev')
+    def __bool__(self):
+        # It is impossible to have 0 sequences and >0 positions.
+        return self.shape.position > 0
+
+    # Python 2 compatibility.
+    __nonzero__ = __bool__
+
+    @experimental(as_of='0.4.0-dev')
+    def __len__(self):
+        return self.shape.sequence
+
+    @experimental(as_of='0.4.0-dev')
+    def __iter__(self):
+        return iter(self._seqs)
+
+    @experimental(as_of='0.4.0-dev')
+    def __reversed__(self):
+        return reversed(self._seqs)
+
+    @experimental(as_of='0.4.0-dev')
+    def __str__(self):
+        # TODO implement me!
+        return super(TabularMSA, self).__str__()
+
+    @experimental(as_of='0.4.0-dev')
+    def __eq__(self, other):
+        if not isinstance(other, TabularMSA):
+            return False
+
+        # Use np.array_equal instead of (a == b).all():
+        #   http://stackoverflow.com/a/10580782/3776794
+        return ((self._seqs == other._seqs) and
+                np.array_equal(self._keys, other._keys))
+
+    @experimental(as_of='0.4.0-dev')
+    def __ne__(self, other):
+        return not (self == other)
+
+    @experimental(as_of='0.4.0-dev')
+    def has_keys(self):
+        return self._keys is not None
+
+    @experimental(as_of='0.4.0-dev')
+    def reindex(self, key=None):
+        keys = None
         if key is not None:
             keys = [resolve_key(seq, key) for seq in self._seqs]
-            repeats = find_duplicates(keys)
-            if repeats:
-                raise UniqueError(repeats)
-            self._keys = np.asarray(keys)
-
-    def __str__(self):
-        return super(TabularMSA, self).__str__()
+            duplicates = find_duplicates(keys)
+            if duplicates:
+                raise UniqueError(
+                    "Keys must be unique. Duplicate keys: %r" % duplicates)
+            keys = np.asarray(keys)
+        self._keys = keys

--- a/skbio/alignment/_tabular_msa.py
+++ b/skbio/alignment/_tabular_msa.py
@@ -23,28 +23,124 @@ _Shape = collections.namedtuple('Shape', ['sequence', 'position'])
 
 
 class TabularMSA(SkbioObject):
+    """Store a multiple sequence alignment in tabular (row/column) form.
+
+    Parameters
+    ----------
+    sequences : iterable of alphabet-aware scikit-bio sequence objects
+        Aligned sequences in the MSA. Sequences must be the same type, length,
+        and have an alphabet. For example, `sequences` could be an iterable of
+        ``DNA``, ``RNA``, or ``Protein`` objects.
+    key : callable or metadata key, optional
+        If provided, defines a unique, hashable key for each sequence in
+        `sequences`. Can either be a callable accepting a single argument (each
+        sequence) or a key into each sequence's ``metadata`` attribute. If not
+        provided, keys will not be set and certain operations requiring keys
+        will raise an ``OperationError``.
+
+    See Also
+    --------
+    skbio.sequence.DNA
+    skbio.sequence.RNA
+    skbio.sequence.Protein
+
+    """
+
     @property
     @experimental(as_of='0.4.0-dev')
     def dtype(self):
+        """Data type of the stored sequences.
+
+        Notes
+        -----
+        This property is not writeable.
+
+        Examples
+        --------
+        >>> from skbio import DNA, TabularMSA
+        >>> msa = TabularMSA([DNA('ACG'), DNA('AC-')])
+        >>> msa.dtype
+        <class 'skbio.sequence._dna.DNA'>
+        >>> msa.dtype is DNA
+        True
+
+        """
         return self._dtype
 
     @property
     @experimental(as_of='0.4.0-dev')
     def shape(self):
+        """Number of sequences (rows) and positions (columns).
+
+        Notes
+        -----
+        This property is not writeable.
+
+        Examples
+        --------
+        >>> from skbio import DNA, TabularMSA
+
+        Create a ``TabularMSA`` with 2 sequences and 3 positions:
+
+        >>> msa = TabularMSA([DNA('ACG'), DNA('AC-')])
+        >>> msa.shape
+        Shape(sequence=2, position=3)
+        >>> msa.shape == (2, 3)
+        True
+
+        Dimensions can be accessed by index or by name:
+
+        >>> msa.shape[0]
+        2
+        >>> msa.shape.sequence
+        2
+        >>> msa.shape[1]
+        3
+        >>> msa.shape.position
+        3
+
+        """
         return self._shape
 
     @property
     @experimental(as_of='0.4.0-dev')
     def keys(self):
+        """Keys in the order of sequences in the MSA.
+
+        Raises
+        ------
+        OperationError
+            If keys do not exist.
+
+        See Also
+        --------
+        has_keys
+        reindex
+
+        Notes
+        -----
+        This property is not writeable.
+
+        Examples
+        --------
+        >>> from skbio import DNA, TabularMSA
+        >>> seqs = [DNA('ACG', metadata={'id': 'a'}),
+        ...         DNA('AC-', metadata={'id': 'b'})]
+        >>> msa = TabularMSA(seqs, key='id')
+        >>> msa.keys # doctest: +NORMALIZE_WHITESPACE
+        array(['a', 'b'],
+              dtype='<U1')
+
+        """
         if self._keys is None:
             raise OperationError(
                 "Keys do not exist. Use `reindex` to set them.")
         return self._keys
 
     @experimental(as_of='0.4.0-dev')
-    def __init__(self, iterable, key=None):
-        iterable = iter(iterable)
-        seq = next(iterable, None)
+    def __init__(self, sequences, key=None):
+        sequences = iter(sequences)
+        seq = next(sequences, None)
 
         dtype = None
         length = 0
@@ -54,19 +150,19 @@ class TabularMSA(SkbioObject):
             dtype = type(seq)
             if not issubclass(dtype, IUPACSequence):
                 raise TypeError(
-                    "`iterable` must contain scikit-bio sequence objects that "
-                    "have an alphabet, not type %r" % dtype.__name__)
+                    "`sequences` must contain scikit-bio sequence objects "
+                    "that have an alphabet, not type %r" % dtype.__name__)
             length = len(seq)
 
-            for seq in iterable:
+            for seq in sequences:
                 if type(seq) is not dtype:
                     raise TypeError(
-                        "`iterable` cannot contain mixed types. Type %r does "
+                        "`sequences` cannot contain mixed types. Type %r does "
                         "not match type %r" %
                         (type(seq).__name__, dtype.__name__))
                 if len(seq) != length:
                     raise ValueError(
-                        "`iterable` must contain sequences of the same "
+                        "`sequences` must contain sequences of the same "
                         "length: %r != %r" % (len(seq), length))
                 seqs.append(seq)
 
@@ -77,6 +173,37 @@ class TabularMSA(SkbioObject):
 
     @experimental(as_of='0.4.0-dev')
     def __bool__(self):
+        """Boolean indicating whether the MSA is empty or not.
+
+        Returns
+        -------
+        bool
+            ``False`` if there are no sequences, OR if there are no positions
+            (i.e., all sequences are empty). ``True`` otherwise.
+
+        Examples
+        --------
+        >>> from skbio import DNA, TabularMSA
+
+        MSA with sequences and positions:
+
+        >>> msa = TabularMSA([DNA('ACG'), DNA('AC-')])
+        >>> bool(msa)
+        True
+
+        No sequences:
+
+        >>> msa = TabularMSA([])
+        >>> bool(msa)
+        False
+
+        No positions:
+
+        >>> msa = TabularMSA([DNA(''), DNA('')])
+        >>> bool(msa)
+        False
+
+        """
         # It is impossible to have 0 sequences and >0 positions.
         return self.shape.position > 0
 
@@ -85,14 +212,70 @@ class TabularMSA(SkbioObject):
 
     @experimental(as_of='0.4.0-dev')
     def __len__(self):
+        """Number of sequences in the MSA.
+
+        Returns
+        -------
+        int
+            Number of sequences in the MSA (i.e., size of the 1st dimension).
+
+        Notes
+        -----
+        This is equivalent to ``msa.shape[0]``.
+
+        Examples
+        --------
+        >>> from skbio import DNA, TabularMSA
+        >>> msa = TabularMSA([DNA('ACG'), DNA('AC-')])
+        >>> len(msa)
+        2
+        >>> msa = TabularMSA([])
+        >>> len(msa)
+        0
+
+        """
         return self.shape.sequence
 
     @experimental(as_of='0.4.0-dev')
     def __iter__(self):
+        """Iterate over sequences in the MSA.
+
+        Yields
+        ------
+        alphabet-aware scikit-bio sequence object
+            Each sequence in the order they are stored in the MSA.
+
+        Examples
+        --------
+        >>> from skbio import DNA, TabularMSA
+        >>> msa = TabularMSA([DNA('ACG'), DNA('AC-')])
+        >>> for seq in msa:
+        ...     str(seq)
+        'ACG'
+        'AC-'
+
+        """
         return iter(self._seqs)
 
     @experimental(as_of='0.4.0-dev')
     def __reversed__(self):
+        """Iterate in reverse order over sequences in the MSA.
+
+        Yields
+        ------
+        alphabet-aware scikit-bio sequence object
+            Each sequence in reverse order from how they are stored in the MSA.
+
+        Examples
+        --------
+        >>> from skbio import DNA, TabularMSA
+        >>> msa = TabularMSA([DNA('ACG'), DNA('AC-')])
+        >>> for seq in reversed(msa):
+        ...     str(seq)
+        'AC-'
+        'ACG'
+
+        """
         return reversed(self._seqs)
 
     @experimental(as_of='0.4.0-dev')
@@ -102,6 +285,53 @@ class TabularMSA(SkbioObject):
 
     @experimental(as_of='0.4.0-dev')
     def __eq__(self, other):
+        """Determine if this MSA is equal to another.
+
+        ``TabularMSA`` objects are equal if their sequences and keys are equal.
+
+        Parameters
+        ----------
+        other : TabularMSA
+            MSA to test for equality against.
+
+        Returns
+        -------
+        bool
+            Indicates whether this MSA is equal to `other`.
+
+        Examples
+        --------
+        >>> from skbio import DNA, RNA, TabularMSA
+        >>> msa1 = TabularMSA([DNA('ACG'), DNA('AC-')])
+        >>> msa1 == msa1
+        True
+
+        MSAs with different sequence characters are not equal:
+
+        >>> msa2 = TabularMSA([DNA('ACG'), DNA('--G')])
+        >>> msa1 == msa2
+        False
+
+        MSAs with different types of sequences (different ``dtype``) are not
+        equal:
+
+        >>> msa3 = TabularMSA([RNA('ACG'), RNA('AC-')])
+        >>> msa1 == msa3
+        False
+
+        MSAs with different sequence metadata are not equal:
+
+        >>> msa4 = TabularMSA([DNA('ACG', metadata={'id': 'a'}), DNA('AC-')])
+        >>> msa1 == msa4
+        False
+
+        MSAs with different keys are not equal:
+
+        >>> msa5 = TabularMSA([DNA('ACG'), DNA('AC-')], key=str)
+        >>> msa1 == msa5
+        False
+
+        """
         if not isinstance(other, TabularMSA):
             return False
 
@@ -112,14 +342,133 @@ class TabularMSA(SkbioObject):
 
     @experimental(as_of='0.4.0-dev')
     def __ne__(self, other):
+        """Determine if this MSA is not equal to another.
+
+        ``TabularMSA`` objects are not equal if their sequences or keys are not
+        equal.
+
+        Parameters
+        ----------
+        other : TabularMSA
+            MSA to test for inequality against.
+
+        Returns
+        -------
+        bool
+            Indicates whether this MSA is not equal to `other`.
+
+        Examples
+        --------
+        >>> from skbio import DNA, RNA, TabularMSA
+        >>> msa1 = TabularMSA([DNA('ACG'), DNA('AC-')])
+        >>> msa1 != msa1
+        False
+
+        MSAs with different sequence characters are not equal:
+
+        >>> msa2 = TabularMSA([DNA('ACG'), DNA('--G')])
+        >>> msa1 != msa2
+        True
+
+        MSAs with different types of sequences (different ``dtype``) are not
+        equal:
+
+        >>> msa3 = TabularMSA([RNA('ACG'), RNA('AC-')])
+        >>> msa1 != msa3
+        True
+
+        MSAs with different sequence metadata are not equal:
+
+        >>> msa4 = TabularMSA([DNA('ACG', metadata={'id': 'a'}), DNA('AC-')])
+        >>> msa1 != msa4
+        True
+
+        MSAs with different keys are not equal:
+
+        >>> msa5 = TabularMSA([DNA('ACG'), DNA('AC-')], key=str)
+        >>> msa1 != msa5
+        True
+
+        """
         return not (self == other)
 
     @experimental(as_of='0.4.0-dev')
     def has_keys(self):
+        """Determine if keys exist on the MSA.
+
+        Returns
+        -------
+        bool
+            Indicates whether the MSA has keys.
+
+        See Also
+        --------
+        keys
+        reindex
+
+        Examples
+        --------
+        >>> from skbio import DNA, TabularMSA
+        >>> msa = TabularMSA([DNA('ACG'), DNA('AC-')])
+        >>> msa.has_keys()
+        False
+        >>> msa = TabularMSA([DNA('ACG'), DNA('AC-')], key=str)
+        >>> msa.has_keys()
+        True
+
+        """
         return self._keys is not None
 
     @experimental(as_of='0.4.0-dev')
     def reindex(self, key=None):
+        """Reassign keys to sequences in the MSA.
+
+        Parameters
+        ----------
+        key : callable or metadata key, optional
+            If provided, defines a unique, hashable key for each sequence in
+            the MSA. Can either be a callable accepting a single argument (each
+            sequence) or a key into each sequence's ``metadata`` attribute. If
+            not provided, keys will not be set and certain operations requiring
+            keys will raise an ``OperationError``.
+
+        Raises
+        ------
+        UniqueError
+            If keys are not unique.
+
+        See Also
+        --------
+        keys
+        has_keys
+
+        Examples
+        --------
+        Create a ``TabularMSA`` object without keys:
+
+        >>> from skbio import DNA, TabularMSA
+        >>> seqs = [DNA('ACG', metadata={'id': 'a'}),
+        ...         DNA('AC-', metadata={'id': 'b'})]
+        >>> msa = TabularMSA(seqs)
+        >>> msa.has_keys()
+        False
+
+        Set keys on the MSA, using each sequence's ID:
+
+        >>> msa.reindex(key='id')
+        >>> msa.has_keys()
+        True
+        >>> msa.keys # doctest: +NORMALIZE_WHITESPACE
+        array(['a', 'b'],
+              dtype='<U1')
+
+        Remove keys from the MSA:
+
+        >>> msa.reindex()
+        >>> msa.has_keys()
+        False
+
+        """
         keys = None
         if key is not None:
             keys = [resolve_key(seq, key) for seq in self._seqs]

--- a/skbio/alignment/_tabular_msa.py
+++ b/skbio/alignment/_tabular_msa.py
@@ -96,7 +96,7 @@ class TabularMSA(SkbioObject):
         --------
         >>> from skbio import DNA, TabularMSA
 
-        Create a ``TabularMSA`` with 2 sequences and 3 positions:
+        Create a ``TabularMSA`` object with 2 sequences and 3 positions:
 
         >>> msa = TabularMSA([DNA('ACG'), DNA('AC-')])
         >>> msa.shape
@@ -135,23 +135,51 @@ class TabularMSA(SkbioObject):
 
         Notes
         -----
-        This property is not writeable.
+        This property can be set and deleted.
 
         Examples
         --------
+        Create a ``TabularMSA`` object keyed by sequence identifier:
+
         >>> from skbio import DNA, TabularMSA
         >>> seqs = [DNA('ACG', metadata={'id': 'a'}),
         ...         DNA('AC-', metadata={'id': 'b'})]
         >>> msa = TabularMSA(seqs, key='id')
+
+        Retrieve keys:
+
         >>> msa.keys # doctest: +NORMALIZE_WHITESPACE
         array(['a', 'b'],
               dtype='<U1')
 
+        Set keys:
+
+        >>> msa.keys = ['seq1', 'seq2']
+        >>> msa.keys # doctest: +NORMALIZE_WHITESPACE
+        array(['seq1', 'seq2'],
+              dtype='<U4')
+
+        Delete keys:
+
+        >>> msa.has_keys()
+        True
+        >>> del msa.keys
+        >>> msa.has_keys()
+        False
+
         """
-        if self._keys is None:
+        if not self.has_keys():
             raise OperationError(
                 "Keys do not exist. Use `reindex` to set them.")
         return self._keys
+
+    @keys.setter
+    def keys(self, keys):
+        self.reindex(keys=keys)
+
+    @keys.deleter
+    def keys(self):
+        self.reindex()
 
     @experimental(as_of='0.4.0-dev')
     def __init__(self, sequences, key=None, keys=None):

--- a/skbio/alignment/tests/test_tabular_msa.py
+++ b/skbio/alignment/tests/test_tabular_msa.py
@@ -8,22 +8,14 @@
 
 from __future__ import absolute_import, division, print_function
 
+import unittest
 
-class TestingUtilError(Exception):
-    """Raised when an exception is needed to test exception handling."""
+from skbio.alignment import TabularMSA
+
+
+class TestTabularMSA(unittest.TestCase):
     pass
 
 
-class OverrideError(AssertionError):
-    """Raised when a property does not exist in the parent class."""
-    pass
-
-
-class OperationError(ValueError):
-    """Raised when an operation cannot be performed."""
-    pass
-
-
-class UniqueError(ValueError):
-    """Raised when unique values were expected."""
-    pass
+if __name__ == "__main__":
+    unittest.main()

--- a/skbio/alignment/tests/test_tabular_msa.py
+++ b/skbio/alignment/tests/test_tabular_msa.py
@@ -9,12 +9,314 @@
 from __future__ import absolute_import, division, print_function
 
 import unittest
+import itertools
 
-from skbio.alignment import TabularMSA
+import six
+import numpy as np
+import numpy.testing as npt
+
+from skbio import Sequence, DNA, RNA, Protein, TabularMSA
+from skbio.util import OperationError, UniqueError
+from skbio.util._testing import ReallyEqualMixin
 
 
-class TestTabularMSA(unittest.TestCase):
+class TabularMSASubclass(TabularMSA):
+    """Used for testing purposes."""
     pass
+
+
+class TestTabularMSA(unittest.TestCase, ReallyEqualMixin):
+    def test_constructor_invalid_dtype(self):
+        with six.assertRaisesRegex(self, TypeError,
+                                   'sequence.*alphabet.*Sequence'):
+            TabularMSA([Sequence('')])
+
+        with six.assertRaisesRegex(self, TypeError, 'sequence.*alphabet.*int'):
+            TabularMSA([42, DNA('')])
+
+    def test_constructor_not_monomorphic(self):
+        with six.assertRaisesRegex(self, TypeError, 'mixed types.*RNA.*DNA'):
+            TabularMSA([DNA(''), RNA('')])
+
+        with six.assertRaisesRegex(self, TypeError,
+                                   'mixed types.*float.*Protein'):
+            TabularMSA([Protein(''), Protein(''), 42.0, Protein('')])
+
+    def test_constructor_unequal_length(self):
+        with six.assertRaisesRegex(self, ValueError, 'same length.*1 != 0'):
+            TabularMSA([Protein(''), Protein('P')])
+
+        with six.assertRaisesRegex(self, ValueError, 'same length.*1 != 3'):
+            TabularMSA([Protein('PAW'), Protein('ABC'), Protein('A')])
+
+    def test_constructor_non_unique_keys(self):
+        with six.assertRaisesRegex(self, UniqueError,
+                                   'Duplicate keys:.*42'):
+            TabularMSA([DNA('ACGT'), DNA('TGCA')], key=lambda x: 42)
+
+        with six.assertRaisesRegex(self, UniqueError,
+                                   "Duplicate keys:.*'a'"):
+            TabularMSA([DNA('', metadata={'id': 'a'}),
+                        DNA('', metadata={'id': 'b'}),
+                        DNA('', metadata={'id': 'a'})],
+                       key='id')
+
+    def test_constructor_non_iterable(self):
+        with self.assertRaises(TypeError):
+            TabularMSA(42)
+
+    def test_constructor_non_hashable_keys(self):
+        with self.assertRaises(TypeError):
+            TabularMSA([DNA('ACGT'), DNA('TGCA')], key=lambda x: [42])
+
+    def test_constructor_empty_no_keys(self):
+        # sequence empty
+        msa = TabularMSA([])
+        self.assertIsNone(msa.dtype)
+        self.assertEqual(msa.shape, (0, 0))
+        with self.assertRaises(OperationError):
+            msa.keys
+        with self.assertRaises(StopIteration):
+            next(iter(msa))
+
+        # position empty
+        seqs = [DNA(''), DNA('')]
+        msa = TabularMSA(seqs)
+        self.assertIs(msa.dtype, DNA)
+        self.assertEqual(msa.shape, (2, 0))
+        with self.assertRaises(OperationError):
+            msa.keys
+        self.assertEqual(list(msa), seqs)
+
+    def test_constructor_empty_with_keys(self):
+        # sequence empty
+        msa = TabularMSA([], key=lambda x: x)
+        npt.assert_array_equal(msa.keys, np.array([]))
+
+        # position empty
+        msa = TabularMSA([DNA('', metadata={'id': 42}),
+                          DNA('', metadata={'id': 43})], key='id')
+        npt.assert_array_equal(msa.keys, np.array([42, 43]))
+
+    def test_constructor_non_empty_no_keys(self):
+        # 1x3
+        seqs = [DNA('ACG')]
+        msa = TabularMSA(seqs)
+        self.assertIs(msa.dtype, DNA)
+        self.assertEqual(msa.shape, (1, 3))
+        with self.assertRaises(OperationError):
+            msa.keys
+        self.assertEqual(list(msa), seqs)
+
+        # 3x1
+        seqs = [DNA('A'), DNA('C'), DNA('G')]
+        msa = TabularMSA(seqs)
+        self.assertIs(msa.dtype, DNA)
+        self.assertEqual(msa.shape, (3, 1))
+        with self.assertRaises(OperationError):
+            msa.keys
+        self.assertEqual(list(msa), seqs)
+
+    def test_constructor_non_empty_with_keys(self):
+        seqs = [DNA('ACG'), DNA('CGA'), DNA('GTT')]
+        msa = TabularMSA(seqs, key=str)
+        self.assertIs(msa.dtype, DNA)
+        self.assertEqual(msa.shape, (3, 3))
+        npt.assert_array_equal(msa.keys, np.array(['ACG', 'CGA', 'GTT']))
+        self.assertEqual(list(msa), seqs)
+
+    def test_constructor_works_with_iterator(self):
+        seqs = [DNA('ACG'), DNA('CGA'), DNA('GTT')]
+        msa = TabularMSA(iter(seqs), key=str)
+        self.assertIs(msa.dtype, DNA)
+        self.assertEqual(msa.shape, (3, 3))
+        npt.assert_array_equal(msa.keys, np.array(['ACG', 'CGA', 'GTT']))
+        self.assertEqual(list(msa), seqs)
+
+    def test_dtype(self):
+        self.assertIsNone(TabularMSA([]).dtype)
+        self.assertIs(TabularMSA([Protein('')]).dtype, Protein)
+
+    def test_shape(self):
+        shape = TabularMSA([DNA('ACG'), DNA('GCA')]).shape
+        self.assertEqual(shape, (2, 3))
+        self.assertEqual(shape.sequence, shape[0])
+        self.assertEqual(shape.position, shape[1])
+
+    def test_keys(self):
+        with six.assertRaisesRegex(self, OperationError,
+                                   'Keys do not exist.*reindex'):
+            TabularMSA([]).keys
+
+        keys = TabularMSA([DNA('AC'), DNA('AG'), DNA('AT')], key=str).keys
+        self.assertIsInstance(keys, np.ndarray)
+        npt.assert_array_equal(keys, np.array(['AC', 'AG', 'AT']))
+
+    def test_bool(self):
+        self.assertFalse(TabularMSA([]))
+        self.assertFalse(TabularMSA([RNA('')]))
+        self.assertFalse(
+            TabularMSA([RNA('', metadata={'id': 1}),
+                        RNA('', metadata={'id': 2})], key='id'))
+
+        self.assertTrue(TabularMSA([RNA('U')]))
+        self.assertTrue(TabularMSA([RNA('--'), RNA('..')]))
+        self.assertTrue(TabularMSA([RNA('AUC'), RNA('GCA')]))
+
+    def test_len(self):
+        self.assertEqual(len(TabularMSA([])), 0)
+        self.assertEqual(len(TabularMSA([DNA('')])), 1)
+        self.assertEqual(len(TabularMSA([DNA('AT'), DNA('AG'), DNA('AT')])), 3)
+
+    def test_iter(self):
+        with self.assertRaises(StopIteration):
+            next(iter(TabularMSA([])))
+
+        seqs = [DNA(''), DNA('')]
+        self.assertEqual(list(iter(TabularMSA(seqs))), seqs)
+
+        seqs = [DNA('AAA'), DNA('GCT')]
+        self.assertEqual(list(iter(TabularMSA(seqs))), seqs)
+
+    def test_reversed(self):
+        with self.assertRaises(StopIteration):
+            next(reversed(TabularMSA([])))
+
+        seqs = [DNA(''), DNA('', metadata={'id': 42})]
+        self.assertEqual(list(reversed(TabularMSA(seqs))), seqs[::-1])
+
+        seqs = [DNA('AAA'), DNA('GCT')]
+        self.assertEqual(list(reversed(TabularMSA(seqs))), seqs[::-1])
+
+    def test_eq_and_ne(self):
+        # Each element contains the components necessary to construct a
+        # TabularMSA object: seqs and kwargs. None of these objects (once
+        # constructed) should compare equal to one another.
+        components = [
+            # empties
+            ([], {}),
+            ([], {'key': str}),
+            ([RNA('')], {}),
+            ([RNA('')], {'key': str}),
+
+            # 1x1
+            ([RNA('U')], {'key': str}),
+
+            # 2x3
+            ([RNA('AUG'), RNA('GUA')], {'key': str}),
+
+            ([RNA('AG'), RNA('GG')], {}),
+            # has keys
+            ([RNA('AG'), RNA('GG')], {'key': str}),
+            # different dtype
+            ([DNA('AG'), DNA('GG')], {'key': str}),
+            # different keys
+            ([RNA('AG'), RNA('GG')], {'key': lambda x: str(x) + '42'}),
+            # different sequence metadata
+            ([RNA('AG', metadata={'id': 42}), RNA('GG')], {'key': str}),
+            # different sequence data, same keys
+            ([RNA('AG'), RNA('GA')],
+             {'key': lambda x: 'AG' if 'AG' in x else 'GG'}),
+        ]
+
+        for seqs, kwargs in components:
+            obj = TabularMSA(seqs, **kwargs)
+            self.assertReallyEqual(obj, obj)
+            self.assertReallyEqual(obj, TabularMSA(seqs, **kwargs))
+            self.assertReallyEqual(obj, TabularMSASubclass(seqs, **kwargs))
+
+        for (seqs1, kwargs1), (seqs2, kwargs2) in \
+                itertools.combinations(components, 2):
+            obj1 = TabularMSA(seqs1, **kwargs1)
+            obj2 = TabularMSA(seqs2, **kwargs2)
+            self.assertReallyNotEqual(obj1, obj2)
+            self.assertReallyNotEqual(obj1,
+                                      TabularMSASubclass(seqs2, **kwargs2))
+
+        # completely different types
+        msa = TabularMSA([])
+        self.assertReallyNotEqual(msa, 42)
+        self.assertReallyNotEqual(msa, [])
+        self.assertReallyNotEqual(msa, {})
+        self.assertReallyNotEqual(msa, '')
+
+    def test_has_keys(self):
+        self.assertFalse(TabularMSA([]).has_keys())
+        self.assertTrue(TabularMSA([], key=str).has_keys())
+
+        self.assertFalse(TabularMSA([DNA('')]).has_keys())
+        self.assertTrue(TabularMSA([DNA('')], key=str).has_keys())
+
+        self.assertFalse(TabularMSA([DNA('ACG'), DNA('GCA')]).has_keys())
+        self.assertTrue(
+            TabularMSA([DNA('ACG', metadata={'id': 1}),
+                        DNA('GCA', metadata={'id': 2})], key='id').has_keys())
+
+        msa = TabularMSA([])
+        self.assertFalse(msa.has_keys())
+        msa.reindex(key=str)
+        self.assertTrue(msa.has_keys())
+        msa.reindex()
+        self.assertFalse(msa.has_keys())
+
+    def test_reindex_empty(self):
+        # sequence empty
+        msa = TabularMSA([])
+        msa.reindex()
+        self.assertEqual(msa, TabularMSA([]))
+        self.assertFalse(msa.has_keys())
+
+        msa.reindex(key=str)
+        self.assertEqual(msa, TabularMSA([], key=str))
+        npt.assert_array_equal(msa.keys, np.array([]))
+
+        # position empty
+        msa = TabularMSA([DNA('')])
+        msa.reindex()
+        self.assertEqual(msa, TabularMSA([DNA('')]))
+        self.assertFalse(msa.has_keys())
+
+        msa.reindex(key=str)
+        self.assertEqual(msa, TabularMSA([DNA('')], key=str))
+        npt.assert_array_equal(msa.keys, np.array(['']))
+
+    def test_reindex_non_empty(self):
+        msa = TabularMSA([DNA('ACG', metadata={'id': 1}),
+                          DNA('AAA', metadata={'id': 2})], key=str)
+        npt.assert_array_equal(msa.keys, np.array(['ACG', 'AAA']))
+
+        msa.reindex(key='id')
+        self.assertEqual(
+            msa,
+            TabularMSA([DNA('ACG', metadata={'id': 1}),
+                        DNA('AAA', metadata={'id': 2})], key='id'))
+        npt.assert_array_equal(msa.keys, np.array([1, 2]))
+
+        msa.reindex()
+        self.assertFalse(msa.has_keys())
+
+    def test_reindex_non_unique_keys(self):
+        msa = TabularMSA([DNA('ACGT'), DNA('TGCA')], key=str)
+        keys = np.array(['ACGT', 'TGCA'])
+        npt.assert_array_equal(msa.keys, keys)
+
+        with six.assertRaisesRegex(self, UniqueError,
+                                   'Duplicate keys:.*42'):
+            msa.reindex(key=lambda x: 42)
+
+        # original state is maintained
+        npt.assert_array_equal(msa.keys, keys)
+
+    def test_reindex_non_hashable_keys(self):
+        msa = TabularMSA([DNA('ACGT'), DNA('TGCA')], key=str)
+        keys = np.array(['ACGT', 'TGCA'])
+        npt.assert_array_equal(msa.keys, keys)
+
+        with self.assertRaises(TypeError):
+            msa.reindex(key=lambda x: [42])
+
+        # original state is maintained
+        npt.assert_array_equal(msa.keys, keys)
 
 
 if __name__ == "__main__":

--- a/skbio/io/tests/test_registry.py
+++ b/skbio/io/tests/test_registry.py
@@ -23,7 +23,8 @@ from skbio.io import (FormatIdentificationWarning, UnrecognizedFormatError,
 from skbio.io.registry import (IORegistry, FileSentinel, Format,
                                DuplicateRegistrationError,
                                InvalidRegistrationError)
-from skbio.util import TestingUtilError, get_data_path
+from skbio.util import get_data_path
+from skbio.util._exception import TestingUtilError
 from skbio import DNA, read, write
 
 

--- a/skbio/util/__init__.py
+++ b/skbio/util/__init__.py
@@ -43,7 +43,8 @@ Exceptions
 .. autosummary::
    :toctree: generated/
 
-   TestingUtilError
+   OperationError
+   UniqueError
 
 Warnings
 --------
@@ -67,17 +68,17 @@ Warnings
 from __future__ import absolute_import, division, print_function
 
 from ._warning import EfficiencyWarning, RepresentationWarning
-from ._exception import TestingUtilError
+from ._exception import OperationError, UniqueError
 from ._misc import (cardinal_to_ordinal, create_dir, find_duplicates, flatten,
                     is_casava_v180_or_later, remove_files, safe_md5)
 from ._testing import (get_data_path, TestRunner,
                        assert_ordination_results_equal,
                        assert_data_frame_almost_equal)
 
-__all__ = ['EfficiencyWarning', 'RepresentationWarning', 'TestingUtilError',
-           'cardinal_to_ordinal', 'create_dir', 'find_duplicates', 'flatten',
-           'is_casava_v180_or_later', 'remove_files', 'safe_md5',
-           'get_data_path', 'TestRunner', 'assert_ordination_results_equal',
-           'assert_data_frame_almost_equal']
+__all__ = ['EfficiencyWarning', 'RepresentationWarning', 'OperationError',
+           'UniqueError', 'cardinal_to_ordinal', 'create_dir',
+           'find_duplicates', 'flatten', 'is_casava_v180_or_later',
+           'remove_files', 'safe_md5', 'get_data_path', 'TestRunner',
+           'assert_ordination_results_equal', 'assert_data_frame_almost_equal']
 
 test = TestRunner(__file__).test

--- a/skbio/util/_testing.py
+++ b/skbio/util/_testing.py
@@ -23,6 +23,49 @@ from pandas.util.testing import assert_index_equal
 from ._decorator import experimental
 
 
+class ReallyEqualMixin(object):
+    """Use this for testing __eq__/__ne__.
+
+    Taken and modified from the following public domain code:
+      https://ludios.org/testing-your-eq-ne-cmp/
+
+    """
+
+    def assertReallyEqual(self, a, b):
+        # assertEqual first, because it will have a good message if the
+        # assertion fails.
+        self.assertEqual(a, b)
+        self.assertEqual(b, a)
+        self.assertTrue(a == b)
+        self.assertTrue(b == a)
+        self.assertFalse(a != b)
+        self.assertFalse(b != a)
+
+        # We do not support cmp/__cmp__ because they do not exist in Python 3.
+        # However, we still test this to catch potential bugs where the
+        # object's parent class defines a __cmp__.
+        if not PY3:
+            self.assertEqual(0, cmp(a, b))  # noqa
+            self.assertEqual(0, cmp(b, a))  # noqa
+
+    def assertReallyNotEqual(self, a, b):
+        # assertNotEqual first, because it will have a good message if the
+        # assertion fails.
+        self.assertNotEqual(a, b)
+        self.assertNotEqual(b, a)
+        self.assertFalse(a == b)
+        self.assertFalse(b == a)
+        self.assertTrue(a != b)
+        self.assertTrue(b != a)
+
+        # We do not support cmp/__cmp__ because they do not exist in Python 3.
+        # However, we still test this to catch potential bugs where the
+        # object's parent class defines a __cmp__.
+        if not PY3:
+            self.assertNotEqual(0, cmp(a, b))  # noqa
+            self.assertNotEqual(0, cmp(b, a))  # noqa
+
+
 @nottest
 class TestRunner(object):
     """Simple wrapper class around nosetests functionality.


### PR DESCRIPTION
Adds an initial implementation of `TabularMSA` based on the [RFC](https://github.com/biocore/scikit-bio-rfcs/blob/master/active/001-tabular-msa.md). This should be enough of a structure to get other developers involved in implementing the remaining methods in parallel.

Fixes #1081, fixes #1083, fixes #1084, fixes #1085, fixes #1094, fixes #1096, fixes #1099, fixes #1101.

@ebolyen and I pair-programmed parts of this.

To-do:

- [x] add `keys` support to constructor and `reindex`
- [x] make `keys` property settable and deletable. These would be the same operations as `msa.reindex(keys=my_keys)` and `msa.reindex()`, respectively.
- [x] make `keys` property immutable
- [ ] squash commits