### PR TITLE
MAINT: use mixin for classes storing metadata

### DIFF
--- a/skbio/alignment/_tabular_msa.py
+++ b/skbio/alignment/_tabular_msa.py
@@ -275,7 +275,7 @@ class TabularMSA(MetadataMixin, SkbioObject):
         self._dtype = dtype
         self._shape = _Shape(sequence=len(seqs), position=length)
 
-        super(TabularMSA, self).__init__(metadata=metadata)
+        MetadataMixin.__init__(self, metadata=metadata)
 
         self.reindex(key=key, keys=keys)
 
@@ -451,7 +451,7 @@ class TabularMSA(MetadataMixin, SkbioObject):
         if not isinstance(other, TabularMSA):
             return False
 
-        if not super(TabularMSA, self).__eq__(other):
+        if not MetadataMixin.__eq__(self, other):
             return False
 
         # Use np.array_equal instead of (a == b).all():

--- a/skbio/alignment/_tabular_msa.py
+++ b/skbio/alignment/_tabular_msa.py
@@ -275,7 +275,7 @@ class TabularMSA(MetadataMixin, SkbioObject):
         self._dtype = dtype
         self._shape = _Shape(sequence=len(seqs), position=length)
 
-        super().__init__(metadata=metadata)
+        super(TabularMSA, self).__init__(metadata=metadata)
 
         self.reindex(key=key, keys=keys)
 
@@ -451,7 +451,7 @@ class TabularMSA(MetadataMixin, SkbioObject):
         if not isinstance(other, TabularMSA):
             return False
 
-        if not super().__eq__(other):
+        if not super(TabularMSA, self).__eq__(other):
             return False
 
         # Use np.array_equal instead of (a == b).all():

--- a/skbio/alignment/_tabular_msa.py
+++ b/skbio/alignment/_tabular_msa.py
@@ -15,7 +15,7 @@ from future.builtins import zip
 from future.utils import viewkeys, viewvalues
 import numpy as np
 
-from skbio._base import SkbioObject
+from skbio._base import SkbioObject, MetadataMixin
 from skbio.sequence._iupac_sequence import IUPACSequence
 from skbio.sequence import Sequence
 from skbio.util import find_duplicates, OperationError, UniqueError
@@ -26,7 +26,7 @@ from skbio.util._misc import resolve_key
 _Shape = collections.namedtuple('Shape', ['sequence', 'position'])
 
 
-class TabularMSA(SkbioObject):
+class TabularMSA(MetadataMixin, SkbioObject):
     """Store a multiple sequence alignment in tabular (row/column) form.
 
     Parameters
@@ -200,72 +200,6 @@ class TabularMSA(SkbioObject):
     def keys(self):
         self.reindex()
 
-    @property
-    @experimental(as_of='0.4.0-dev')
-    def metadata(self):
-        """``dict`` containing metadata which applies to the entire MSA.
-
-        Notes
-        -----
-        This property can be set and deleted. When setting new metadata a
-        shallow copy of the dictionary is made.
-
-        Examples
-        --------
-        >>> from pprint import pprint
-        >>> from skbio import DNA, TabularMSA
-
-        Create an MSA with metadata:
-
-        >>> msa = TabularMSA([DNA('TT-GA'), DNA('ATAGC')],
-        ...                  metadata={'id': 'msa-id',
-        ...                            'description': 'msa description'})
-
-        Retrieve metadata:
-
-        >>> pprint(msa.metadata) # using pprint to display dict in sorted order
-        {'description': 'msa description', 'id': 'msa-id'}
-
-        Update metadata:
-
-        >>> msa.metadata['id'] = 'new-id'
-        >>> msa.metadata['medline'] = 12345678
-        >>> pprint(msa.metadata)
-        {'description': 'msa description', 'id': 'new-id', 'medline': 12345678}
-
-        Set metadata:
-
-        >>> msa.metadata = {'abc': 123}
-        >>> msa.metadata
-        {'abc': 123}
-
-        Delete metadata:
-
-        >>> msa.has_metadata()
-        True
-        >>> del msa.metadata
-        >>> msa.metadata
-        {}
-        >>> msa.has_metadata()
-        False
-
-        """
-        if self._metadata is None:
-            # not using setter to avoid copy
-            self._metadata = {}
-        return self._metadata
-
-    @metadata.setter
-    def metadata(self, metadata):
-        if not isinstance(metadata, dict):
-            raise TypeError("metadata must be a dict")
-        # shallow copy
-        self._metadata = metadata.copy()
-
-    @metadata.deleter
-    def metadata(self):
-        self._metadata = None
-
     @classmethod
     @experimental(as_of="0.4.0-dev")
     def from_dict(cls, dictionary):
@@ -341,10 +275,7 @@ class TabularMSA(SkbioObject):
         self._dtype = dtype
         self._shape = _Shape(sequence=len(seqs), position=length)
 
-        if metadata is None:
-            self._metadata = None
-        else:
-            self.metadata = metadata
+        super().__init__(metadata=metadata)
 
         self.reindex(key=key, keys=keys)
 
@@ -520,17 +451,7 @@ class TabularMSA(SkbioObject):
         if not isinstance(other, TabularMSA):
             return False
 
-        # we're not simply comparing self.metadata to other.metadata in order
-        # to avoid creating "empty" metadata representations on the TabularMSA
-        # objects if they don't have metadata.
-        if self.has_metadata() and other.has_metadata():
-            if self.metadata != other.metadata:
-                return False
-        elif not (self.has_metadata() or other.has_metadata()):
-            # both don't have metadata
-            pass
-        else:
-            # one has metadata while the other does not
+        if not super().__eq__(other):
             return False
 
         # Use np.array_equal instead of (a == b).all():
@@ -588,36 +509,6 @@ class TabularMSA(SkbioObject):
 
         """
         return self._keys is not None
-
-    @experimental(as_of='0.4.0-dev')
-    def has_metadata(self):
-        """Determine if the MSA has metadata.
-
-        An MSA has metadata if its ``metadata`` dictionary is not empty (i.e.,
-        has at least one key-value pair).
-
-        Returns
-        -------
-        bool
-            Indicates whether the MSA has metadata
-
-        See Also
-        --------
-        metadata
-
-        Examples
-        --------
-        >>> from skbio import DNA, TabularMSA
-        >>> seqs = [DNA('AC--G'), DNA('ATAAG')]
-        >>> msa = TabularMSA(seqs)
-        >>> msa.has_metadata()
-        False
-        >>> msa = TabularMSA(seqs, metadata={'id': 'msa-id'})
-        >>> msa.has_metadata()
-        True
-
-        """
-        return self._metadata is not None and bool(self.metadata)
 
     @experimental(as_of='0.4.0-dev')
     def reindex(self, key=None, keys=None):

--- a/skbio/alignment/tests/test_tabular_msa.py
+++ b/skbio/alignment/tests/test_tabular_msa.py
@@ -35,7 +35,7 @@ class Unorderable(object):
 
 class TestTabularMSA(unittest.TestCase, ReallyEqualMixin, MetadataMixinTests):
     def setUp(self):
-        self.constructor = functools.partial(TabularMSA, [])
+        self._metadata_constructor_ = functools.partial(TabularMSA, [])
 
     def test_from_dict_empty(self):
         self.assertEqual(TabularMSA.from_dict({}), TabularMSA([], keys=[]))

--- a/skbio/alignment/tests/test_tabular_msa.py
+++ b/skbio/alignment/tests/test_tabular_msa.py
@@ -9,16 +9,16 @@
 from __future__ import absolute_import, division, print_function
 
 import unittest
+import functools
 import itertools
 
 import six
 import numpy as np
-import pandas as pd
 import numpy.testing as npt
 
 from skbio import Sequence, DNA, RNA, Protein, TabularMSA
 from skbio.util import OperationError, UniqueError
-from skbio.util._testing import ReallyEqualMixin
+from skbio.util._testing import ReallyEqualMixin, MetadataMixinTests
 
 
 class TabularMSASubclass(TabularMSA):
@@ -33,7 +33,10 @@ class Unorderable(object):
     __cmp__ = __lt__
 
 
-class TestTabularMSA(unittest.TestCase, ReallyEqualMixin):
+class TestTabularMSA(unittest.TestCase, ReallyEqualMixin, MetadataMixinTests):
+    def setUp(self):
+        self.constructor = functools.partial(TabularMSA, [])
+
     def test_from_dict_empty(self):
         self.assertEqual(TabularMSA.from_dict({}), TabularMSA([], keys=[]))
 
@@ -112,10 +115,6 @@ class TestTabularMSA(unittest.TestCase, ReallyEqualMixin):
                                    'Number.*keys.*number.*sequences: 0 != 2'):
             TabularMSA([DNA('ACGT'), DNA('TGCA')], keys=iter([]))
 
-    def test_constructor_invalid_metadata(self):
-        with self.assertRaises(TypeError):
-            TabularMSA([], metadata=42)
-
     def test_constructor_empty_no_keys(self):
         # sequence empty
         msa = TabularMSA([])
@@ -188,41 +187,6 @@ class TestTabularMSA(unittest.TestCase, ReallyEqualMixin):
         self.assertEqual(msa.shape, (3, 3))
         npt.assert_array_equal(msa.keys, np.array(['ACG', 'CGA', 'GTT']))
         self.assertEqual(list(msa), seqs)
-
-    def test_constructor_handles_missing_metadata_efficiently(self):
-        self.assertIsNone(TabularMSA([])._metadata)
-
-    def test_constructor_no_metadata(self):
-        self.assertFalse(TabularMSA([]).has_metadata())
-        self.assertFalse(
-            TabularMSA([DNA('', metadata={'id': 42})]).has_metadata())
-        self.assertFalse(
-            TabularMSA([DNA('AGC', metadata={'id': 42}),
-                        DNA('---', metadata={'id': 43})]).has_metadata())
-
-    def test_constructor_with_metadata(self):
-        msa = TabularMSA([], metadata={'foo': 'bar'})
-        self.assertEqual(msa.metadata, {'foo': 'bar'})
-
-        msa = TabularMSA([DNA('', metadata={'id': 42})],
-                         metadata={'foo': 'bar'})
-        self.assertEqual(msa.metadata, {'foo': 'bar'})
-
-        msa = TabularMSA([DNA('AGC'), DNA('---')], metadata={'foo': 'bar'})
-        self.assertEqual(msa.metadata, {'foo': 'bar'})
-
-    def test_constructor_makes_shallow_copy_of_metadata(self):
-        md = {'foo': 'bar', 42: []}
-        msa = TabularMSA([RNA('-.-'), RNA('.-.')], metadata=md)
-
-        self.assertEqual(msa.metadata, md)
-        self.assertIsNot(msa.metadata, md)
-
-        md['foo'] = 'baz'
-        self.assertEqual(msa.metadata, {'foo': 'bar', 42: []})
-
-        md[42].append(True)
-        self.assertEqual(msa.metadata, {'foo': 'bar', 42: [True]})
 
     def test_dtype(self):
         self.assertIsNone(TabularMSA([]).dtype)
@@ -347,75 +311,6 @@ class TestTabularMSA(unittest.TestCase, ReallyEqualMixin):
         del msa.keys
         self.assertFalse(msa.has_keys())
 
-    def test_metadata_getter(self):
-        msa = TabularMSA([])
-        self.assertIsNone(msa._metadata)
-        self.assertEqual(msa.metadata, {})
-        self.assertIsNotNone(msa._metadata)
-        self.assertIsInstance(msa.metadata, dict)
-
-        msa = TabularMSA([], metadata={42: 'foo', ('hello', 'world'): 43})
-        self.assertEqual(msa.metadata, {42: 'foo', ('hello', 'world'): 43})
-        self.assertIsInstance(msa.metadata, dict)
-
-        msa.metadata[42] = 'bar'
-        self.assertEqual(msa.metadata, {42: 'bar', ('hello', 'world'): 43})
-
-    def test_metadata_setter(self):
-        msa = TabularMSA([DNA('A-A'), DNA('A-G')])
-        self.assertFalse(msa.has_metadata())
-
-        msa.metadata = {'hello': 'world'}
-        self.assertTrue(msa.has_metadata())
-        self.assertEqual(msa.metadata, {'hello': 'world'})
-
-        msa.metadata = {}
-        self.assertFalse(msa.has_metadata())
-
-    def test_metadata_setter_makes_shallow_copy(self):
-        msa = TabularMSA([RNA('-.-'), RNA('.-.')])
-        md = {'foo': 'bar', 42: []}
-        msa.metadata = md
-
-        self.assertEqual(msa.metadata, md)
-        self.assertIsNot(msa.metadata, md)
-
-        md['foo'] = 'baz'
-        self.assertEqual(msa.metadata, {'foo': 'bar', 42: []})
-
-        md[42].append(True)
-        self.assertEqual(msa.metadata, {'foo': 'bar', 42: [True]})
-
-    def test_metadata_setter_invalid_type(self):
-        msa = TabularMSA([Protein('PAW')], metadata={123: 456})
-
-        for md in (None, 0, 'a', ('f', 'o', 'o'), np.array([]),
-                   pd.DataFrame()):
-            with six.assertRaisesRegex(self, TypeError,
-                                       'metadata must be a dict'):
-                msa.metadata = md
-            self.assertEqual(msa.metadata, {123: 456})
-
-    def test_metadata_deleter(self):
-        msa = TabularMSA([Protein('PAW')], metadata={'foo': 'bar'})
-        self.assertEqual(msa.metadata, {'foo': 'bar'})
-
-        del msa.metadata
-        self.assertIsNone(msa._metadata)
-        self.assertFalse(msa.has_metadata())
-
-        # delete again
-        del msa.metadata
-        self.assertIsNone(msa._metadata)
-        self.assertFalse(msa.has_metadata())
-
-        msa = TabularMSA([])
-        self.assertIsNone(msa._metadata)
-        self.assertFalse(msa.has_metadata())
-        del msa.metadata
-        self.assertIsNone(msa._metadata)
-        self.assertFalse(msa.has_metadata())
-
     def test_bool(self):
         self.assertFalse(TabularMSA([]))
         self.assertFalse(TabularMSA([RNA('')]))
@@ -512,29 +407,6 @@ class TestTabularMSA(unittest.TestCase, ReallyEqualMixin):
         msa1 = TabularMSA([DNA('ACGT')])
         msa2 = TabularMSA((DNA('ACGT'),))
         self.assertReallyEqual(msa1, msa2)
-
-    def test_eq_missing_metadata(self):
-        self.assertReallyEqual(TabularMSA([DNA('A')]),
-                               TabularMSA([DNA('A')], metadata={}))
-
-    def test_eq_handles_missing_metadata_efficiently(self):
-        msa1 = TabularMSA([DNA('ACGT')])
-        msa2 = TabularMSA([DNA('ACGT')])
-        self.assertReallyEqual(msa1, msa2)
-
-        self.assertIsNone(msa1._metadata)
-        self.assertIsNone(msa2._metadata)
-
-    def test_has_metadata(self):
-        msa = TabularMSA([])
-        self.assertFalse(msa.has_metadata())
-        # Handles metadata efficiently.
-        self.assertIsNone(msa._metadata)
-
-        self.assertFalse(TabularMSA([], metadata={}).has_metadata())
-
-        self.assertTrue(TabularMSA([], metadata={'': ''}).has_metadata())
-        self.assertTrue(TabularMSA([], metadata={'foo': 42}).has_metadata())
 
     def test_has_keys(self):
         self.assertFalse(TabularMSA([]).has_keys())

--- a/skbio/sequence/_sequence.py
+++ b/skbio/sequence/_sequence.py
@@ -671,7 +671,7 @@ class Sequence(MetadataMixin, collections.Sequence, SkbioObject):
 
             self._set_bytes(sequence)
 
-        super(Sequence, self).__init__(metadata=metadata)
+        MetadataMixin.__init__(self, metadata=metadata)
 
         if positional_metadata is None:
             self._positional_metadata = None
@@ -808,7 +808,7 @@ class Sequence(MetadataMixin, collections.Sequence, SkbioObject):
         if self.__class__ != other.__class__:
             return False
 
-        if not super(Sequence, self).__eq__(other):
+        if not MetadataMixin.__eq__(self, other):
             return False
 
         if self._string != other._string:

--- a/skbio/sequence/_sequence.py
+++ b/skbio/sequence/_sequence.py
@@ -671,7 +671,7 @@ class Sequence(MetadataMixin, collections.Sequence, SkbioObject):
 
             self._set_bytes(sequence)
 
-        super().__init__(metadata=metadata)
+        super(Sequence, self).__init__(metadata=metadata)
 
         if positional_metadata is None:
             self._positional_metadata = None
@@ -808,7 +808,7 @@ class Sequence(MetadataMixin, collections.Sequence, SkbioObject):
         if self.__class__ != other.__class__:
             return False
 
-        if not super().__eq__(other):
+        if not super(Sequence, self).__eq__(other):
             return False
 
         if self._string != other._string:

--- a/skbio/sequence/_sequence.py
+++ b/skbio/sequence/_sequence.py
@@ -22,12 +22,12 @@ from scipy.spatial.distance import hamming
 
 import pandas as pd
 
-from skbio._base import SkbioObject
+from skbio._base import SkbioObject, MetadataMixin
 from skbio.sequence._repr import _SequenceReprBuilder
 from skbio.util._decorator import stable, experimental
 
 
-class Sequence(collections.Sequence, SkbioObject):
+class Sequence(MetadataMixin, collections.Sequence, SkbioObject):
     """Store biological sequence data and optional associated metadata.
 
     ``Sequence`` objects do not enforce an alphabet and are thus the most
@@ -346,81 +346,6 @@ class Sequence(collections.Sequence, SkbioObject):
 
     @property
     @stable(as_of="0.4.0")
-    def metadata(self):
-        """``dict`` containing metadata which applies to the entire sequence.
-
-        Notes
-        -----
-        This property can be set and deleted.
-
-        Examples
-        --------
-        >>> from pprint import pprint
-        >>> from skbio import Sequence
-
-        Create a sequence with metadata:
-
-        >>> s = Sequence('ACGTACGTACGTACGT',
-        ...              metadata={'id': 'seq-id',
-        ...                        'description': 'seq description'})
-        >>> s
-        Sequence
-        ------------------------------------
-        Metadata:
-            'description': 'seq description'
-            'id': 'seq-id'
-        Stats:
-            length: 16
-        ------------------------------------
-        0 ACGTACGTAC GTACGT
-
-        Retrieve metadata:
-
-        >>> pprint(s.metadata) # using pprint to display dict in sorted order
-        {'description': 'seq description', 'id': 'seq-id'}
-
-        Update metadata:
-
-        >>> s.metadata['id'] = 'new-id'
-        >>> s.metadata['pubmed'] = 12345
-        >>> pprint(s.metadata)
-        {'description': 'seq description', 'id': 'new-id', 'pubmed': 12345}
-
-        Set metadata:
-
-        >>> s.metadata = {'abc': 123}
-        >>> s.metadata
-        {'abc': 123}
-
-        Delete metadata:
-
-        >>> s.has_metadata()
-        True
-        >>> del s.metadata
-        >>> s.metadata
-        {}
-        >>> s.has_metadata()
-        False
-
-        """
-        if self._metadata is None:
-            # not using setter to avoid copy
-            self._metadata = {}
-        return self._metadata
-
-    @metadata.setter
-    def metadata(self, metadata):
-        if not isinstance(metadata, dict):
-            raise TypeError("metadata must be a dict")
-        # shallow copy
-        self._metadata = metadata.copy()
-
-    @metadata.deleter
-    def metadata(self):
-        self._metadata = None
-
-    @property
-    @stable(as_of="0.4.0")
     def positional_metadata(self):
         """``pd.DataFrame`` containing metadata on a per-character basis.
 
@@ -692,7 +617,6 @@ class Sequence(collections.Sequence, SkbioObject):
     @stable(as_of="0.4.0")
     def __init__(self, sequence, metadata=None, positional_metadata=None,
                  lowercase=False):
-
         if isinstance(sequence, np.ndarray):
             if sequence.dtype == np.uint8:
                 self._set_bytes_contiguous(sequence)
@@ -747,10 +671,7 @@ class Sequence(collections.Sequence, SkbioObject):
 
             self._set_bytes(sequence)
 
-        if metadata is None:
-            self._metadata = None
-        else:
-            self.metadata = metadata
+        super().__init__(metadata=metadata)
 
         if positional_metadata is None:
             self._positional_metadata = None
@@ -887,18 +808,7 @@ class Sequence(collections.Sequence, SkbioObject):
         if self.__class__ != other.__class__:
             return False
 
-        # we're not simply comparing self.metadata to other.metadata in order
-        # to avoid creating "empty" metadata representations on the sequence
-        # objects if they don't have metadata. same strategy is used below for
-        # positional metadata
-        if self.has_metadata() and other.has_metadata():
-            if self.metadata != other.metadata:
-                return False
-        elif not (self.has_metadata() or other.has_metadata()):
-            # both don't have metadata
-            pass
-        else:
-            # one has metadata while the other does not
+        if not super().__eq__(other):
             return False
 
         if self._string != other._string:
@@ -1339,28 +1249,6 @@ class Sequence(collections.Sequence, SkbioObject):
 
         """
         return self._copy(True, memo)
-
-    @stable(as_of="0.4.0")
-    def has_metadata(self):
-        """Determine if the sequence contains metadata.
-
-        Returns
-        -------
-        bool
-            Indicates whether the sequence has metadata
-
-        Examples
-        --------
-        >>> from skbio import DNA
-        >>> s = DNA('ACACGACGTT')
-        >>> s.has_metadata()
-        False
-        >>> t = DNA('ACACGACGTT', metadata={'id': 'seq-id'})
-        >>> t.has_metadata()
-        True
-
-        """
-        return self._metadata is not None and bool(self.metadata)
 
     @stable(as_of="0.4.0")
     def has_positional_metadata(self):

--- a/skbio/sequence/tests/test_sequence.py
+++ b/skbio/sequence/tests/test_sequence.py
@@ -58,7 +58,7 @@ class TestSequence(TestCase, ReallyEqualMixin, MetadataMixinTests):
             np.array([]),
             np.array([], dtype=int)]
 
-        self.constructor = functools.partial(Sequence, '')
+        self._metadata_constructor_ = functools.partial(Sequence, '')
 
     def test_concat_bad_how(self):
         seq1 = seq2 = Sequence("123")

--- a/skbio/sequence/tests/test_sequence.py
+++ b/skbio/sequence/tests/test_sequence.py
@@ -11,6 +11,7 @@ import six
 from six.moves import zip_longest
 
 import copy
+import functools
 import re
 from types import GeneratorType
 from collections import Hashable
@@ -24,6 +25,7 @@ from skbio import Sequence
 from skbio.util import assert_data_frame_almost_equal
 from skbio.sequence._sequence import (_single_index_to_slice, _is_single_index,
                                       _as_slice_if_single_index)
+from skbio.util._testing import ReallyEqualMixin, MetadataMixinTests
 
 
 class SequenceSubclass(Sequence):
@@ -36,7 +38,7 @@ class SequenceSubclassTwo(Sequence):
     pass
 
 
-class TestSequence(TestCase):
+class TestSequence(TestCase, ReallyEqualMixin, MetadataMixinTests):
     def setUp(self):
         self.lowercase_seq = Sequence('AAAAaaaa', lowercase='key')
         self.sequence_kinds = frozenset([
@@ -55,6 +57,8 @@ class TestSequence(TestCase):
             # ndarray of implicit float dtype
             np.array([]),
             np.array([], dtype=int)]
+
+        self.constructor = functools.partial(Sequence, '')
 
     def test_concat_bad_how(self):
         seq1 = seq2 = Sequence("123")
@@ -190,16 +194,13 @@ class TestSequence(TestCase):
             seq.positional_metadata,
             pd.DataFrame({'quality': range(11)}, index=np.arange(11)))
 
-    def test_init_handles_missing_metadata_efficiently(self):
-        seq = Sequence('ACGT')
+    def test_init_handles_missing_positional_metadata_efficiently(self):
+        self.assertIsNone(Sequence('ACGT')._positional_metadata)
 
-        # metadata attributes should be None and not initialized to a "missing"
-        # representation
-        self.assertIsNone(seq._metadata)
-        self.assertIsNone(seq._positional_metadata)
-
+    def test_init_from_sequence_handles_missing_metadata_efficiently(self):
         # initializing from an existing Sequence object should handle metadata
         # attributes efficiently on both objects
+        seq = Sequence('ACGT')
         new_seq = Sequence(seq)
         self.assertIsNone(seq._metadata)
         self.assertIsNone(seq._positional_metadata)
@@ -377,44 +378,6 @@ class TestSequence(TestCase):
         with self.assertRaises(ValueError):
             bytes[1] = 42
 
-    def test_init_empty_metadata(self):
-        for empty in None, {}:
-            seq = Sequence('', metadata=empty)
-
-            self.assertFalse(seq.has_metadata())
-            self.assertEqual(seq.metadata, {})
-
-    def test_init_empty_metadata_key(self):
-        seq = Sequence('', metadata={'': ''})
-
-        self.assertTrue(seq.has_metadata())
-        self.assertEqual(seq.metadata, {'': ''})
-
-    def test_init_empty_metadata_item(self):
-        seq = Sequence('', metadata={'foo': ''})
-
-        self.assertTrue(seq.has_metadata())
-        self.assertEqual(seq.metadata, {'foo': ''})
-
-    def test_init_single_character_metadata_item(self):
-        seq = Sequence('', metadata={'foo': 'z'})
-
-        self.assertTrue(seq.has_metadata())
-        self.assertEqual(seq.metadata, {'foo': 'z'})
-
-    def test_init_multiple_character_metadata_item(self):
-        seq = Sequence('', metadata={'foo': '\nabc\tdef  G123'})
-
-        self.assertTrue(seq.has_metadata())
-        self.assertEqual(seq.metadata, {'foo': '\nabc\tdef  G123'})
-
-    def test_init_metadata_multiple_keys(self):
-        seq = Sequence('', metadata={'foo': 'abc', 42: {'nested': 'metadata'}})
-
-        self.assertTrue(seq.has_metadata())
-        self.assertEqual(seq.metadata,
-                         {'foo': 'abc', 42: {'nested': 'metadata'}})
-
     def test_init_empty_positional_metadata(self):
         # empty seq with missing/empty positional metadata
         for empty in None, {}, pd.DataFrame():
@@ -541,12 +504,6 @@ class TestSequence(TestCase):
         with self.assertRaises(UnicodeEncodeError):
             Sequence(u'abc\u1F30')
 
-    def test_init_invalid_metadata(self):
-        for md in (0, 'a', ('f', 'o', 'o'), np.array([]), pd.DataFrame()):
-            with six.assertRaisesRegex(self, TypeError,
-                                       'metadata must be a dict'):
-                Sequence('abc', metadata=md)
-
     def test_init_invalid_positional_metadata(self):
         # not consumable by Pandas
         with six.assertRaisesRegex(self, TypeError,
@@ -600,105 +557,6 @@ class TestSequence(TestCase):
         # test that we can't set the property
         with self.assertRaises(AttributeError):
             seq.values = np.array("GGGG", dtype='c')
-
-    def test_metadata_property_getter(self):
-        md = {'foo': 'bar'}
-        seq = Sequence('', metadata=md)
-        self.assertIsInstance(seq.metadata, dict)
-        self.assertEqual(seq.metadata, md)
-        self.assertIsNot(seq.metadata, md)
-
-        # update existing key
-        seq.metadata['foo'] = 'baz'
-        self.assertEqual(seq.metadata, {'foo': 'baz'})
-
-        # add new key
-        seq.metadata['foo2'] = 'bar2'
-        self.assertEqual(seq.metadata, {'foo': 'baz', 'foo2': 'bar2'})
-
-    def test_metadata_property_getter_missing(self):
-        seq = Sequence('ACGT')
-
-        self.assertIsNone(seq._metadata)
-        self.assertEqual(seq.metadata, {})
-        self.assertIsNotNone(seq._metadata)
-
-    def test_metadata_property_setter(self):
-        md = {'foo': 'bar'}
-        seq = Sequence('', metadata=md)
-        self.assertEqual(seq.metadata, md)
-        self.assertIsNot(seq.metadata, md)
-
-        new_md = {'bar': 'baz', 42: 42}
-        seq.metadata = new_md
-        self.assertEqual(seq.metadata, new_md)
-        self.assertIsNot(seq.metadata, new_md)
-
-        seq.metadata = {}
-        self.assertEqual(seq.metadata, {})
-        self.assertFalse(seq.has_metadata())
-
-    def test_metadata_property_setter_invalid_type(self):
-        seq = Sequence('abc', metadata={123: 456})
-
-        for md in (None, 0, 'a', ('f', 'o', 'o'), np.array([]),
-                   pd.DataFrame()):
-            with six.assertRaisesRegex(self, TypeError,
-                                       'metadata must be a dict'):
-                seq.metadata = md
-
-            # object should still be usable and its original metadata shouldn't
-            # have changed
-            self.assertEqual(seq.metadata, {123: 456})
-
-    def test_metadata_property_deleter(self):
-        md = {'foo': 'bar'}
-        seq = Sequence('CAT', metadata=md)
-        self.assertTrue(seq.has_metadata())
-        self.assertEqual(seq.metadata, md)
-        self.assertIsNot(seq.metadata, md)
-
-        del seq.metadata
-        self.assertIsNone(seq._metadata)
-        self.assertFalse(seq.has_metadata())
-        self.assertEqual(seq.metadata, {})
-
-        # test deleting again
-        del seq.metadata
-        self.assertIsNone(seq._metadata)
-        self.assertFalse(seq.has_metadata())
-        self.assertEqual(seq.metadata, {})
-
-        # test deleting missing metadata immediately after instantiation
-        seq = Sequence('ACGT')
-        self.assertIsNone(seq._metadata)
-        del seq.metadata
-        self.assertIsNone(seq._metadata)
-
-    def test_metadata_property_shallow_copy(self):
-        md = {'key1': 'val1', 'key2': 'val2', 'key3': [1, 2]}
-        seq = Sequence('CAT', metadata=md)
-
-        self.assertTrue(seq.has_metadata())
-        self.assertEqual(seq.metadata, md)
-        self.assertIsNot(seq.metadata, md)
-
-        # updates to keys
-        seq.metadata['key1'] = 'new val'
-        self.assertEqual(seq.metadata,
-                         {'key1': 'new val', 'key2': 'val2', 'key3': [1, 2]})
-        # original metadata untouched
-        self.assertEqual(md, {'key1': 'val1', 'key2': 'val2', 'key3': [1, 2]})
-
-        # updates to mutable value (by reference)
-        seq.metadata['key3'].append(3)
-        self.assertEqual(
-            seq.metadata,
-            {'key1': 'new val', 'key2': 'val2', 'key3': [1, 2, 3]})
-        # original metadata changed because we didn't deep copy
-        self.assertEqual(
-            md,
-            {'key1': 'val1', 'key2': 'val2', 'key3': [1, 2, 3]})
 
     def test_positional_metadata_property_getter(self):
         md = pd.DataFrame({'foo': [22, 22, 0]})
@@ -969,17 +827,6 @@ class TestSequence(TestCase):
         seq2 = SequenceSubclass('ACGT')
         self.assertFalse(seq1 == seq2)
 
-    def test_eq_metadata_mismatch(self):
-        # both provided
-        seq1 = Sequence('ACGT', metadata={'id': 'foo'})
-        seq2 = Sequence('ACGT', metadata={'id': 'bar'})
-        self.assertFalse(seq1 == seq2)
-
-        # one provided
-        seq1 = Sequence('ACGT', metadata={'id': 'foo'})
-        seq2 = Sequence('ACGT')
-        self.assertFalse(seq1 == seq2)
-
     def test_eq_positional_metadata_mismatch(self):
         # both provided
         seq1 = Sequence('ACGT', positional_metadata={'quality': [1, 2, 3, 4]})
@@ -996,16 +843,12 @@ class TestSequence(TestCase):
         seq2 = Sequence('TGCA')
         self.assertFalse(seq1 == seq2)
 
-    def test_eq_handles_missing_metadata_efficiently(self):
+    def test_eq_handles_missing_positional_metadata_efficiently(self):
         seq1 = Sequence('ACGT')
         seq2 = Sequence('ACGT')
         self.assertTrue(seq1 == seq2)
 
-        # metadata attributes should be None and not initialized to a "missing"
-        # representation
-        self.assertIsNone(seq1._metadata)
         self.assertIsNone(seq1._positional_metadata)
-        self.assertIsNone(seq2._metadata)
         self.assertIsNone(seq2._positional_metadata)
 
     def test_getitem_gives_new_sequence(self):
@@ -2389,22 +2232,6 @@ class TestSequence(TestCase):
             exp = [Sequence("89ab")]
             obs = s.iter_contiguous(c(contiguous()), invert=True)
             self.assertEqual(list(obs), exp)
-
-    def test_has_metadata(self):
-        # truly missing
-        seq = Sequence('ACGT')
-        self.assertFalse(seq.has_metadata())
-        # metadata attribute should be None and not initialized to a "missing"
-        # representation
-        self.assertIsNone(seq._metadata)
-
-        # looks empty
-        seq = Sequence('ACGT', metadata={})
-        self.assertFalse(seq.has_metadata())
-
-        # metadata is present
-        seq = Sequence('ACGT', metadata={'foo': 42})
-        self.assertTrue(seq.has_metadata())
 
     def test_has_positional_metadata(self):
         # truly missing

--- a/skbio/tests/test_base.py
+++ b/skbio/tests/test_base.py
@@ -36,7 +36,7 @@ class TestSkbioObject(unittest.TestCase):
 class TestMetadataMixin(unittest.TestCase, ReallyEqualMixin,
                         MetadataMixinTests):
     def setUp(self):
-        self.constructor = MetadataMixin
+        self._metadata_constructor_ = MetadataMixin
 
 
 class TestOrdinationResults(unittest.TestCase):

--- a/skbio/tests/test_base.py
+++ b/skbio/tests/test_base.py
@@ -20,7 +20,8 @@ from IPython.core.display import Image, SVG
 from nose.tools import assert_is_instance, assert_true
 
 from skbio import OrdinationResults
-from skbio._base import SkbioObject
+from skbio._base import SkbioObject, MetadataMixin
+from skbio.util._testing import ReallyEqualMixin, MetadataMixinTests
 
 
 class TestSkbioObject(unittest.TestCase):
@@ -30,6 +31,12 @@ class TestSkbioObject(unittest.TestCase):
 
         with self.assertRaises(TypeError):
             Foo()
+
+
+class TestMetadataMixin(unittest.TestCase, ReallyEqualMixin,
+                        MetadataMixinTests):
+    def setUp(self):
+        self.constructor = MetadataMixin
 
 
 class TestOrdinationResults(unittest.TestCase):

--- a/skbio/util/_testing.py
+++ b/skbio/util/_testing.py
@@ -12,6 +12,8 @@ from future.utils import PY3
 import os
 import inspect
 
+import six
+import pandas as pd
 import pandas.util.testing as pdt
 from nose import core
 from nose.tools import nottest
@@ -64,6 +66,167 @@ class ReallyEqualMixin(object):
         if not PY3:
             self.assertNotEqual(0, cmp(a, b))  # noqa
             self.assertNotEqual(0, cmp(b, a))  # noqa
+
+
+class MetadataMixinTests(object):
+    def test_constructor_invalid_type(self):
+        for md in (0, 'a', ('f', 'o', 'o'), np.array([]), pd.DataFrame()):
+            with six.assertRaisesRegex(self, TypeError,
+                                       'metadata must be a dict'):
+                self.constructor(metadata=md)
+
+    def test_constructor_no_metadata(self):
+        for md in None, {}:
+            obj = self.constructor(metadata=md)
+
+            self.assertFalse(obj.has_metadata())
+            self.assertEqual(obj.metadata, {})
+
+    def test_constructor_with_metadata(self):
+        obj = self.constructor(metadata={'foo': 'bar'})
+        self.assertEqual(obj.metadata, {'foo': 'bar'})
+
+        obj = self.constructor(metadata={'': '', 123: {'a': 'b', 'c': 'd'}})
+        self.assertEqual(obj.metadata, {'': '', 123: {'a': 'b', 'c': 'd'}})
+
+    def test_constructor_handles_missing_metadata_efficiently(self):
+        self.assertIsNone(self.constructor()._metadata)
+        self.assertIsNone(self.constructor(metadata=None)._metadata)
+
+    def test_constructor_makes_shallow_copy_of_metadata(self):
+        md = {'foo': 'bar', 42: []}
+        obj = self.constructor(metadata=md)
+
+        self.assertEqual(obj.metadata, md)
+        self.assertIsNot(obj.metadata, md)
+
+        md['foo'] = 'baz'
+        self.assertEqual(obj.metadata, {'foo': 'bar', 42: []})
+
+        md[42].append(True)
+        self.assertEqual(obj.metadata, {'foo': 'bar', 42: [True]})
+
+    def test_eq(self):
+        self.assertReallyEqual(self.constructor(metadata={'foo': 42}),
+                               self.constructor(metadata={'foo': 42}))
+
+        self.assertReallyEqual(self.constructor(metadata={'foo': 42, 123: {}}),
+                               self.constructor(metadata={'foo': 42, 123: {}}))
+
+    def test_eq_missing_metadata(self):
+        self.assertReallyEqual(self.constructor(), self.constructor())
+        self.assertReallyEqual(self.constructor(),
+                               self.constructor(metadata={}))
+        self.assertReallyEqual(self.constructor(metadata={}),
+                               self.constructor(metadata={}))
+
+    def test_eq_handles_missing_metadata_efficiently(self):
+        obj1 = self.constructor()
+        obj2 = self.constructor()
+        self.assertReallyEqual(obj1, obj2)
+
+        self.assertIsNone(obj1._metadata)
+        self.assertIsNone(obj2._metadata)
+
+    def test_ne(self):
+        # Both have metadata.
+        obj1 = self.constructor(metadata={'id': 'foo'})
+        obj2 = self.constructor(metadata={'id': 'bar'})
+        self.assertReallyNotEqual(obj1, obj2)
+
+        # One has metadata.
+        obj1 = self.constructor(metadata={'id': 'foo'})
+        obj2 = self.constructor()
+        self.assertReallyNotEqual(obj1, obj2)
+
+    def test_metadata_getter(self):
+        obj = self.constructor(metadata={42: 'foo', ('hello', 'world'): 43})
+
+        self.assertIsInstance(obj.metadata, dict)
+        self.assertEqual(obj.metadata, {42: 'foo', ('hello', 'world'): 43})
+
+        obj.metadata[42] = 'bar'
+        self.assertEqual(obj.metadata, {42: 'bar', ('hello', 'world'): 43})
+
+    def test_metadata_getter_no_metadata(self):
+        obj = self.constructor()
+
+        self.assertIsNone(obj._metadata)
+        self.assertIsInstance(obj.metadata, dict)
+        self.assertEqual(obj.metadata, {})
+        self.assertIsNotNone(obj._metadata)
+
+    def test_metadata_setter(self):
+        obj = self.constructor()
+
+        self.assertFalse(obj.has_metadata())
+
+        obj.metadata = {'hello': 'world'}
+        self.assertTrue(obj.has_metadata())
+        self.assertEqual(obj.metadata, {'hello': 'world'})
+
+        obj.metadata = {}
+        self.assertFalse(obj.has_metadata())
+        self.assertEqual(obj.metadata, {})
+
+    def test_metadata_setter_makes_shallow_copy(self):
+        obj = self.constructor()
+
+        md = {'foo': 'bar', 42: []}
+        obj.metadata = md
+
+        self.assertEqual(obj.metadata, md)
+        self.assertIsNot(obj.metadata, md)
+
+        md['foo'] = 'baz'
+        self.assertEqual(obj.metadata, {'foo': 'bar', 42: []})
+
+        md[42].append(True)
+        self.assertEqual(obj.metadata, {'foo': 'bar', 42: [True]})
+
+    def test_metadata_setter_invalid_type(self):
+        obj = self.constructor(metadata={123: 456})
+
+        for md in (None, 0, 'a', ('f', 'o', 'o'), np.array([]),
+                   pd.DataFrame()):
+            with six.assertRaisesRegex(self, TypeError,
+                                       'metadata must be a dict'):
+                obj.metadata = md
+            self.assertEqual(obj.metadata, {123: 456})
+
+    def test_metadata_deleter(self):
+        obj = self.constructor(metadata={'foo': 'bar'})
+
+        self.assertEqual(obj.metadata, {'foo': 'bar'})
+
+        del obj.metadata
+        self.assertIsNone(obj._metadata)
+        self.assertFalse(obj.has_metadata())
+
+        # Delete again.
+        del obj.metadata
+        self.assertIsNone(obj._metadata)
+        self.assertFalse(obj.has_metadata())
+
+        obj = self.constructor()
+
+        self.assertIsNone(obj._metadata)
+        self.assertFalse(obj.has_metadata())
+        del obj.metadata
+        self.assertIsNone(obj._metadata)
+        self.assertFalse(obj.has_metadata())
+
+    def test_has_metadata(self):
+        obj = self.constructor()
+
+        self.assertFalse(obj.has_metadata())
+        # Handles metadata efficiently.
+        self.assertIsNone(obj._metadata)
+
+        self.assertFalse(self.constructor(metadata={}).has_metadata())
+
+        self.assertTrue(self.constructor(metadata={'': ''}).has_metadata())
+        self.assertTrue(self.constructor(metadata={'foo': 42}).has_metadata())
 
 
 @nottest

--- a/skbio/util/_testing.py
+++ b/skbio/util/_testing.py
@@ -73,29 +73,30 @@ class MetadataMixinTests(object):
         for md in (0, 'a', ('f', 'o', 'o'), np.array([]), pd.DataFrame()):
             with six.assertRaisesRegex(self, TypeError,
                                        'metadata must be a dict'):
-                self.constructor(metadata=md)
+                self._metadata_constructor_(metadata=md)
 
     def test_constructor_no_metadata(self):
         for md in None, {}:
-            obj = self.constructor(metadata=md)
+            obj = self._metadata_constructor_(metadata=md)
 
             self.assertFalse(obj.has_metadata())
             self.assertEqual(obj.metadata, {})
 
     def test_constructor_with_metadata(self):
-        obj = self.constructor(metadata={'foo': 'bar'})
+        obj = self._metadata_constructor_(metadata={'foo': 'bar'})
         self.assertEqual(obj.metadata, {'foo': 'bar'})
 
-        obj = self.constructor(metadata={'': '', 123: {'a': 'b', 'c': 'd'}})
+        obj = self._metadata_constructor_(
+                metadata={'': '', 123: {'a': 'b', 'c': 'd'}})
         self.assertEqual(obj.metadata, {'': '', 123: {'a': 'b', 'c': 'd'}})
 
     def test_constructor_handles_missing_metadata_efficiently(self):
-        self.assertIsNone(self.constructor()._metadata)
-        self.assertIsNone(self.constructor(metadata=None)._metadata)
+        self.assertIsNone(self._metadata_constructor_()._metadata)
+        self.assertIsNone(self._metadata_constructor_(metadata=None)._metadata)
 
     def test_constructor_makes_shallow_copy_of_metadata(self):
         md = {'foo': 'bar', 42: []}
-        obj = self.constructor(metadata=md)
+        obj = self._metadata_constructor_(metadata=md)
 
         self.assertEqual(obj.metadata, md)
         self.assertIsNot(obj.metadata, md)
@@ -107,22 +108,25 @@ class MetadataMixinTests(object):
         self.assertEqual(obj.metadata, {'foo': 'bar', 42: [True]})
 
     def test_eq(self):
-        self.assertReallyEqual(self.constructor(metadata={'foo': 42}),
-                               self.constructor(metadata={'foo': 42}))
+        self.assertReallyEqual(
+                self._metadata_constructor_(metadata={'foo': 42}),
+                self._metadata_constructor_(metadata={'foo': 42}))
 
-        self.assertReallyEqual(self.constructor(metadata={'foo': 42, 123: {}}),
-                               self.constructor(metadata={'foo': 42, 123: {}}))
+        self.assertReallyEqual(
+                self._metadata_constructor_(metadata={'foo': 42, 123: {}}),
+                self._metadata_constructor_(metadata={'foo': 42, 123: {}}))
 
     def test_eq_missing_metadata(self):
-        self.assertReallyEqual(self.constructor(), self.constructor())
-        self.assertReallyEqual(self.constructor(),
-                               self.constructor(metadata={}))
-        self.assertReallyEqual(self.constructor(metadata={}),
-                               self.constructor(metadata={}))
+        self.assertReallyEqual(self._metadata_constructor_(),
+                               self._metadata_constructor_())
+        self.assertReallyEqual(self._metadata_constructor_(),
+                               self._metadata_constructor_(metadata={}))
+        self.assertReallyEqual(self._metadata_constructor_(metadata={}),
+                               self._metadata_constructor_(metadata={}))
 
     def test_eq_handles_missing_metadata_efficiently(self):
-        obj1 = self.constructor()
-        obj2 = self.constructor()
+        obj1 = self._metadata_constructor_()
+        obj2 = self._metadata_constructor_()
         self.assertReallyEqual(obj1, obj2)
 
         self.assertIsNone(obj1._metadata)
@@ -130,17 +134,18 @@ class MetadataMixinTests(object):
 
     def test_ne(self):
         # Both have metadata.
-        obj1 = self.constructor(metadata={'id': 'foo'})
-        obj2 = self.constructor(metadata={'id': 'bar'})
+        obj1 = self._metadata_constructor_(metadata={'id': 'foo'})
+        obj2 = self._metadata_constructor_(metadata={'id': 'bar'})
         self.assertReallyNotEqual(obj1, obj2)
 
         # One has metadata.
-        obj1 = self.constructor(metadata={'id': 'foo'})
-        obj2 = self.constructor()
+        obj1 = self._metadata_constructor_(metadata={'id': 'foo'})
+        obj2 = self._metadata_constructor_()
         self.assertReallyNotEqual(obj1, obj2)
 
     def test_metadata_getter(self):
-        obj = self.constructor(metadata={42: 'foo', ('hello', 'world'): 43})
+        obj = self._metadata_constructor_(
+                metadata={42: 'foo', ('hello', 'world'): 43})
 
         self.assertIsInstance(obj.metadata, dict)
         self.assertEqual(obj.metadata, {42: 'foo', ('hello', 'world'): 43})
@@ -149,7 +154,7 @@ class MetadataMixinTests(object):
         self.assertEqual(obj.metadata, {42: 'bar', ('hello', 'world'): 43})
 
     def test_metadata_getter_no_metadata(self):
-        obj = self.constructor()
+        obj = self._metadata_constructor_()
 
         self.assertIsNone(obj._metadata)
         self.assertIsInstance(obj.metadata, dict)
@@ -157,7 +162,7 @@ class MetadataMixinTests(object):
         self.assertIsNotNone(obj._metadata)
 
     def test_metadata_setter(self):
-        obj = self.constructor()
+        obj = self._metadata_constructor_()
 
         self.assertFalse(obj.has_metadata())
 
@@ -170,7 +175,7 @@ class MetadataMixinTests(object):
         self.assertEqual(obj.metadata, {})
 
     def test_metadata_setter_makes_shallow_copy(self):
-        obj = self.constructor()
+        obj = self._metadata_constructor_()
 
         md = {'foo': 'bar', 42: []}
         obj.metadata = md
@@ -185,7 +190,7 @@ class MetadataMixinTests(object):
         self.assertEqual(obj.metadata, {'foo': 'bar', 42: [True]})
 
     def test_metadata_setter_invalid_type(self):
-        obj = self.constructor(metadata={123: 456})
+        obj = self._metadata_constructor_(metadata={123: 456})
 
         for md in (None, 0, 'a', ('f', 'o', 'o'), np.array([]),
                    pd.DataFrame()):
@@ -195,7 +200,7 @@ class MetadataMixinTests(object):
             self.assertEqual(obj.metadata, {123: 456})
 
     def test_metadata_deleter(self):
-        obj = self.constructor(metadata={'foo': 'bar'})
+        obj = self._metadata_constructor_(metadata={'foo': 'bar'})
 
         self.assertEqual(obj.metadata, {'foo': 'bar'})
 
@@ -208,7 +213,7 @@ class MetadataMixinTests(object):
         self.assertIsNone(obj._metadata)
         self.assertFalse(obj.has_metadata())
 
-        obj = self.constructor()
+        obj = self._metadata_constructor_()
 
         self.assertIsNone(obj._metadata)
         self.assertFalse(obj.has_metadata())
@@ -217,16 +222,20 @@ class MetadataMixinTests(object):
         self.assertFalse(obj.has_metadata())
 
     def test_has_metadata(self):
-        obj = self.constructor()
+        obj = self._metadata_constructor_()
 
         self.assertFalse(obj.has_metadata())
         # Handles metadata efficiently.
         self.assertIsNone(obj._metadata)
 
-        self.assertFalse(self.constructor(metadata={}).has_metadata())
+        self.assertFalse(
+                self._metadata_constructor_(metadata={}).has_metadata())
 
-        self.assertTrue(self.constructor(metadata={'': ''}).has_metadata())
-        self.assertTrue(self.constructor(metadata={'foo': 42}).has_metadata())
+        self.assertTrue(
+                self._metadata_constructor_(metadata={'': ''}).has_metadata())
+        self.assertTrue(
+                self._metadata_constructor_(
+                        metadata={'foo': 42}).has_metadata())
 
 
 @nottest


### PR DESCRIPTION
We were duplicating code on ``Sequence`` and ``TabularMSA`` to support arbitrary metadata. Most, if not all, classes in scikit-bio will eventually support metadata so this refactoring will avoid further code duplication as the project grows.

This commit adds a private mixin ``skbio._base.MetadataMixin`` which centralizes the following metadata logic:

- `metadata` property (getter, setter, deleter)
- `has_metadata` method
- metadata handling in `__init__`
- metadata handling in `__eq__`/`__ne__`

Additionally, a private unit test mixin `skbio.util._testing.MetadataMixinTests` is used to test `MetadataMixin`, `Sequence`, and `TabularMSA`, avoiding redundant unit tests and ensuring that metadata API and behavior is consistent across classes.