### PR TITLE
ENH: add classonlymethod decorator

### DIFF
--- a/skbio/alignment/_tabular_msa.py
+++ b/skbio/alignment/_tabular_msa.py
@@ -19,7 +19,7 @@ from skbio._base import SkbioObject
 from skbio.sequence._iupac_sequence import IUPACSequence
 from skbio.sequence import Sequence
 from skbio.util import find_duplicates, OperationError, UniqueError
-from skbio.util._decorator import experimental
+from skbio.util._decorator import experimental, classonlymethod
 from skbio.util._misc import resolve_key
 
 
@@ -266,7 +266,7 @@ class TabularMSA(SkbioObject):
     def metadata(self):
         self._metadata = None
 
-    @classmethod
+    @classonlymethod
     @experimental(as_of="0.4.0-dev")
     def from_dict(cls, dictionary):
         """Create a ``TabularMSA`` from a ``dict``.

--- a/skbio/io/registry.py
+++ b/skbio/io/registry.py
@@ -183,7 +183,7 @@ from . import (UnrecognizedFormatError, ArgumentOverrideWarning,
                FormatIdentificationWarning)
 from .util import _resolve_file, open_file, open_files, _d as _open_kwargs
 from skbio.util._misc import make_sentinel, find_sentinels
-from skbio.util._decorator import stable
+from skbio.util._decorator import stable, classonlymethod
 
 FileSentinel = make_sentinel("FileSentinel")
 
@@ -619,7 +619,7 @@ class IORegistry(object):
         """Add read method if any formats have a reader for `cls`."""
         read_formats = registry.list_read_formats(cls)
 
-        @classmethod
+        @classonlymethod
         def read(cls, file, format=None, **kwargs):
             return registry.read(file, into=cls, format=format, **kwargs)
 

--- a/skbio/sequence/_genetic_code.py
+++ b/skbio/sequence/_genetic_code.py
@@ -11,7 +11,7 @@ from __future__ import absolute_import, division, print_function
 import numpy as np
 from future.builtins import range
 
-from skbio.util._decorator import classproperty, stable
+from skbio.util._decorator import classproperty, stable, classonlymethod
 from skbio._base import SkbioObject
 from skbio.sequence import Protein, RNA
 from skbio.sequence._base import ElasticLines
@@ -141,7 +141,7 @@ class GeneticCode(SkbioObject):
             cls.__offset_table = table
         return cls.__offset_table
 
-    @classmethod
+    @classonlymethod
     @stable(as_of="0.4.0")
     def from_ncbi(cls, table_id=1):
         """Return NCBI genetic code specified by table ID.

--- a/skbio/sequence/_sequence.py
+++ b/skbio/sequence/_sequence.py
@@ -24,7 +24,7 @@ import pandas as pd
 
 from skbio._base import SkbioObject
 from skbio.sequence._repr import _SequenceReprBuilder
-from skbio.util._decorator import stable, experimental
+from skbio.util._decorator import stable, experimental, classonlymethod
 
 
 class Sequence(collections.Sequence, SkbioObject):
@@ -547,7 +547,7 @@ class Sequence(collections.Sequence, SkbioObject):
     def _string(self):
         return self._bytes.tostring()
 
-    @classmethod
+    @classonlymethod
     @experimental(as_of="0.4.0-dev")
     def concat(cls, sequences, how='strict'):
         """Concatenate an iterable of ``Sequence`` objects.

--- a/skbio/stats/distance/_base.py
+++ b/skbio/stats/distance/_base.py
@@ -21,7 +21,7 @@ from scipy.spatial.distance import squareform
 from skbio._base import SkbioObject
 from skbio.stats._misc import _pprint_strs
 from skbio.util import find_duplicates
-from skbio.util._decorator import experimental
+from skbio.util._decorator import experimental, classonlymethod
 from skbio.util._misc import resolve_key
 
 
@@ -656,7 +656,7 @@ class DistanceMatrix(DissimilarityMatrix):
     # Override here, used in superclass __str__
     _matrix_element_name = 'distance'
 
-    @classmethod
+    @classonlymethod
     @experimental(as_of="0.4.0-dev")
     def from_iterable(cls, iterable, metric, key=None, keys=None):
         """Create DistanceMatrix from all pairs in an iterable given a metric.

--- a/skbio/tree/_tree.py
+++ b/skbio/tree/_tree.py
@@ -25,7 +25,7 @@ from skbio.stats.distance import DistanceMatrix
 from ._exception import (NoLengthError, DuplicateNodeError, NoParentError,
                          MissingNodeError, TreeError)
 from skbio.util import RepresentationWarning
-from skbio.util._decorator import experimental
+from skbio.util._decorator import experimental, classonlymethod
 
 
 def distance_from_r(m1, m2):
@@ -1822,7 +1822,7 @@ class TreeNode(SkbioObject):
 
     lca = lowest_common_ancestor  # for convenience
 
-    @classmethod
+    @classonlymethod
     @experimental(as_of="0.4.0")
     def from_taxonomy(cls, lineage_map):
         """Construct a tree from a taxonomy
@@ -1916,7 +1916,7 @@ class TreeNode(SkbioObject):
             node = node.children[0]
         return distance
 
-    @classmethod
+    @classonlymethod
     @experimental(as_of="0.4.0")
     def from_linkage_matrix(cls, linkage_matrix, id_list):
         """Return tree from SciPy linkage matrix.

--- a/skbio/util/_decorator.py
+++ b/skbio/util/_decorator.py
@@ -336,3 +336,35 @@ class classproperty(property):
 
     def __set__(self, obj, value):
         raise AttributeError("can't set attribute")
+
+
+class classonlymethod(classmethod):
+    """Just like `classmethod`, but it can't be called on an instance."""
+
+    def __init__(self, function):
+        super(classonlymethod, self).__init__(function)
+
+    def __get__(self, obj, cls=None):
+        if obj is not None:
+            raise TypeError("Class-only method called on an instance. Use"
+                            " '%s.%s' instead."
+                            % (cls.__name__, self.__func__.__name__))
+
+        evaldict = self.__func__.__globals__.copy()
+        evaldict['_call_'] = self.__func__
+        evaldict['_cls_'] = cls
+        fun = FunctionMakerDropFirstArg.create(
+            self.__func__, "return _call_(_cls_, %(shortsignature)s)",
+            evaldict, __wrapped__=self.__func__)
+        fun.__func__ = self.__func__  # Doctests need the orginal function
+        return fun
+
+
+class FunctionMakerDropFirstArg(decorator.FunctionMaker):
+    def __init__(self, *args, **kwargs):
+        super(FunctionMakerDropFirstArg, self).__init__(*args, **kwargs)
+        self.signature = self._remove_first_arg(self.signature)
+        self.shortsignature = self._remove_first_arg(self.shortsignature)
+
+    def _remove_first_arg(self, string):
+        return ",".join(string.split(',')[1:])[1:]

--- a/skbio/util/tests/test_decorator.py
+++ b/skbio/util/tests/test_decorator.py
@@ -11,10 +11,68 @@ import unittest
 import inspect
 import warnings
 
-from skbio.util._decorator import classproperty, overrides
+from skbio.util._decorator import classproperty, overrides, classonlymethod
 from skbio.util._decorator import (stable, experimental, deprecated,
                                    _state_decorator)
 from skbio.util._exception import OverrideError
+
+
+class TestClassOnlyMethod(unittest.TestCase):
+    def test_works_on_class(self):
+        class A(object):
+            @classonlymethod
+            def example(cls):
+                return cls
+
+        self.assertEqual(A.example(), A)
+
+    def test_fails_on_instance(self):
+        class A(object):
+            @classonlymethod
+            def example(cls):
+                pass
+
+        with self.assertRaises(TypeError) as e:
+            A().example()
+
+        self.assertIn('A.example', str(e.exception))
+        self.assertIn('instance', str(e.exception))
+
+    def test_matches_classmethod(self):
+        class A(object):
+            pass
+
+        def example(cls, thing):
+            """doc"""
+
+        A.example1 = classmethod(example)
+        A.example2 = classonlymethod(example)
+
+        self.assertEqual(A.__dict__['example1'].__func__, example)
+        self.assertEqual(A.__dict__['example2'].__func__, example)
+
+        self.assertEqual(A.example1.__doc__, example.__doc__)
+        self.assertEqual(A.example2.__doc__, example.__doc__)
+
+        self.assertEqual(A.example1.__name__, example.__name__)
+        self.assertEqual(A.example2.__name__, example.__name__)
+
+    def test_passes_args_kwargs(self):
+        self.ran_test = False
+
+        class A(object):
+            @classonlymethod
+            def example(cls, arg1, arg2, kwarg1=None, kwarg2=None,
+                        default=5):
+                self.assertEqual(arg1, 1)
+                self.assertEqual(arg2, 2)
+                self.assertEqual(kwarg1, '1')
+                self.assertEqual(kwarg2, '2')
+                self.assertEqual(default, 5)
+                self.ran_test = True
+
+        A.example(1, *[2], kwarg2='2', **{'kwarg1': '1'})
+        self.assertTrue(self.ran_test)
 
 
 class TestOverrides(unittest.TestCase):


### PR DESCRIPTION
The [descriptor protocol](http://users.rcn.com/python/download/Descriptor.htm) is kewl.

This is very useful for things like `Sequence.concat` where the class which it was called on defines the return type. It used to be possible to say `seq1.concat([seq2, seq3])` but it is ambiguous as to the behaviour (it would only concat seq2 and 3 and cast as the type of seq1, but a future maintainer of such code may not know this, indeed the original author probably didn't either).