### PR TITLE
MAINT: some fixes to recent DissimilarityMatrix.to_data_frame method (#1162)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,7 @@
 ## Version 0.4.0-dev (changes since 0.4.0 release go here)
 
 ### Features
-* Added `skbio.stats.distance.to_dataframe` method to read DistanceMatrixes or DissimilarityMatrixes to a
-`pd.DataFrame`. ([#757](https://github.com/biocore/scikit-bio/issues/757#event-448597393))
+* Added `skbio.DissimilarityMatrix.to_data_frame` method for creating a ``pandas.DataFrame`` from a `DissimilarityMatrix` or `DistanceMatrix`. ([#757](https://github.com/biocore/scikit-bio/issues/757))
 * Added `skbio.io.format.blast6` for reading BLAST+ output format 6 or BLAST output format 8 files into a `pd.DataFrame`. ([#1110](https://github.com/biocore/scikit-bio/issues/1110))
 * Added `inner`, `ilr`, `ilr_inv` and `clr_inv`, ``skbio.stats.composition``, which enables linear transformations on compositions ([#892](https://github.com/biocore/scikit-bio/issues/892)
 * Added ``skbio.diversity.alpha.pielou_e`` function as an evenness metric of alpha diversity. ([#1068](https://github.com/biocore/scikit-bio/issues/1068))

--- a/skbio/io/format/tests/test_genbank.py
+++ b/skbio/io/format/tests/test_genbank.py
@@ -13,6 +13,7 @@ import io
 import numpy as np
 import pandas as pd
 import numpy.testing as npt
+import six
 from unittest import TestCase, main
 from datetime import datetime
 
@@ -257,8 +258,8 @@ REFERENCE   1  (bases 1 to 154478)
             ['LOCUS       NP_001832                360 aa'
              '            linear   PRI 2001-12-18']]
         for line in lines:
-            with self.assertRaisesRegexp(
-                    GenBankFormatError, 'Could not parse the LOCUS line:.*'):
+            with six.assertRaisesRegex(self, GenBankFormatError,
+                                       'Could not parse the LOCUS line:.*'):
                 _parse_locus(line)
 
     def test_parse_section_default(self):
@@ -329,9 +330,9 @@ REFERENCE   1  (bases 1 to 154478)
             'abc',
             '3-8']
         for example in examples:
-            with self.assertRaisesRegexp(
-                    GenBankFormatError,
-                    'Could not parse location string: "%s"' % example):
+            with six.assertRaisesRegex(self, GenBankFormatError,
+                                       'Could not parse location string: '
+                                       '"%s"' % example):
                 _parse_loc_str(example, length)
 
     def test_genbank_to_generator_single(self):

--- a/skbio/stats/distance/_base.py
+++ b/skbio/stats/distance/_base.py
@@ -411,8 +411,29 @@ class DissimilarityMatrix(SkbioObject):
         plt.close(fig)
         return data
 
-    @experimental(as_of="0.4.0")
-    def to_dataframe(self):
+    @experimental(as_of="0.4.0-dev")
+    def to_data_frame(self):
+        """Create a ``pandas.DataFrame`` from this ``DissimilarityMatrix``.
+
+        Returns
+        -------
+        pd.DataFrame
+            ``pd.DataFrame`` with IDs on index and columns.
+
+        Examples
+        --------
+        >>> from skbio import DistanceMatrix
+        >>> dm = DistanceMatrix([[0, 1, 2],
+        ...                      [1, 0, 3],
+        ...                      [2, 3, 0]], ids=['a', 'b', 'c'])
+        >>> df = dm.to_data_frame()
+        >>> df
+           a  b  c
+        a  0  1  2
+        b  1  0  3
+        c  2  3  0
+
+        """
         return pd.DataFrame(data=self.data, index=self.ids, columns=self.ids)
 
     @experimental(as_of="0.4.0")

--- a/skbio/stats/distance/tests/test_base.py
+++ b/skbio/stats/distance/tests/test_base.py
@@ -334,11 +334,24 @@ class DissimilarityMatrixTests(DissimilarityMatrixTestData):
         dm = self.dm_1x1
         self.assertIsInstance(dm.svg, SVG)
 
-    def test_to_dataframe(self):
-        dm = self.dm_3x3
-        df = dm.to_dataframe()
-        exp = pd.DataFrame(data=self.dm_3x3_data, index=self.dm_3x3.ids,
-                           columns=self.dm_3x3.ids)
+    def test_to_data_frame_1x1(self):
+        df = self.dm_1x1.to_data_frame()
+        exp = pd.DataFrame([[0.0]], index=['a'], columns=['a'])
+        assert_data_frame_almost_equal(df, exp)
+
+    def test_to_data_frame_3x3(self):
+        df = self.dm_3x3.to_data_frame()
+        exp = pd.DataFrame([[0.0, 0.01, 4.2],
+                            [0.01, 0.0, 12.0],
+                            [4.2, 12.0, 0.0]],
+                           index=['a', 'b', 'c'], columns=['a', 'b', 'c'])
+        assert_data_frame_almost_equal(df, exp)
+
+    def test_to_data_frame_default_ids(self):
+        df = DissimilarityMatrix(self.dm_2x2_data).to_data_frame()
+        exp = pd.DataFrame([[0.0, 0.123],
+                            [0.123, 0.0]],
+                           index=['0', '1'], columns=['0', '1'])
         assert_data_frame_almost_equal(df, exp)
 
     def test_str(self):


### PR DESCRIPTION
Changes:

- fix changelog mention
- fix experimental version
- add docstring
- change method name to `to_data_frame`
- more unit tests

Also updated `skbio/io/format/tests/test_genbank.py` to use `six.assertRaisesRegex` instead of deprecated `assertRaisesRegexp`.