### PR TITLE
ENH: add TabularMSA.gap_frequencies

### DIFF
--- a/skbio/alignment/_tabular_msa.py
+++ b/skbio/alignment/_tabular_msa.py
@@ -11,7 +11,7 @@ from __future__ import absolute_import, division, print_function
 import collections
 import operator
 
-from future.builtins import zip
+from future.builtins import zip, range
 from future.utils import viewkeys, viewvalues
 import numpy as np
 
@@ -561,6 +561,95 @@ class TabularMSA(SkbioObject):
 
         """
         return not (self == other)
+
+    @experimental(as_of='0.4.0-dev')
+    def gap_frequencies(self, axis='position', relative=False):
+        """Compute frequency of gap characters along an axis.
+
+        Parameters
+        ----------
+        axis : {'position', 'sequence'}, optional
+            Axis to compute gap character frequencies along. If 'position' or
+            1, frequencies are computed for each position in the MSA. If
+            'sequence' or 0, frequencies are computed for each sequence.
+        relative : bool, optional
+            If ``True``, return the relative frequency of gap characters
+            instead of the count.
+
+        Returns
+        -------
+        1D np.ndarray (int or float)
+            Vector of gap character frequencies along the specified axis. Will
+            have int dtype if ``relative=False`` and float dtype if
+            ``relative=True``.
+
+        Raises
+        ------
+        ValueError
+            If `axis` is invalid.
+
+        Notes
+        -----
+        If there are no positions in the MSA, ``axis='sequence'``, **and**
+        ``relative=True``, the relative frequency of gap characters in each
+        sequence will be ``np.nan``.
+
+        Examples
+        --------
+        Compute frequency of gap characters for each position in the MSA:
+
+        >>> from skbio import DNA, TabularMSA
+        >>> msa = TabularMSA([DNA('ACG'),
+        ...                   DNA('A--'),
+        ...                   DNA('AC.'),
+        ...                   DNA('AG.')])
+        >>> msa.gap_frequencies()
+        array([0, 1, 3])
+
+        Compute relative frequencies:
+
+        >>> msa.gap_frequencies(relative=True)
+        array([ 0.  ,  0.25,  0.75])
+
+        Compute frequency of gap characters for each sequence:
+
+        >>> msa.gap_frequencies(axis='sequence')
+        array([0, 2, 1, 1])
+
+        """
+        if axis == 'sequence' or axis == 0:
+            seq_iterator = self
+            length = self.shape.position
+        elif axis == 'position' or axis == 1:
+            # TODO: use TabularMSA.iter_positions when it is implemented
+            # (#1100).
+            seq_iterator = (self._get_position(i)
+                            for i in range(self.shape.position))
+            length = self.shape.sequence
+        else:
+            raise ValueError(
+                "`axis` must be 'sequence' (0) or 'position' (1), not %r"
+                % axis)
+
+        gap_freqs = []
+        for seq in seq_iterator:
+            # Not using Sequence.frequencies(relative=relative) because each
+            # gap character's relative frequency is computed separately and
+            # must be summed. This is less precise than summing the absolute
+            # frequencies of gap characters and dividing by the length. Likely
+            # not a big deal for typical gap characters ('-', '.') but can be
+            # problematic as the number of gap characters grows (we aren't
+            # guaranteed to always have two gap characters). See unit tests for
+            # an example.
+            freqs = seq.frequencies(chars=self.dtype.gap_chars)
+            gap_freqs.append(sum(viewvalues(freqs)))
+
+        gap_freqs = np.asarray(gap_freqs, dtype=float if relative else int)
+
+        if relative:
+            gap_freqs /= length
+
+        return gap_freqs
 
     @experimental(as_of='0.4.0-dev')
     def has_keys(self):

--- a/skbio/alignment/_tabular_msa.py
+++ b/skbio/alignment/_tabular_msa.py
@@ -563,15 +563,15 @@ class TabularMSA(SkbioObject):
         return not (self == other)
 
     @experimental(as_of='0.4.0-dev')
-    def gap_frequencies(self, axis='position', relative=False):
-        """Compute frequency of gap characters along an axis.
+    def gap_frequencies(self, axis='sequence', relative=False):
+        """Compute frequency of gap characters across an axis.
 
         Parameters
         ----------
-        axis : {'position', 'sequence'}, optional
-            Axis to compute gap character frequencies along. If 'position' or
-            1, frequencies are computed for each position in the MSA. If
-            'sequence' or 0, frequencies are computed for each sequence.
+        axis : {'sequence', 'position'}, optional
+            Axis to compute gap character frequencies across. If 'sequence' or
+            0, frequencies are computed for each position in the MSA. If
+            'position' or 1, frequencies are computed for each sequence.
         relative : bool, optional
             If ``True``, return the relative frequency of gap characters
             instead of the count.
@@ -579,8 +579,8 @@ class TabularMSA(SkbioObject):
         Returns
         -------
         1D np.ndarray (int or float)
-            Vector of gap character frequencies along the specified axis. Will
-            have int dtype if ``relative=False`` and float dtype if
+            Vector of gap character frequencies across the specified axis. Will
+            have ``int`` dtype if ``relative=False`` and ``float`` dtype if
             ``relative=True``.
 
         Raises
@@ -590,13 +590,14 @@ class TabularMSA(SkbioObject):
 
         Notes
         -----
-        If there are no positions in the MSA, ``axis='sequence'``, **and**
+        If there are no positions in the MSA, ``axis='position'``, **and**
         ``relative=True``, the relative frequency of gap characters in each
         sequence will be ``np.nan``.
 
         Examples
         --------
-        Compute frequency of gap characters for each position in the MSA:
+        Compute frequency of gap characters for each position in the MSA (i.e.,
+        *across* the sequence axis):
 
         >>> from skbio import DNA, TabularMSA
         >>> msa = TabularMSA([DNA('ACG'),
@@ -606,26 +607,27 @@ class TabularMSA(SkbioObject):
         >>> msa.gap_frequencies()
         array([0, 1, 3])
 
-        Compute relative frequencies:
+        Compute relative frequencies across the same axis:
 
         >>> msa.gap_frequencies(relative=True)
         array([ 0.  ,  0.25,  0.75])
 
-        Compute frequency of gap characters for each sequence:
+        Compute frequency of gap characters for each sequence (i.e., *across*
+        the position axis):
 
-        >>> msa.gap_frequencies(axis='sequence')
+        >>> msa.gap_frequencies(axis='position')
         array([0, 2, 1, 1])
 
         """
         if axis == 'sequence' or axis == 0:
-            seq_iterator = self
-            length = self.shape.position
-        elif axis == 'position' or axis == 1:
             # TODO: use TabularMSA.iter_positions when it is implemented
             # (#1100).
             seq_iterator = (self._get_position(i)
                             for i in range(self.shape.position))
             length = self.shape.sequence
+        elif axis == 'position' or axis == 1:
+            seq_iterator = self
+            length = self.shape.position
         else:
             raise ValueError(
                 "`axis` must be 'sequence' (0) or 'position' (1), not %r"

--- a/skbio/alignment/_tabular_msa.py
+++ b/skbio/alignment/_tabular_msa.py
@@ -540,19 +540,15 @@ class TabularMSA(MetadataMixin, SkbioObject):
         array([0, 2, 1, 1])
 
         """
-        if axis == 'sequence' or axis == 0:
+        if self._is_sequence_axis(axis):
             # TODO: use TabularMSA.iter_positions when it is implemented
             # (#1100).
             seq_iterator = (self._get_position(i)
                             for i in range(self.shape.position))
             length = self.shape.sequence
-        elif axis == 'position' or axis == 1:
+        else:
             seq_iterator = self
             length = self.shape.position
-        else:
-            raise ValueError(
-                "`axis` must be 'sequence' (0) or 'position' (1), not %r"
-                % axis)
 
         gap_freqs = []
         for seq in seq_iterator:
@@ -831,3 +827,13 @@ class TabularMSA(MetadataMixin, SkbioObject):
         # if self.has_positional_metadata():
         #     seq.metadata = dict(self.positional_metadata.iloc[i])
         return seq
+
+    def _is_sequence_axis(self, axis):
+        if axis == 'sequence' or axis == 0:
+            return True
+        elif axis == 'position' or axis == 1:
+            return False
+        else:
+            raise ValueError(
+                "`axis` must be 'sequence' (0) or 'position' (1), not %r"
+                % axis)

--- a/skbio/alignment/tests/test_tabular_msa.py
+++ b/skbio/alignment/tests/test_tabular_msa.py
@@ -1127,5 +1127,30 @@ class TestGapFrequencies(unittest.TestCase):
         npt.assert_array_equal(np.array([0, 0, 2, 4, 4]), freqs)
 
 
+class TestIsSequenceAxis(unittest.TestCase):
+    def setUp(self):
+        self.msa = TabularMSA([])
+
+    def test_invalid_str(self):
+        with six.assertRaisesRegex(self, ValueError, "axis.*'foo'"):
+            self.msa._is_sequence_axis('foo')
+
+    def test_invalid_int(self):
+        with six.assertRaisesRegex(self, ValueError, "axis.*2"):
+            self.msa._is_sequence_axis(2)
+
+    def test_positive_str(self):
+        self.assertTrue(self.msa._is_sequence_axis('sequence'))
+
+    def test_positive_int(self):
+        self.assertTrue(self.msa._is_sequence_axis(0))
+
+    def test_negative_str(self):
+        self.assertFalse(self.msa._is_sequence_axis('position'))
+
+    def test_negative_int(self):
+        self.assertFalse(self.msa._is_sequence_axis(1))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/skbio/alignment/tests/test_tabular_msa.py
+++ b/skbio/alignment/tests/test_tabular_msa.py
@@ -17,7 +17,9 @@ import pandas as pd
 import numpy.testing as npt
 
 from skbio import Sequence, DNA, RNA, Protein, TabularMSA
+from skbio.sequence._iupac_sequence import IUPACSequence
 from skbio.util import OperationError, UniqueError
+from skbio.util._decorator import classproperty, overrides
 from skbio.util._testing import ReallyEqualMixin
 
 
@@ -1013,6 +1015,244 @@ class TestTabularMSA(unittest.TestCase, ReallyEqualMixin):
         self.assertEqual(d2, d1)
         self.assertIs(d1['a'], d2['a'])
         self.assertIs(d1[42], d2[42])
+
+
+class TestGapFrequencies(unittest.TestCase):
+    def test_default_behavior(self):
+        msa = TabularMSA([DNA('AA.'),
+                          DNA('-A-')])
+
+        freqs = msa.gap_frequencies()
+
+        npt.assert_array_equal(np.array([1, 0, 2]), freqs)
+
+    def test_invalid_axis_str(self):
+        with six.assertRaisesRegex(self, ValueError, "axis.*'foo'"):
+            TabularMSA([]).gap_frequencies(axis='foo')
+
+    def test_invalid_axis_int(self):
+        with six.assertRaisesRegex(self, ValueError, "axis.*2"):
+            TabularMSA([]).gap_frequencies(axis=2)
+
+    def test_sequence_axis_str_and_int_equivalent(self):
+        msa = TabularMSA([DNA('ACGT'),
+                          DNA('A.G-'),
+                          DNA('----')])
+
+        str_freqs = msa.gap_frequencies(axis='sequence')
+        int_freqs = msa.gap_frequencies(axis=0)
+
+        npt.assert_array_equal(str_freqs, int_freqs)
+        npt.assert_array_equal(np.array([0, 2, 4]), str_freqs)
+
+    def test_position_axis_str_and_int_equivalent(self):
+        msa = TabularMSA([DNA('ACGT'),
+                          DNA('A.G-'),
+                          DNA('----')])
+
+        str_freqs = msa.gap_frequencies(axis='position')
+        int_freqs = msa.gap_frequencies(axis=1)
+
+        npt.assert_array_equal(str_freqs, int_freqs)
+        npt.assert_array_equal(np.array([1, 2, 1, 2]), str_freqs)
+
+    def test_correct_dtype_absolute_empty(self):
+        msa = TabularMSA([])
+
+        freqs = msa.gap_frequencies(axis='sequence')
+
+        npt.assert_array_equal(np.array([]), freqs)
+        self.assertEqual(int, freqs.dtype)
+
+    def test_correct_dtype_relative_empty(self):
+        msa = TabularMSA([])
+
+        freqs = msa.gap_frequencies(axis='sequence', relative=True)
+
+        npt.assert_array_equal(np.array([]), freqs)
+        self.assertEqual(float, freqs.dtype)
+
+    def test_correct_dtype_absolute_non_empty(self):
+        msa = TabularMSA([DNA('AC'),
+                          DNA('-.')])
+
+        freqs = msa.gap_frequencies(axis='sequence')
+
+        npt.assert_array_equal(np.array([0, 2]), freqs)
+        self.assertEqual(int, freqs.dtype)
+
+    def test_correct_dtype_relative_non_empty(self):
+        msa = TabularMSA([DNA('AC'),
+                          DNA('-.')])
+
+        freqs = msa.gap_frequencies(axis='sequence', relative=True)
+
+        npt.assert_array_equal(np.array([0.0, 1.0]), freqs)
+        self.assertEqual(float, freqs.dtype)
+
+    def test_no_sequences_absolute(self):
+        msa = TabularMSA([])
+
+        seq_freqs = msa.gap_frequencies(axis='sequence')
+        pos_freqs = msa.gap_frequencies(axis='position')
+
+        npt.assert_array_equal(np.array([]), seq_freqs)
+        npt.assert_array_equal(np.array([]), pos_freqs)
+
+    def test_no_sequences_relative(self):
+        msa = TabularMSA([])
+
+        seq_freqs = msa.gap_frequencies(axis='sequence', relative=True)
+        pos_freqs = msa.gap_frequencies(axis='position', relative=True)
+
+        npt.assert_array_equal(np.array([]), seq_freqs)
+        npt.assert_array_equal(np.array([]), pos_freqs)
+
+    def test_no_positions_absolute(self):
+        msa = TabularMSA([DNA('')])
+
+        seq_freqs = msa.gap_frequencies(axis='sequence')
+        pos_freqs = msa.gap_frequencies(axis='position')
+
+        npt.assert_array_equal(np.array([0]), seq_freqs)
+        npt.assert_array_equal(np.array([]), pos_freqs)
+
+    def test_no_positions_relative(self):
+        msa = TabularMSA([DNA('')])
+
+        seq_freqs = msa.gap_frequencies(axis='sequence', relative=True)
+        pos_freqs = msa.gap_frequencies(axis='position', relative=True)
+
+        npt.assert_array_equal(np.array([np.nan]), seq_freqs)
+        npt.assert_array_equal(np.array([]), pos_freqs)
+
+    def test_single_sequence_absolute(self):
+        msa = TabularMSA([DNA('.T')])
+
+        seq_freqs = msa.gap_frequencies(axis='sequence')
+        pos_freqs = msa.gap_frequencies(axis='position')
+
+        npt.assert_array_equal(np.array([1]), seq_freqs)
+        npt.assert_array_equal(np.array([1, 0]), pos_freqs)
+
+    def test_single_sequence_relative(self):
+        msa = TabularMSA([DNA('.T')])
+
+        seq_freqs = msa.gap_frequencies(axis='sequence', relative=True)
+        pos_freqs = msa.gap_frequencies(axis='position', relative=True)
+
+        npt.assert_array_equal(np.array([0.5]), seq_freqs)
+        npt.assert_array_equal(np.array([1.0, 0.0]), pos_freqs)
+
+    def test_single_position_absolute(self):
+        msa = TabularMSA([DNA('.'),
+                          DNA('T')])
+
+        seq_freqs = msa.gap_frequencies(axis='sequence')
+        pos_freqs = msa.gap_frequencies(axis='position')
+
+        npt.assert_array_equal(np.array([1, 0]), seq_freqs)
+        npt.assert_array_equal(np.array([1]), pos_freqs)
+
+    def test_single_position_relative(self):
+        msa = TabularMSA([DNA('.'),
+                          DNA('T')])
+
+        seq_freqs = msa.gap_frequencies(axis='sequence', relative=True)
+        pos_freqs = msa.gap_frequencies(axis='position', relative=True)
+
+        npt.assert_array_equal(np.array([1.0, 0.0]), seq_freqs)
+        npt.assert_array_equal(np.array([0.5]), pos_freqs)
+
+    def test_sequence_axis_absolute(self):
+        msa = TabularMSA([
+                DNA('ACGT'),   # no gaps
+                DNA('A.G-'),   # some gaps (mixed gap chars)
+                DNA('----'),   # all gaps
+                DNA('....')])  # all gaps
+
+        freqs = msa.gap_frequencies(axis='sequence')
+
+        npt.assert_array_equal(np.array([0, 2, 4, 4]), freqs)
+
+    def test_sequence_axis_relative(self):
+        msa = TabularMSA([DNA('ACGT'),
+                          DNA('A.G-'),
+                          DNA('CCC.'),
+                          DNA('----'),
+                          DNA('....')])
+
+        freqs = msa.gap_frequencies(axis='sequence', relative=True)
+
+        npt.assert_array_equal(np.array([0.0, 0.5, 0.25, 1.0, 1.0]), freqs)
+
+    def test_position_axis_absolute(self):
+        msa = TabularMSA([DNA('AC-.'),
+                          DNA('A.-.'),
+                          DNA('G--.')])
+
+        freqs = msa.gap_frequencies(axis='position')
+
+        npt.assert_array_equal(np.array([0, 2, 3, 3]), freqs)
+
+    def test_position_axis_relative(self):
+        msa = TabularMSA([DNA('AC--.'),
+                          DNA('A.A-.'),
+                          DNA('G-A-.')])
+
+        freqs = msa.gap_frequencies(axis='position', relative=True)
+
+        npt.assert_array_equal(np.array([0.0, 2/3, 1/3, 1.0, 1.0]), freqs)
+
+    def test_relative_frequencies_precise(self):
+        class CustomSequence(IUPACSequence):
+            @classproperty
+            @overrides(IUPACSequence)
+            def gap_chars(cls):
+                return set('0123456789')
+
+            @classproperty
+            @overrides(IUPACSequence)
+            def nondegenerate_chars(cls):
+                return set('')
+
+            @classproperty
+            @overrides(IUPACSequence)
+            def degenerate_map(cls):
+                return {}
+
+        msa = TabularMSA([CustomSequence('0123456789')])
+
+        freqs = msa.gap_frequencies(axis='sequence', relative=True)
+
+        npt.assert_array_equal(np.array([1.0]), freqs)
+
+    def test_custom_gap_characters(self):
+        class CustomSequence(IUPACSequence):
+            @classproperty
+            @overrides(IUPACSequence)
+            def gap_chars(cls):
+                return set('#$*')
+
+            @classproperty
+            @overrides(IUPACSequence)
+            def nondegenerate_chars(cls):
+                return set('ABC-.')
+
+            @classproperty
+            @overrides(IUPACSequence)
+            def degenerate_map(cls):
+                return {'D': 'ABC-.'}
+
+        msa = TabularMSA([CustomSequence('ABCD'),
+                          CustomSequence('-.-.'),
+                          CustomSequence('A#C*'),
+                          CustomSequence('####'),
+                          CustomSequence('$$$$')])
+
+        freqs = msa.gap_frequencies(axis='sequence')
+
+        npt.assert_array_equal(np.array([0, 0, 2, 4, 4]), freqs)
 
 
 if __name__ == "__main__":

--- a/skbio/alignment/tests/test_tabular_msa.py
+++ b/skbio/alignment/tests/test_tabular_msa.py
@@ -1034,17 +1034,6 @@ class TestGapFrequencies(unittest.TestCase):
         with six.assertRaisesRegex(self, ValueError, "axis.*2"):
             TabularMSA([]).gap_frequencies(axis=2)
 
-    def test_sequence_axis_str_and_int_equivalent(self):
-        msa = TabularMSA([DNA('ACGT'),
-                          DNA('A.G-'),
-                          DNA('----')])
-
-        str_freqs = msa.gap_frequencies(axis='sequence')
-        int_freqs = msa.gap_frequencies(axis=0)
-
-        npt.assert_array_equal(str_freqs, int_freqs)
-        npt.assert_array_equal(np.array([0, 2, 4]), str_freqs)
-
     def test_position_axis_str_and_int_equivalent(self):
         msa = TabularMSA([DNA('ACGT'),
                           DNA('A.G-'),
@@ -1054,12 +1043,23 @@ class TestGapFrequencies(unittest.TestCase):
         int_freqs = msa.gap_frequencies(axis=1)
 
         npt.assert_array_equal(str_freqs, int_freqs)
+        npt.assert_array_equal(np.array([0, 2, 4]), str_freqs)
+
+    def test_sequence_axis_str_and_int_equivalent(self):
+        msa = TabularMSA([DNA('ACGT'),
+                          DNA('A.G-'),
+                          DNA('----')])
+
+        str_freqs = msa.gap_frequencies(axis='sequence')
+        int_freqs = msa.gap_frequencies(axis=0)
+
+        npt.assert_array_equal(str_freqs, int_freqs)
         npt.assert_array_equal(np.array([1, 2, 1, 2]), str_freqs)
 
     def test_correct_dtype_absolute_empty(self):
         msa = TabularMSA([])
 
-        freqs = msa.gap_frequencies(axis='sequence')
+        freqs = msa.gap_frequencies(axis='position')
 
         npt.assert_array_equal(np.array([]), freqs)
         self.assertEqual(int, freqs.dtype)
@@ -1067,7 +1067,7 @@ class TestGapFrequencies(unittest.TestCase):
     def test_correct_dtype_relative_empty(self):
         msa = TabularMSA([])
 
-        freqs = msa.gap_frequencies(axis='sequence', relative=True)
+        freqs = msa.gap_frequencies(axis='position', relative=True)
 
         npt.assert_array_equal(np.array([]), freqs)
         self.assertEqual(float, freqs.dtype)
@@ -1076,7 +1076,7 @@ class TestGapFrequencies(unittest.TestCase):
         msa = TabularMSA([DNA('AC'),
                           DNA('-.')])
 
-        freqs = msa.gap_frequencies(axis='sequence')
+        freqs = msa.gap_frequencies(axis='position')
 
         npt.assert_array_equal(np.array([0, 2]), freqs)
         self.assertEqual(int, freqs.dtype)
@@ -1085,7 +1085,7 @@ class TestGapFrequencies(unittest.TestCase):
         msa = TabularMSA([DNA('AC'),
                           DNA('-.')])
 
-        freqs = msa.gap_frequencies(axis='sequence', relative=True)
+        freqs = msa.gap_frequencies(axis='position', relative=True)
 
         npt.assert_array_equal(np.array([0.0, 1.0]), freqs)
         self.assertEqual(float, freqs.dtype)
@@ -1114,8 +1114,8 @@ class TestGapFrequencies(unittest.TestCase):
         seq_freqs = msa.gap_frequencies(axis='sequence')
         pos_freqs = msa.gap_frequencies(axis='position')
 
-        npt.assert_array_equal(np.array([0]), seq_freqs)
-        npt.assert_array_equal(np.array([]), pos_freqs)
+        npt.assert_array_equal(np.array([]), seq_freqs)
+        npt.assert_array_equal(np.array([0]), pos_freqs)
 
     def test_no_positions_relative(self):
         msa = TabularMSA([DNA('')])
@@ -1123,8 +1123,8 @@ class TestGapFrequencies(unittest.TestCase):
         seq_freqs = msa.gap_frequencies(axis='sequence', relative=True)
         pos_freqs = msa.gap_frequencies(axis='position', relative=True)
 
-        npt.assert_array_equal(np.array([np.nan]), seq_freqs)
-        npt.assert_array_equal(np.array([]), pos_freqs)
+        npt.assert_array_equal(np.array([]), seq_freqs)
+        npt.assert_array_equal(np.array([np.nan]), pos_freqs)
 
     def test_single_sequence_absolute(self):
         msa = TabularMSA([DNA('.T')])
@@ -1132,8 +1132,8 @@ class TestGapFrequencies(unittest.TestCase):
         seq_freqs = msa.gap_frequencies(axis='sequence')
         pos_freqs = msa.gap_frequencies(axis='position')
 
-        npt.assert_array_equal(np.array([1]), seq_freqs)
-        npt.assert_array_equal(np.array([1, 0]), pos_freqs)
+        npt.assert_array_equal(np.array([1, 0]), seq_freqs)
+        npt.assert_array_equal(np.array([1]), pos_freqs)
 
     def test_single_sequence_relative(self):
         msa = TabularMSA([DNA('.T')])
@@ -1141,8 +1141,8 @@ class TestGapFrequencies(unittest.TestCase):
         seq_freqs = msa.gap_frequencies(axis='sequence', relative=True)
         pos_freqs = msa.gap_frequencies(axis='position', relative=True)
 
-        npt.assert_array_equal(np.array([0.5]), seq_freqs)
-        npt.assert_array_equal(np.array([1.0, 0.0]), pos_freqs)
+        npt.assert_array_equal(np.array([1.0, 0.0]), seq_freqs)
+        npt.assert_array_equal(np.array([0.5]), pos_freqs)
 
     def test_single_position_absolute(self):
         msa = TabularMSA([DNA('.'),
@@ -1151,8 +1151,8 @@ class TestGapFrequencies(unittest.TestCase):
         seq_freqs = msa.gap_frequencies(axis='sequence')
         pos_freqs = msa.gap_frequencies(axis='position')
 
-        npt.assert_array_equal(np.array([1, 0]), seq_freqs)
-        npt.assert_array_equal(np.array([1]), pos_freqs)
+        npt.assert_array_equal(np.array([1]), seq_freqs)
+        npt.assert_array_equal(np.array([1, 0]), pos_freqs)
 
     def test_single_position_relative(self):
         msa = TabularMSA([DNA('.'),
@@ -1161,46 +1161,46 @@ class TestGapFrequencies(unittest.TestCase):
         seq_freqs = msa.gap_frequencies(axis='sequence', relative=True)
         pos_freqs = msa.gap_frequencies(axis='position', relative=True)
 
-        npt.assert_array_equal(np.array([1.0, 0.0]), seq_freqs)
-        npt.assert_array_equal(np.array([0.5]), pos_freqs)
+        npt.assert_array_equal(np.array([0.5]), seq_freqs)
+        npt.assert_array_equal(np.array([1.0, 0.0]), pos_freqs)
 
-    def test_sequence_axis_absolute(self):
+    def test_position_axis_absolute(self):
         msa = TabularMSA([
                 DNA('ACGT'),   # no gaps
                 DNA('A.G-'),   # some gaps (mixed gap chars)
                 DNA('----'),   # all gaps
                 DNA('....')])  # all gaps
 
-        freqs = msa.gap_frequencies(axis='sequence')
+        freqs = msa.gap_frequencies(axis='position')
 
         npt.assert_array_equal(np.array([0, 2, 4, 4]), freqs)
 
-    def test_sequence_axis_relative(self):
+    def test_position_axis_relative(self):
         msa = TabularMSA([DNA('ACGT'),
                           DNA('A.G-'),
                           DNA('CCC.'),
                           DNA('----'),
                           DNA('....')])
 
-        freqs = msa.gap_frequencies(axis='sequence', relative=True)
+        freqs = msa.gap_frequencies(axis='position', relative=True)
 
         npt.assert_array_equal(np.array([0.0, 0.5, 0.25, 1.0, 1.0]), freqs)
 
-    def test_position_axis_absolute(self):
+    def test_sequence_axis_absolute(self):
         msa = TabularMSA([DNA('AC-.'),
                           DNA('A.-.'),
                           DNA('G--.')])
 
-        freqs = msa.gap_frequencies(axis='position')
+        freqs = msa.gap_frequencies(axis='sequence')
 
         npt.assert_array_equal(np.array([0, 2, 3, 3]), freqs)
 
-    def test_position_axis_relative(self):
+    def test_sequence_axis_relative(self):
         msa = TabularMSA([DNA('AC--.'),
                           DNA('A.A-.'),
                           DNA('G-A-.')])
 
-        freqs = msa.gap_frequencies(axis='position', relative=True)
+        freqs = msa.gap_frequencies(axis='sequence', relative=True)
 
         npt.assert_array_equal(np.array([0.0, 2/3, 1/3, 1.0, 1.0]), freqs)
 
@@ -1223,7 +1223,7 @@ class TestGapFrequencies(unittest.TestCase):
 
         msa = TabularMSA([CustomSequence('0123456789')])
 
-        freqs = msa.gap_frequencies(axis='sequence', relative=True)
+        freqs = msa.gap_frequencies(axis='position', relative=True)
 
         npt.assert_array_equal(np.array([1.0]), freqs)
 
@@ -1250,7 +1250,7 @@ class TestGapFrequencies(unittest.TestCase):
                           CustomSequence('####'),
                           CustomSequence('$$$$')])
 
-        freqs = msa.gap_frequencies(axis='sequence')
+        freqs = msa.gap_frequencies(axis='position')
 
         npt.assert_array_equal(np.array([0, 0, 2, 4, 4]), freqs)
 


### PR DESCRIPTION
Fixes #1089. Tried out Arrange Act Assert (#1149) for these unit tests. I like it!

This is the first method with an `axis` parameter. The RFC specifies that `'sequence'` and `0` are equivalent, likewise with `'position'` and `1`. However, our notion of `axis` differs from numpy:

```python
In [1]: import numpy as np

In [2]: a = np.array([[1,2,3], [4,5,6]])

In [3]: a
Out[3]:
array([[1, 2, 3],
       [4, 5, 6]])

In [4]: a.sum(axis=0)
Out[4]: array([5, 7, 9])

In [5]: a.sum(axis=1)
Out[5]: array([ 6, 15])

In [6]: from skbio import DNA, TabularMSA

In [7]: msa = TabularMSA([DNA('ACG'), DNA('A--')])

In [8]: msa.gap_frequencies(axis=0)
Out[8]: array([0, 2])

In [9]: msa.gap_frequencies(axis=1)
Out[9]: array([0, 1, 1])
```

Is scikit-bio's notion of `axis` correct or should we be matching numpy? Intuitively our API makes more sense to me but not matching numpy may be a mistake...