### PR TITLE
ENH: better error message for PY2 list iosource

### DIFF
--- a/skbio/io/_iosources.py
+++ b/skbio/io/_iosources.py
@@ -8,7 +8,6 @@
 
 from __future__ import absolute_import, division, print_function
 import six
-from six import string_types, text_type
 
 import io
 import gzip

--- a/skbio/io/_iosources.py
+++ b/skbio/io/_iosources.py
@@ -7,7 +7,7 @@
 # ----------------------------------------------------------------------------
 
 from __future__ import absolute_import, division, print_function
-
+import six
 from six import string_types, text_type
 
 import io
@@ -80,7 +80,7 @@ class Compressor(IOSource):
 
 class FilePathSource(IOSource):
     def can_read(self):
-        return isinstance(self.file, string_types)
+        return isinstance(self.file, six.string_types)
 
     def can_write(self):
         return self.can_read()
@@ -95,7 +95,7 @@ class FilePathSource(IOSource):
 class HTTPSource(IOSource):
     def can_read(self):
         return (
-            isinstance(self.file, string_types) and
+            isinstance(self.file, six.string_types) and
             requests.compat.urlparse(self.file).scheme in {'http', 'https'})
 
     def get_reader(self):
@@ -169,11 +169,17 @@ class IterableSource(IOSource):
             if head is None:
                 self.repaired = []
                 return True
-            if isinstance(head, text_type):
+            if isinstance(head, six.text_type):
                 self.repaired = itertools.chain([head], iterator)
                 return True
             else:
                 # We may have mangled a generator at this point, so just abort
+                if six.PY2 and isinstance(head, bytes):
+                    raise IOSourceError(
+                        "Could not open source: %r (mode: %r).\n Prepend a "
+                        r"`u` to the strings (e.g. [u'line1\n', u'line2\n'])" %
+                        (self.file, self.options['mode']))
+
                 raise IOSourceError(
                     "Could not open source: %r (mode: %r)" %
                     (self.file, self.options['mode']))

--- a/skbio/io/tests/test_util.py
+++ b/skbio/io/tests/test_util.py
@@ -7,6 +7,7 @@
 # ----------------------------------------------------------------------------
 
 from __future__ import absolute_import, division, print_function
+import six
 
 import unittest
 import tempfile
@@ -533,9 +534,19 @@ class TestIterableReaderWriter(unittest.TestCase):
             self.assertIsInstance(result, io.TextIOBase)
             self.assertEqual(result.readlines(), l)
 
+    def test_open_invalid_iterable_missing_u(self):
+        is_py2 = six.PY2
+        six.PY2 = True
+        try:
+            with six.assertRaisesRegex(self, skbio.io.IOSourceError,
+                                       ".*Prepend.*`u`.*"):
+                skbio.io.open([b'abc'])
+        finally:
+            six.PY2 = is_py2
+
     def test_open_invalid_iterable(self):
         with self.assertRaises(skbio.io.IOSourceError):
-            skbio.io.open([b'abc'])
+            skbio.io.open([1, 2, 3])
 
     def test_open_empty_iterable(self):
         with skbio.io.open([]) as result:


### PR DESCRIPTION
fixes #1103 

Error example:
```python
In [1]: from skbio import DNA

In [2]: DNA.read(['abc'])
---------------------------------------------------------------------------
IOSourceError                             Traceback (most recent call last)
<ipython-input-2-886913a61d43> in <module>()
----> 1 DNA.read(['abc'])

/home/evan/biocore/scikit-bio/skbio/io/registry.pyc in read(cls, file, format, **kwargs)
    622         @classmethod
    623         def read(cls, file, format=None, **kwargs):
--> 624             return registry.read(file, into=cls, format=format, **kwargs)
    625 
    626         imports = registry._import_paths(read_formats)

/home/evan/biocore/scikit-bio/skbio/io/registry.pyc in read(self, file, format, into, verify, **kwargs)
    495             return (x for x in itertools.chain([next(gen)], gen))
    496         else:
--> 497             return self._read_ret(file, format, into, verify, kwargs)
    498 
    499     def _read_ret(self, file, fmt, into, verify, kwargs):

/home/evan/biocore/scikit-bio/skbio/io/registry.pyc in _read_ret(self, file, fmt, into, verify, kwargs)
    499     def _read_ret(self, file, fmt, into, verify, kwargs):
    500         io_kwargs = self._find_io_kwargs(kwargs)
--> 501         with _resolve_file(file, **io_kwargs) as (file, _, _):
    502             reader, kwargs = self._init_reader(file, fmt, into, verify, kwargs,
    503                                                io_kwargs)

/home/evan/.conda/envs/2skbio/lib/python2.7/site-packages/contextlib2.pyc in __enter__(self)
     47     def __enter__(self):
     48         try:
---> 49             return next(self.gen)
     50         except StopIteration:
     51             raise RuntimeError("generator didn't yield")

/home/evan/biocore/scikit-bio/skbio/io/util.pyc in _resolve_file(file, **kwargs)
    202 @contextmanager
    203 def _resolve_file(file, **kwargs):
--> 204     file, source, is_binary_file = _resolve(file, **kwargs)
    205     try:
    206         yield file, source, is_binary_file

/home/evan/biocore/scikit-bio/skbio/io/util.pyc in _resolve(file, mode, encoding, errors, newline, compression, compresslevel)
     56     for source_handler in get_io_sources():
     57         source = source_handler(file, arguments)
---> 58         if mode == 'r' and source.can_read():
     59             newfile = source.get_reader()
     60             break

/home/evan/biocore/scikit-bio/skbio/io/_iosources.pyc in can_read(self)
    179                         "Could not open source: %r (mode: %r).\n Prepend a "
    180                         r"`u` to the strings (e.g. [u'line1\n', u'line2\n'])" %
--> 181                         (self.file, self.options['mode']))
    182 
    183                 raise IOSourceError(

IOSourceError: Could not open source: ['abc'] (mode: 'r').
 Prepend a `u` to the strings (e.g. [u'line1\n', u'line2\n'])
```