### PR TITLE
ENH: add TabularMSA.sort, from_dict, and to_dict

### DIFF
--- a/skbio/alignment/_tabular_msa.py
+++ b/skbio/alignment/_tabular_msa.py
@@ -690,14 +690,14 @@ class TabularMSA(SkbioObject):
 
         """
         if key is None:
-            sort_keys = self.keys
+            sort_keys = self.keys.tolist()
         else:
             sort_keys = [resolve_key(seq, key) for seq in self._seqs]
 
         if len(self) > 0:
             if self.has_keys():
                 _, sorted_seqs, sorted_keys = self._sort_by_first_element(
-                    [sort_keys, self._seqs, self.keys], reverse)
+                    [sort_keys, self._seqs, self.keys.tolist()], reverse)
                 self.keys = sorted_keys
             else:
                 _, sorted_seqs = self._sort_by_first_element(

--- a/skbio/alignment/_tabular_msa.py
+++ b/skbio/alignment/_tabular_msa.py
@@ -622,8 +622,7 @@ class TabularMSA(SkbioObject):
     def sort(self, key=None, reverse=False):
         """Sort sequences in-place.
 
-        Performs a stable sort of the sequences in-place using Python's
-        ``sorted`` function.
+        Performs a stable sort of the sequences in-place.
 
         Parameters
         ----------
@@ -645,13 +644,12 @@ class TabularMSA(SkbioObject):
         keys
         has_keys
         reindex
-        sorted
 
         Notes
         -----
-        This method is modeled after, and in fact uses, Python's built-in
-        sorting functionality (e.g., ``list.sort()``, ``sorted()``). See [1]_
-        for an excellent tutorial on sorting in Python.
+        This method's API is similar to Python's built-in sorting functionality
+        (e.g., ``list.sort()``, ``sorted()``). See [1]_ for an excellent
+        tutorial on sorting in Python.
 
         References
         ----------

--- a/skbio/alignment/_tabular_msa.py
+++ b/skbio/alignment/_tabular_msa.py
@@ -9,7 +9,10 @@
 from __future__ import absolute_import, division, print_function
 
 import collections
+import operator
 
+from future.builtins import zip
+from future.utils import viewkeys, viewvalues
 import numpy as np
 
 from skbio._base import SkbioObject
@@ -123,6 +126,11 @@ class TabularMSA(SkbioObject):
     def keys(self):
         """Keys in the order of sequences in the MSA.
 
+        Returns
+        -------
+        np.ndarray (object)
+            Immutable 1D array of keys with ``object`` dtype.
+
         Raises
         ------
         OperationError
@@ -135,8 +143,7 @@ class TabularMSA(SkbioObject):
 
         Notes
         -----
-        This property can be set and deleted. Keys are stored as an immutable
-        ``numpy.ndarray``.
+        This property can be set and deleted.
 
         Examples
         --------
@@ -149,26 +156,23 @@ class TabularMSA(SkbioObject):
 
         Retrieve keys:
 
-        >>> msa.keys # doctest: +NORMALIZE_WHITESPACE
-        array(['a', 'b'],
-              dtype='<U1')
+        >>> msa.keys
+        array(['a', 'b'], dtype=object)
 
         Set keys:
 
         >>> msa.keys = ['seq1', 'seq2']
-        >>> msa.keys # doctest: +NORMALIZE_WHITESPACE
-        array(['seq1', 'seq2'],
-              dtype='<U4')
+        >>> msa.keys
+        array(['seq1', 'seq2'], dtype=object)
 
         To make updates to a subset of the keys, first make a copy of the keys,
         update them, then set them again:
 
         >>> new_keys = msa.keys.copy()
-        >>> new_keys[0] = 'new1'
+        >>> new_keys[0] = 'new-key'
         >>> msa.keys = new_keys
-        >>> msa.keys # doctest: +NORMALIZE_WHITESPACE
-        array(['new1', 'seq2'],
-              dtype='<U4')
+        >>> msa.keys
+        array(['new-key', 'seq2'], dtype=object)
 
         Delete keys:
 
@@ -191,6 +195,48 @@ class TabularMSA(SkbioObject):
     @keys.deleter
     def keys(self):
         self.reindex()
+
+    @classmethod
+    @experimental(as_of="0.4.0-dev")
+    def from_dict(cls, dictionary):
+        """Create a ``TabularMSA`` from a ``dict``.
+
+        Parameters
+        ----------
+        dictionary : dict
+            Dictionary mapping keys to alphabet-aware scikit-bio sequence
+            objects. The ``TabularMSA`` object will have its keys set to the
+            keys in the dictionary.
+
+        Returns
+        -------
+        TabularMSA
+            ``TabularMSA`` object constructed from the keys and sequences in
+            `dictionary`.
+
+        See Also
+        --------
+        to_dict
+        sort
+
+        Notes
+        -----
+        The order of sequences and keys in the resulting ``TabularMSA`` object
+        is arbitrary. Use ``TabularMSA.sort`` to set a different order.
+
+        Examples
+        --------
+        >>> from skbio import DNA, TabularMSA
+        >>> seqs = {'a': DNA('ACGT'), 'b': DNA('A--T')}
+        >>> msa = TabularMSA.from_dict(seqs)
+
+        """
+        # Python 2 and 3 guarantee same order of iteration as long as no
+        # modifications are made to the dictionary between calls:
+        #     https://docs.python.org/2/library/stdtypes.html#dict.items
+        #     https://docs.python.org/3/library/stdtypes.html#
+        #         dictionary-view-objects
+        return cls(viewvalues(dictionary), keys=viewkeys(dictionary))
 
     @experimental(as_of='0.4.0-dev')
     def __init__(self, sequences, key=None, keys=None):
@@ -525,9 +571,8 @@ class TabularMSA(SkbioObject):
         >>> msa.reindex(key='id')
         >>> msa.has_keys()
         True
-        >>> msa.keys # doctest: +NORMALIZE_WHITESPACE
-        array(['a', 'b'],
-              dtype='<U1')
+        >>> msa.keys
+        array(['a', 'b'], dtype=object)
 
         Remove keys from the MSA:
 
@@ -538,9 +583,8 @@ class TabularMSA(SkbioObject):
         Alternatively, an iterable of keys may be passed via `keys`:
 
         >>> msa.reindex(keys=['a', 'b'])
-        >>> msa.keys # doctest: +NORMALIZE_WHITESPACE
-        array(['a', 'b'],
-              dtype='<U1')
+        >>> msa.keys
+        array(['a', 'b'], dtype=object)
 
         """
         if key is not None and keys is not None:
@@ -564,9 +608,140 @@ class TabularMSA(SkbioObject):
             if duplicates:
                 raise UniqueError(
                     "Keys must be unique. Duplicate keys: %r" % duplicates)
+
             # Create an immutable ndarray to ensure key invariants are
-            # preserved.
-            keys_ = np.asarray(keys_)
+            # preserved. Use object dtype to preserve original key types. This
+            # is important, for example, because np.array(['a', 42]) will
+            # upcast to ['a', '42'].
+            keys_ = np.array(keys_, dtype=object, copy=True)
             keys_.flags.writeable = False
 
         self._keys = keys_
+
+    @experimental(as_of='0.4.0-dev')
+    def sort(self, key=None, reverse=False):
+        """Sort sequences in-place.
+
+        Performs a stable sort of the sequences in-place using Python's
+        ``sorted`` function.
+
+        Parameters
+        ----------
+        key : callable or metadata key, optional
+            If provided, defines a key to sort each sequence on. Can either be
+            a callable accepting a single argument (each sequence) or a key
+            into each sequence's ``metadata`` attribute. If not provided,
+            sequences will be sorted using existing keys on the ``TabularMSA``.
+        reverse: bool, optional
+            If ``True``, sort in reverse order.
+
+        Raises
+        ------
+        OperationError
+            If `key` is not provided and keys do not exist on the MSA.
+
+        See Also
+        --------
+        keys
+        has_keys
+        reindex
+        sorted
+
+        Notes
+        -----
+        This method is modeled after, and in fact uses, Python's built-in
+        sorting functionality (e.g., ``list.sort()``, ``sorted()``). See [1]_
+        for an excellent tutorial on sorting in Python.
+
+        References
+        ----------
+        .. [1] https://docs.python.org/3/howto/sorting.html
+
+        Examples
+        --------
+        Create a ``TabularMSA`` object without keys:
+
+        >>> from skbio import DNA, TabularMSA
+        >>> seqs = [DNA('ACG', metadata={'id': 'c'}),
+        ...         DNA('AC-', metadata={'id': 'b'}),
+        ...         DNA('AC-', metadata={'id': 'a'})]
+        >>> msa = TabularMSA(seqs)
+
+        Sort the sequences in alphabetical order by sequence identifier:
+
+        >>> msa.sort(key='id')
+        >>> msa == TabularMSA([DNA('AC-', metadata={'id': 'a'}),
+        ...                    DNA('AC-', metadata={'id': 'b'}),
+        ...                    DNA('ACG', metadata={'id': 'c'})])
+        True
+
+        Note that since the sort is in-place, the ``TabularMSA`` object is
+        modified (a new object is **not** returned).
+
+        Create a ``TabularMSA`` object with keys:
+
+        >>> seqs = [DNA('ACG'), DNA('AC-'), DNA('AC-')]
+        >>> msa = TabularMSA(seqs, keys=['c', 'b', 'a'])
+
+        Sort the sequences using the MSA's existing keys:
+
+        >>> msa.sort()
+        >>> msa == TabularMSA([DNA('AC-'), DNA('AC-'), DNA('ACG')],
+        ...                   keys=['a', 'b', 'c'])
+        True
+
+        """
+        if key is None:
+            sort_keys = self.keys
+        else:
+            sort_keys = [resolve_key(seq, key) for seq in self._seqs]
+
+        if len(self) > 0:
+            if self.has_keys():
+                _, sorted_seqs, sorted_keys = self._sort_by_first_element(
+                    [sort_keys, self._seqs, self.keys], reverse)
+                self.keys = sorted_keys
+            else:
+                _, sorted_seqs = self._sort_by_first_element(
+                    [sort_keys, self._seqs], reverse)
+            self._seqs = list(sorted_seqs)
+
+    def _sort_by_first_element(self, components, reverse):
+        """Helper for TabularMSA.sort."""
+        # Taken and modified from http://stackoverflow.com/a/13668413/3776794
+        return zip(*sorted(
+            zip(*components), key=operator.itemgetter(0), reverse=reverse))
+
+    @experimental(as_of='0.4.0-dev')
+    def to_dict(self):
+        """Create a ``dict`` from this ``TabularMSA``.
+
+        Returns
+        -------
+        dict
+            Dictionary constructed from the keys and sequences in this
+            ``TabularMSA``.
+
+        Raises
+        ------
+        OperationError
+            If keys do not exist.
+
+        See Also
+        --------
+        from_dict
+        keys
+        has_keys
+        reindex
+
+        Examples
+        --------
+        >>> from skbio import DNA, TabularMSA
+        >>> seqs = [DNA('ACGT'), DNA('A--T')]
+        >>> msa = TabularMSA(seqs, keys=['a', 'b'])
+        >>> dictionary = msa.to_dict()
+        >>> dictionary == {'a': DNA('ACGT'), 'b': DNA('A--T')}
+        True
+
+        """
+        return dict(zip(self.keys, self._seqs))

--- a/skbio/alignment/tests/test_tabular_msa.py
+++ b/skbio/alignment/tests/test_tabular_msa.py
@@ -12,6 +12,7 @@ import unittest
 import itertools
 
 import six
+import future.utils
 import numpy as np
 import numpy.testing as npt
 
@@ -26,6 +27,28 @@ class TabularMSASubclass(TabularMSA):
 
 
 class TestTabularMSA(unittest.TestCase, ReallyEqualMixin):
+    def test_from_dict_empty(self):
+        self.assertEqual(TabularMSA.from_dict({}), TabularMSA([], keys=[]))
+
+    def test_from_dict_single_sequence(self):
+        self.assertEqual(TabularMSA.from_dict({'foo': DNA('ACGT')}),
+                         TabularMSA([DNA('ACGT')], keys=['foo']))
+
+    def test_from_dict_multiple_sequences(self):
+        msa = TabularMSA.from_dict(
+            {1: DNA('ACG'), 2: DNA('GGG'), 3: DNA('TAG')})
+        # Sort because order is arbitrary.
+        msa.sort()
+        self.assertEqual(
+            msa,
+            TabularMSA([DNA('ACG'), DNA('GGG'), DNA('TAG')], keys=[1, 2, 3]))
+
+    def test_from_dict_invalid_input(self):
+        # Basic test to make sure error-checking in the TabularMSA constructor
+        # is being invoked.
+        with six.assertRaisesRegex(self, ValueError, 'same length'):
+            TabularMSA.from_dict({'a': DNA('ACG'), 'b': DNA('ACGT')})
+
     def test_constructor_invalid_dtype(self):
         with six.assertRaisesRegex(self, TypeError,
                                    'sequence.*alphabet.*Sequence'):
@@ -186,6 +209,7 @@ class TestTabularMSA(unittest.TestCase, ReallyEqualMixin):
 
         keys = TabularMSA([DNA('AC'), DNA('AG'), DNA('AT')], key=str).keys
         self.assertIsInstance(keys, np.ndarray)
+        self.assertEqual(keys.dtype, object)
         npt.assert_array_equal(keys, np.array(['AC', 'AG', 'AT']))
 
         # immutable
@@ -194,20 +218,28 @@ class TestTabularMSA(unittest.TestCase, ReallyEqualMixin):
         # original state is maintained
         npt.assert_array_equal(keys, np.array(['AC', 'AG', 'AT']))
 
+    def test_keys_mixed_type(self):
+        msa = TabularMSA([DNA('AC'), DNA('CA'), DNA('AA')],
+                         keys=['abc', 'd', 42])
+        npt.assert_array_equal(msa.keys,
+                               np.array(['abc', 'd', 42], dtype=object))
+
     def test_keys_update_subset_of_keys(self):
         # keys can be copied, modified, then re-set
         msa = TabularMSA([DNA('AC'), DNA('AG'), DNA('AT')], key=str)
         npt.assert_array_equal(msa.keys, np.array(['AC', 'AG', 'AT']))
 
         new_keys = msa.keys.copy()
-        new_keys[1] = 'AA'
+        new_keys[1] = 42
         msa.keys = new_keys
-        npt.assert_array_equal(msa.keys, np.array(['AC', 'AA', 'AT']))
+        npt.assert_array_equal(msa.keys,
+                               np.array(['AC', 42, 'AT'], dtype=object))
 
         self.assertFalse(msa.keys.flags.writeable)
         self.assertTrue(new_keys.flags.writeable)
         new_keys[1] = 'GG'
-        npt.assert_array_equal(msa.keys, np.array(['AC', 'AA', 'AT']))
+        npt.assert_array_equal(msa.keys,
+                               np.array(['AC', 42, 'AT'], dtype=object))
 
     def test_keys_setter_empty(self):
         msa = TabularMSA([])
@@ -492,6 +524,350 @@ class TestTabularMSA(unittest.TestCase, ReallyEqualMixin):
             msa.reindex(keys=[[42], [42]])
 
         npt.assert_array_equal(msa.keys, keys)
+
+    def test_sort_no_msa_keys_and_key_not_specified(self):
+        msa = TabularMSA([])
+        with self.assertRaises(OperationError):
+            msa.sort()
+        # original state is maintained
+        self.assertEqual(msa, TabularMSA([]))
+
+        msa = TabularMSA([DNA('TC'), DNA('AA')])
+        with self.assertRaises(OperationError):
+            msa.sort()
+        self.assertEqual(msa, TabularMSA([DNA('TC'), DNA('AA')]))
+
+    def test_sort_on_unorderable_msa_keys(self):
+        # TODO is there a better way to handle this?
+        if future.utils.PY3:
+            msa = TabularMSA([DNA('AAA'), DNA('ACG')], keys=[42, None])
+            with self.assertRaises(TypeError):
+                msa.sort()
+            self.assertEqual(
+                msa,
+                TabularMSA([DNA('AAA'), DNA('ACG')], keys=[42, None]))
+
+    def test_sort_on_unorderable_key(self):
+        # TODO is there a better way to handle this?
+        if future.utils.PY3:
+            msa = TabularMSA([
+                DNA('AAA', metadata={'id': 42}),
+                DNA('ACG', metadata={'id': None})], keys=[42, 43])
+            with self.assertRaises(TypeError):
+                msa.sort(key='id')
+            self.assertEqual(
+                msa,
+                TabularMSA([
+                    DNA('AAA', metadata={'id': 42}),
+                    DNA('ACG', metadata={'id': None})], keys=[42, 43]))
+
+    def test_sort_on_invalid_key(self):
+        msa = TabularMSA([DNA('AAA'), DNA('ACG')], keys=[42, 43])
+        with self.assertRaises(KeyError):
+            msa.sort(key='id')
+        self.assertEqual(
+            msa,
+            TabularMSA([DNA('AAA'), DNA('ACG')], keys=[42, 43]))
+
+    def test_sort_empty_on_msa_keys(self):
+        msa = TabularMSA([], keys=[])
+        msa.sort()
+        self.assertEqual(msa, TabularMSA([], keys=[]))
+
+        msa = TabularMSA([], keys=[])
+        msa.sort(reverse=True)
+        self.assertEqual(msa, TabularMSA([], keys=[]))
+
+    def test_sort_single_sequence_on_msa_keys(self):
+        msa = TabularMSA([DNA('ACGT')], keys=[42])
+        msa.sort()
+        self.assertEqual(msa, TabularMSA([DNA('ACGT')], keys=[42]))
+
+        msa = TabularMSA([DNA('ACGT')], keys=[42])
+        msa.sort(reverse=True)
+        self.assertEqual(msa, TabularMSA([DNA('ACGT')], keys=[42]))
+
+    def test_sort_multiple_sequences_on_msa_keys(self):
+        msa = TabularMSA([
+            DNA('TC'), DNA('GG'), DNA('CC')], keys=['z', 'a', 'b'])
+        msa.sort()
+        self.assertEqual(
+            msa,
+            TabularMSA([
+                DNA('GG'), DNA('CC'), DNA('TC')], keys=['a', 'b', 'z']))
+
+        msa = TabularMSA([
+            DNA('TC'), DNA('GG'), DNA('CC')], keys=['z', 'a', 'b'])
+        msa.sort(reverse=True)
+        self.assertEqual(
+            msa,
+            TabularMSA([
+                DNA('TC'), DNA('CC'), DNA('GG')], keys=['z', 'b', 'a']))
+
+    def test_sort_empty_no_msa_keys_on_metadata_key(self):
+        msa = TabularMSA([])
+        msa.sort(key='id')
+        self.assertEqual(msa, TabularMSA([]))
+
+        msa = TabularMSA([])
+        msa.sort(key='id', reverse=True)
+        self.assertEqual(msa, TabularMSA([]))
+
+    def test_sort_empty_no_msa_keys_on_callable_key(self):
+        msa = TabularMSA([])
+        msa.sort(key=str)
+        self.assertEqual(msa, TabularMSA([]))
+
+        msa = TabularMSA([])
+        msa.sort(key=str, reverse=True)
+        self.assertEqual(msa, TabularMSA([]))
+
+    def test_sort_empty_with_msa_keys_on_metadata_key(self):
+        msa = TabularMSA([], keys=[])
+        msa.sort(key='id')
+        self.assertEqual(msa, TabularMSA([], keys=[]))
+
+        msa = TabularMSA([], keys=[])
+        msa.sort(key='id', reverse=True)
+        self.assertEqual(msa, TabularMSA([], keys=[]))
+
+    def test_sort_empty_with_msa_keys_on_callable_key(self):
+        msa = TabularMSA([], keys=[])
+        msa.sort(key=str)
+        self.assertEqual(msa, TabularMSA([], keys=[]))
+
+        msa = TabularMSA([], keys=[])
+        msa.sort(key=str, reverse=True)
+        self.assertEqual(msa, TabularMSA([], keys=[]))
+
+    def test_sort_single_sequence_no_msa_keys_on_metadata_key(self):
+        msa = TabularMSA([RNA('UCA', metadata={'id': 42})])
+        msa.sort(key='id')
+        self.assertEqual(msa, TabularMSA([RNA('UCA', metadata={'id': 42})]))
+
+        msa = TabularMSA([RNA('UCA', metadata={'id': 42})])
+        msa.sort(key='id', reverse=True)
+        self.assertEqual(msa, TabularMSA([RNA('UCA', metadata={'id': 42})]))
+
+    def test_sort_single_sequence_no_msa_keys_on_callable_key(self):
+        msa = TabularMSA([RNA('UCA')])
+        msa.sort(key=str)
+        self.assertEqual(msa, TabularMSA([RNA('UCA')]))
+
+        msa = TabularMSA([RNA('UCA')])
+        msa.sort(key=str, reverse=True)
+        self.assertEqual(msa, TabularMSA([RNA('UCA')]))
+
+    def test_sort_single_sequence_with_msa_keys_on_metadata_key(self):
+        msa = TabularMSA([RNA('UCA', metadata={'id': 42})], keys=['foo'])
+        msa.sort(key='id')
+        self.assertEqual(
+            msa, TabularMSA([RNA('UCA', metadata={'id': 42})], keys=['foo']))
+
+        msa = TabularMSA([RNA('UCA', metadata={'id': 42})], keys=['foo'])
+        msa.sort(key='id', reverse=True)
+        self.assertEqual(
+            msa, TabularMSA([RNA('UCA', metadata={'id': 42})], keys=['foo']))
+
+    def test_sort_single_sequence_with_msa_keys_on_callable_key(self):
+        msa = TabularMSA([RNA('UCA')], keys=['foo'])
+        msa.sort(key=str)
+        self.assertEqual(msa, TabularMSA([RNA('UCA')], keys=['foo']))
+
+        msa = TabularMSA([RNA('UCA')], keys=['foo'])
+        msa.sort(key=str, reverse=True)
+        self.assertEqual(msa, TabularMSA([RNA('UCA')], keys=['foo']))
+
+    def test_sort_multiple_sequences_no_msa_keys_on_metadata_key(self):
+        msa = TabularMSA([RNA('UCA', metadata={'id': 41}),
+                          RNA('AAA', metadata={'id': 44}),
+                          RNA('GAC', metadata={'id': -1}),
+                          RNA('GAC', metadata={'id': 42})])
+        msa.sort(key='id')
+        self.assertEqual(msa, TabularMSA([RNA('GAC', metadata={'id': -1}),
+                                          RNA('UCA', metadata={'id': 41}),
+                                          RNA('GAC', metadata={'id': 42}),
+                                          RNA('AAA', metadata={'id': 44})]))
+
+        msa = TabularMSA([RNA('UCA', metadata={'id': 41}),
+                          RNA('AAA', metadata={'id': 44}),
+                          RNA('GAC', metadata={'id': -1}),
+                          RNA('GAC', metadata={'id': 42})])
+        msa.sort(key='id', reverse=True)
+        self.assertEqual(msa, TabularMSA([RNA('AAA', metadata={'id': 44}),
+                                          RNA('GAC', metadata={'id': 42}),
+                                          RNA('UCA', metadata={'id': 41}),
+                                          RNA('GAC', metadata={'id': -1})]))
+
+    def test_sort_multiple_sequences_no_msa_keys_on_callable_key(self):
+        msa = TabularMSA([RNA('UCC'),
+                          RNA('UCG'),
+                          RNA('UCA')])
+        msa.sort(key=str)
+        self.assertEqual(msa, TabularMSA([RNA('UCA'), RNA('UCC'), RNA('UCG')]))
+
+        msa = TabularMSA([RNA('UCC'),
+                          RNA('UCG'),
+                          RNA('UCA')])
+        msa.sort(key=str, reverse=True)
+        self.assertEqual(msa, TabularMSA([RNA('UCG'), RNA('UCC'), RNA('UCA')]))
+
+    def test_sort_multiple_sequences_with_msa_keys_on_metadata_key(self):
+        msa = TabularMSA([DNA('TCA', metadata={'#': 41.2}),
+                          DNA('AAA', metadata={'#': 44.5}),
+                          DNA('GAC', metadata={'#': 42.999})],
+                         keys=[None, ('hello', 'world'), True])
+        msa.sort(key='#')
+        self.assertEqual(
+            msa,
+            TabularMSA([DNA('TCA', metadata={'#': 41.2}),
+                        DNA('GAC', metadata={'#': 42.999}),
+                        DNA('AAA', metadata={'#': 44.5})],
+                       keys=[None, True, ('hello', 'world')]))
+
+        msa = TabularMSA([DNA('TCA', metadata={'#': 41.2}),
+                          DNA('AAA', metadata={'#': 44.5}),
+                          DNA('GAC', metadata={'#': 42.999})],
+                         keys=[None, ('hello', 'world'), True])
+        msa.sort(key='#', reverse=True)
+        self.assertEqual(
+            msa,
+            TabularMSA([DNA('AAA', metadata={'#': 44.5}),
+                        DNA('GAC', metadata={'#': 42.999}),
+                        DNA('TCA', metadata={'#': 41.2})],
+                       keys=[('hello', 'world'), True, None]))
+
+    def test_sort_multiple_sequences_with_msa_keys_on_callable_key(self):
+        msa = TabularMSA([RNA('UCC'),
+                          RNA('UCG'),
+                          RNA('UCA')], keys=[1, 'abc', None])
+        msa.sort(key=str)
+        self.assertEqual(msa, TabularMSA([RNA('UCA'), RNA('UCC'), RNA('UCG')],
+                                         keys=[None, 1, 'abc']))
+
+        msa = TabularMSA([RNA('UCC'),
+                          RNA('UCG'),
+                          RNA('UCA')], keys=[1, 'abc', None])
+        msa.sort(key=str, reverse=True)
+        self.assertEqual(msa, TabularMSA([RNA('UCG'), RNA('UCC'), RNA('UCA')],
+                                         keys=['abc', 1, None]))
+
+    def test_sort_on_key_with_some_repeats(self):
+        msa = TabularMSA([
+            DNA('TCCG', metadata={'id': 10}),
+            DNA('TAGG', metadata={'id': 10}),
+            DNA('GGGG', metadata={'id': 8}),
+            DNA('ACGT', metadata={'id': 0}),
+            DNA('TAGG', metadata={'id': 10})], keys=range(5))
+        msa.sort(key='id')
+        self.assertEqual(
+            msa,
+            TabularMSA([
+                DNA('ACGT', metadata={'id': 0}),
+                DNA('GGGG', metadata={'id': 8}),
+                DNA('TCCG', metadata={'id': 10}),
+                DNA('TAGG', metadata={'id': 10}),
+                DNA('TAGG', metadata={'id': 10})], keys=[3, 2, 0, 1, 4]))
+
+    def test_sort_on_key_with_all_repeats(self):
+        msa = TabularMSA([
+            DNA('TTT', metadata={'id': 'a'}),
+            DNA('TTT', metadata={'id': 'b'}),
+            DNA('TTT', metadata={'id': 'c'})], keys=range(3))
+        msa.sort(key=str)
+        self.assertEqual(
+            msa,
+            TabularMSA([
+                DNA('TTT', metadata={'id': 'a'}),
+                DNA('TTT', metadata={'id': 'b'}),
+                DNA('TTT', metadata={'id': 'c'})], keys=range(3)))
+
+    def test_sort_mixed_key_types(self):
+        msa = TabularMSA([
+            DNA('GCG', metadata={'id': 41}),
+            DNA('CGC', metadata={'id': 42.2}),
+            DNA('TCT', metadata={'id': 42})])
+        msa.sort(key='id')
+        self.assertEqual(
+            msa,
+            TabularMSA([
+                DNA('GCG', metadata={'id': 41}),
+                DNA('TCT', metadata={'id': 42}),
+                DNA('CGC', metadata={'id': 42.2})]))
+
+        msa = TabularMSA([
+            DNA('GCG'),
+            DNA('CGC'),
+            DNA('TCT')], keys=[41, 42.2, 42])
+        msa.sort()
+        self.assertEqual(
+            msa,
+            TabularMSA([
+                DNA('GCG'),
+                DNA('TCT'),
+                DNA('CGC')], keys=[41, 42, 42.2]))
+
+    def test_sort_already_sorted(self):
+        msa = TabularMSA([DNA('TC'), DNA('GG'), DNA('CC')], keys=[1, 2, 3])
+        msa.sort()
+        self.assertEqual(
+            msa,
+            TabularMSA([DNA('TC'), DNA('GG'), DNA('CC')], keys=[1, 2, 3]))
+
+        msa = TabularMSA([DNA('TC'), DNA('GG'), DNA('CC')], keys=[3, 2, 1])
+        msa.sort(reverse=True)
+        self.assertEqual(
+            msa,
+            TabularMSA([DNA('TC'), DNA('GG'), DNA('CC')], keys=[3, 2, 1]))
+
+    def test_sort_reverse_sorted(self):
+        msa = TabularMSA([DNA('T'), DNA('G'), DNA('A')], keys=[3, 2, 1])
+        msa.sort()
+        self.assertEqual(
+            msa,
+            TabularMSA([DNA('A'), DNA('G'), DNA('T')], keys=[1, 2, 3]))
+
+        msa = TabularMSA([DNA('T'), DNA('G'), DNA('A')], keys=[1, 2, 3])
+        msa.sort(reverse=True)
+        self.assertEqual(
+            msa,
+            TabularMSA([DNA('A'), DNA('G'), DNA('T')], keys=[3, 2, 1]))
+
+    def test_sort_identical_sequences(self):
+        msa = TabularMSA([DNA(''), DNA(''), DNA('')], keys=['ab', 'aa', 'ac'])
+        msa.sort()
+        self.assertEqual(
+            msa,
+            TabularMSA([DNA(''), DNA(''), DNA('')], keys=['aa', 'ab', 'ac']))
+
+    def test_to_dict_no_keys(self):
+        with self.assertRaises(OperationError):
+            TabularMSA([]).to_dict()
+
+        with self.assertRaises(OperationError):
+            TabularMSA([DNA('AGCT'), DNA('TCGA')]).to_dict()
+
+    def test_to_dict_empty(self):
+        self.assertEqual(TabularMSA([], keys=[]).to_dict(), {})
+        self.assertEqual(TabularMSA([RNA('')], keys=['foo']).to_dict(),
+                         {'foo': RNA('')})
+
+    def test_to_dict_non_empty(self):
+        seqs = [Protein('PAW', metadata={'id': 42}),
+                Protein('WAP', metadata={'id': -999})]
+        msa = TabularMSA(seqs, key='id')
+        self.assertEqual(msa.to_dict(), {42: seqs[0], -999: seqs[1]})
+
+    def test_from_dict_to_dict_roundtrip(self):
+        d = {}
+        self.assertEqual(TabularMSA.from_dict(d).to_dict(), d)
+
+        # can roundtrip even with mixed key types
+        d1 = {'a': DNA('CAT'), 42: DNA('TAG')}
+        d2 = TabularMSA.from_dict(d1).to_dict()
+        self.assertEqual(d2, d1)
+        self.assertIs(d1['a'], d2['a'])
+        self.assertIs(d1[42], d2[42])
 
 
 if __name__ == "__main__":

--- a/skbio/util/_misc.py
+++ b/skbio/util/_misc.py
@@ -18,7 +18,7 @@ from ._decorator import experimental, deprecated
 
 
 def resolve_key(obj, key):
-    """Resolve key given a object and key."""
+    """Resolve key given an object and key."""
     if callable(key):
         return key(obj)
     elif hasattr(obj, 'metadata'):


### PR DESCRIPTION
Also made ``TabularMSA.keys`` use ``object`` dtype to prevent lossy conversions.

Fixes #1082, fixes #1095.