### PR TITLE
ENH: add TabularMSA.__copy__/__deepcopy__

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,9 @@ constructor. ([#6240](https://github.com/biocore/scikit-bio/issues/624))
 * ``DissimilarityMatrix.plot()`` no longer leaves a white border around the
   heatmap it plots (PR #1070).
 
+### Deprecated functionality [stable]
+* `skbio.Sequence.copy` has been deprecated in favor of `copy.copy(seq)` and `copy.deepcopy(seq)`.
+
 ### Deprecated functionality [experimental]
 * ``SequenceCollection.distances`` has been deprecated in favor of ``DistanceMatrix.from_iterable``. Use `key="id"` to exactly match original behavior.
 

--- a/skbio/alignment/_tabular_msa.py
+++ b/skbio/alignment/_tabular_msa.py
@@ -516,14 +516,14 @@ class TabularMSA(MetadataMixin, PositionalMetadataMixin, SkbioObject):
         Returns
         -------
         TabularMSA
-            Shallow copy of this MSA.
+            Shallow copy of this MSA. Sequence objects will be shallow-copied.
 
         See Also
         --------
         __deepcopy__
 
         """
-        seqs = copy.copy(self._seqs)
+        seqs = (copy.copy(seq) for seq in self._seqs)
 
         keys = None
         if self.has_keys():

--- a/skbio/alignment/tests/test_tabular_msa.py
+++ b/skbio/alignment/tests/test_tabular_msa.py
@@ -8,6 +8,7 @@
 
 from __future__ import absolute_import, division, print_function
 
+import copy
 import unittest
 import functools
 import itertools
@@ -929,6 +930,105 @@ class TestTabularMSA(unittest.TestCase, ReallyEqualMixin):
         self.assertEqual(d2, d1)
         self.assertIs(d1['a'], d2['a'])
         self.assertIs(d1[42], d2[42])
+
+
+class TestCopy(unittest.TestCase):
+    # Note: tests for metadata/positional_metadata are in mixin tests above.
+
+    def test_no_sequences(self):
+        msa = TabularMSA([])
+        msa_copy = copy.copy(msa)
+
+        self.assertEqual(msa, msa_copy)
+        self.assertIsNot(msa, msa_copy)
+        self.assertIsNot(msa._seqs, msa_copy._seqs)
+
+    def test_with_sequences(self):
+        msa = TabularMSA([DNA('ACGT'), DNA('TGCA')])
+        msa_copy = copy.copy(msa)
+
+        self.assertEqual(msa, msa_copy)
+        self.assertIsNot(msa, msa_copy)
+        self.assertIsNot(msa._seqs, msa_copy._seqs)
+        # TODO: use __getitem__ when it exists.
+        self.assertIs(msa._seqs[0], msa_copy._seqs[0])
+        self.assertIs(msa._seqs[1], msa_copy._seqs[1])
+
+        msa_copy.append(DNA('AAAA'))
+        self.assertEqual(msa, TabularMSA([DNA('ACGT'), DNA('TGCA')]))
+
+        msa_copy._seqs[0].metadata = {'foo': 'bar'}
+        self.assertEqual(
+            msa,
+            TabularMSA([DNA('ACGT', metadata={'foo': 'bar'}), DNA('TGCA')]))
+
+    def test_with_keys(self):
+        msa = TabularMSA([DNA('ACGT'), DNA('TGCA')], keys=['foo', 'bar'])
+        msa_copy = copy.copy(msa)
+
+        self.assertEqual(msa, msa_copy)
+        self.assertIsNot(msa, msa_copy)
+        self.assertIsNot(msa._keys, msa_copy._keys)
+
+        # Make sure copying keys preserves array flags.
+        with self.assertRaises(ValueError):
+            msa_copy.keys[0] = 42
+
+        msa_copy.keys = [1, 2]
+        npt.assert_array_equal(msa.keys, np.array(['foo', 'bar']))
+
+
+class TestDeepCopy(unittest.TestCase):
+    # Note: tests for metadata/positional_metadata are in mixin tests above.
+
+    def test_no_sequences(self):
+        msa = TabularMSA([])
+        msa_copy = copy.deepcopy(msa)
+
+        self.assertEqual(msa, msa_copy)
+        self.assertIsNot(msa, msa_copy)
+        self.assertIsNot(msa._seqs, msa_copy._seqs)
+
+    def test_with_sequences(self):
+        msa = TabularMSA([DNA('ACGT'), DNA('TGCA')])
+        msa_copy = copy.deepcopy(msa)
+
+        self.assertEqual(msa, msa_copy)
+        self.assertIsNot(msa, msa_copy)
+        self.assertIsNot(msa._seqs, msa_copy._seqs)
+        # TODO: use __getitem__ when it exists.
+        self.assertIsNot(msa._seqs[0], msa_copy._seqs[0])
+        self.assertIsNot(msa._seqs[1], msa_copy._seqs[1])
+
+        msa_copy.append(DNA('AAAA'))
+        self.assertEqual(msa, TabularMSA([DNA('ACGT'), DNA('TGCA')]))
+
+        msa_copy._seqs[0].metadata = {'foo': 'bar'}
+        self.assertEqual(msa, TabularMSA([DNA('ACGT'), DNA('TGCA')]))
+
+    def test_nested_references(self):
+        msa = TabularMSA([DNA('ACGT', metadata={'foo': [1]})])
+        msa_copy = copy.deepcopy(msa)
+
+        self.assertEqual(msa, msa_copy)
+        self.assertIsNot(msa, msa_copy)
+
+        msa_copy._seqs[0].metadata['foo'].append(2)
+        self.assertEqual(msa, TabularMSA([DNA('ACGT', metadata={'foo': [1]})]))
+
+    def test_with_keys(self):
+        msa = TabularMSA([DNA('ACGT'), DNA('TGCA')], keys=['foo', 'bar'])
+        msa_copy = copy.deepcopy(msa)
+
+        self.assertEqual(msa, msa_copy)
+        self.assertIsNot(msa, msa_copy)
+        self.assertIsNot(msa._keys, msa_copy._keys)
+
+        with self.assertRaises(ValueError):
+            msa_copy.keys[0] = 42
+
+        msa_copy.keys = [1, 2]
+        npt.assert_array_equal(msa.keys, np.array(['foo', 'bar']))
 
 
 class TestAppend(unittest.TestCase):

--- a/skbio/alignment/tests/test_tabular_msa.py
+++ b/skbio/alignment/tests/test_tabular_msa.py
@@ -974,23 +974,30 @@ class TestCopy(unittest.TestCase):
         self.assertIsNot(msa._seqs, msa_copy._seqs)
 
     def test_with_sequences(self):
-        msa = TabularMSA([DNA('ACGT'), DNA('TGCA')])
+        msa = TabularMSA([DNA('ACGT', metadata={'foo': [1]}), DNA('TGCA')])
         msa_copy = copy.copy(msa)
 
         self.assertEqual(msa, msa_copy)
         self.assertIsNot(msa, msa_copy)
         self.assertIsNot(msa._seqs, msa_copy._seqs)
         # TODO: use __getitem__ when it exists.
-        self.assertIs(msa._seqs[0], msa_copy._seqs[0])
-        self.assertIs(msa._seqs[1], msa_copy._seqs[1])
+        self.assertIsNot(msa._seqs[0], msa_copy._seqs[0])
+        self.assertIsNot(msa._seqs[1], msa_copy._seqs[1])
 
         msa_copy.append(DNA('AAAA'))
-        self.assertEqual(msa, TabularMSA([DNA('ACGT'), DNA('TGCA')]))
-
-        msa_copy._seqs[0].metadata = {'foo': 'bar'}
         self.assertEqual(
             msa,
-            TabularMSA([DNA('ACGT', metadata={'foo': 'bar'}), DNA('TGCA')]))
+            TabularMSA([DNA('ACGT', metadata={'foo': [1]}), DNA('TGCA')]))
+
+        msa_copy._seqs[0].metadata['bar'] = 42
+        self.assertEqual(
+            msa,
+            TabularMSA([DNA('ACGT', metadata={'foo': [1]}), DNA('TGCA')]))
+
+        msa_copy._seqs[0].metadata['foo'].append(2)
+        self.assertEqual(
+            msa,
+            TabularMSA([DNA('ACGT', metadata={'foo': [1, 2]}), DNA('TGCA')]))
 
     def test_with_keys(self):
         msa = TabularMSA([DNA('ACGT'), DNA('TGCA')], keys=['foo', 'bar'])
@@ -1020,7 +1027,7 @@ class TestDeepCopy(unittest.TestCase):
         self.assertIsNot(msa._seqs, msa_copy._seqs)
 
     def test_with_sequences(self):
-        msa = TabularMSA([DNA('ACGT'), DNA('TGCA')])
+        msa = TabularMSA([DNA('ACGT', metadata={'foo': [1]}), DNA('TGCA')])
         msa_copy = copy.deepcopy(msa)
 
         self.assertEqual(msa, msa_copy)
@@ -1031,20 +1038,19 @@ class TestDeepCopy(unittest.TestCase):
         self.assertIsNot(msa._seqs[1], msa_copy._seqs[1])
 
         msa_copy.append(DNA('AAAA'))
-        self.assertEqual(msa, TabularMSA([DNA('ACGT'), DNA('TGCA')]))
+        self.assertEqual(
+            msa,
+            TabularMSA([DNA('ACGT', metadata={'foo': [1]}), DNA('TGCA')]))
 
-        msa_copy._seqs[0].metadata = {'foo': 'bar'}
-        self.assertEqual(msa, TabularMSA([DNA('ACGT'), DNA('TGCA')]))
-
-    def test_nested_references(self):
-        msa = TabularMSA([DNA('ACGT', metadata={'foo': [1]})])
-        msa_copy = copy.deepcopy(msa)
-
-        self.assertEqual(msa, msa_copy)
-        self.assertIsNot(msa, msa_copy)
+        msa_copy._seqs[0].metadata['bar'] = 42
+        self.assertEqual(
+            msa,
+            TabularMSA([DNA('ACGT', metadata={'foo': [1]}), DNA('TGCA')]))
 
         msa_copy._seqs[0].metadata['foo'].append(2)
-        self.assertEqual(msa, TabularMSA([DNA('ACGT', metadata={'foo': [1]})]))
+        self.assertEqual(
+            msa,
+            TabularMSA([DNA('ACGT', metadata={'foo': [1]}), DNA('TGCA')]))
 
     def test_with_keys(self):
         msa = TabularMSA([DNA('ACGT'), DNA('TGCA')], keys=['foo', 'bar'])

--- a/skbio/sequence/_sequence.py
+++ b/skbio/sequence/_sequence.py
@@ -13,7 +13,6 @@ import six
 
 import re
 import collections
-import copy
 import numbers
 from contextlib import contextmanager
 
@@ -24,8 +23,8 @@ import pandas as pd
 
 from skbio._base import SkbioObject, MetadataMixin, PositionalMetadataMixin
 from skbio.sequence._repr import _SequenceReprBuilder
-from skbio.util._decorator import (stable, experimental, classonlymethod,
-                                   overrides)
+from skbio.util._decorator import (stable, experimental, deprecated,
+                                   classonlymethod, overrides)
 
 
 class Sequence(MetadataMixin, PositionalMetadataMixin, collections.Sequence,
@@ -572,8 +571,8 @@ class Sequence(MetadataMixin, PositionalMetadataMixin, collections.Sequence,
 
             self._set_bytes(sequence)
 
-        MetadataMixin.__init__(self, metadata=metadata)
-        PositionalMetadataMixin.__init__(
+        MetadataMixin._init_(self, metadata=metadata)
+        PositionalMetadataMixin._init_(
             self, positional_metadata=positional_metadata)
 
         if lowercase is False:
@@ -706,13 +705,13 @@ class Sequence(MetadataMixin, PositionalMetadataMixin, collections.Sequence,
         if self.__class__ != other.__class__:
             return False
 
-        if not MetadataMixin.__eq__(self, other):
+        if not MetadataMixin._eq_(self, other):
             return False
 
         if self._string != other._string:
             return False
 
-        if not PositionalMetadataMixin.__eq__(self, other):
+        if not PositionalMetadataMixin._eq_(self, other):
             return False
 
         return True
@@ -1140,7 +1139,10 @@ class Sequence(MetadataMixin, PositionalMetadataMixin, collections.Sequence,
         """
         return self._copy(True, memo)
 
-    @stable(as_of="0.4.0")
+    @deprecated(as_of="0.4.0-dev", until="0.5.1",
+                reason="Use `copy.copy(seq)` instead of "
+                       "`seq.copy(deep=False)`, and `copy.deepcopy(seq)` "
+                       "instead of `seq.copy(deep=True)`.")
     def copy(self, deep=False):
         """Return a copy of the biological sequence.
 
@@ -1272,27 +1274,19 @@ class Sequence(MetadataMixin, PositionalMetadataMixin, collections.Sequence,
         # we don't make a distinction between deep vs. shallow copy of bytes
         # because dtype=np.uint8. we only need to make the distinction when
         # dealing with object dtype
-        bytes = np.copy(self._bytes)
+        bytes_ = np.copy(self._bytes)
 
-        seq_copy = self._constructor(sequence=bytes, metadata=None,
+        seq_copy = self._constructor(sequence=bytes_, metadata=None,
                                      positional_metadata=None)
 
-        if self.has_metadata():
-            metadata = self.metadata
-            if deep:
-                metadata = copy.deepcopy(metadata, memo)
-            else:
-                metadata = metadata.copy()
-            seq_copy._metadata = metadata
-
-        if self.has_positional_metadata():
-            positional_metadata = self.positional_metadata
-            if deep:
-                positional_metadata = copy.deepcopy(positional_metadata, memo)
-            else:
-                # deep=True makes a shallow copy of the underlying data buffer
-                positional_metadata = positional_metadata.copy(deep=True)
-            seq_copy._positional_metadata = positional_metadata
+        if deep:
+            seq_copy._metadata = MetadataMixin._deepcopy_(self, memo)
+            seq_copy._positional_metadata = \
+                PositionalMetadataMixin._deepcopy_(self, memo)
+        else:
+            seq_copy._metadata = MetadataMixin._copy_(self)
+            seq_copy._positional_metadata = \
+                PositionalMetadataMixin._copy_(self)
 
         return seq_copy
 

--- a/skbio/sequence/_sequence.py
+++ b/skbio/sequence/_sequence.py
@@ -1122,7 +1122,7 @@ class Sequence(MetadataMixin, PositionalMetadataMixin, collections.Sequence,
         This method is equivalent to ``seq.copy(deep=False)``.
 
         """
-        return self.copy(deep=False)
+        return self._copy(False, {})
 
     @stable(as_of="0.4.0")
     def __deepcopy__(self, memo):

--- a/skbio/sequence/tests/test_sequence.py
+++ b/skbio/sequence/tests/test_sequence.py
@@ -2025,6 +2025,13 @@ class TestSequence(TestCase, ReallyEqualMixin):
                 pd.DataFrame({'bar': [[], [], [], []],
                               'baz': [42, 42, 42, 42]}))
 
+    def test_copy_preserves_read_only_flag_on_bytes(self):
+        seq = Sequence('ACGT')
+        seq_copy = copy.copy(seq)
+
+        with self.assertRaises(ValueError):
+            seq_copy._bytes[0] = 'B'
+
     def test_deepcopy_memo_is_respected(self):
         # basic test to ensure deepcopy's memo is passed through to recursive
         # deepcopy calls

--- a/skbio/tests/test_base.py
+++ b/skbio/tests/test_base.py
@@ -38,7 +38,27 @@ class TestSkbioObject(unittest.TestCase):
 class TestMetadataMixin(unittest.TestCase, ReallyEqualMixin,
                         MetadataMixinTests):
     def setUp(self):
-        self._metadata_constructor_ = MetadataMixin
+        class ExampleMetadataMixin(MetadataMixin):
+            def __init__(self, metadata=None):
+                MetadataMixin._init_(self, metadata=metadata)
+
+            def __eq__(self, other):
+                return MetadataMixin._eq_(self, other)
+
+            def __ne__(self, other):
+                return MetadataMixin._ne_(self, other)
+
+            def __copy__(self):
+                copy = self.__class__(metadata=None)
+                copy._metadata = MetadataMixin._copy_(self)
+                return copy
+
+            def __deepcopy__(self, memo):
+                copy = self.__class__(metadata=None)
+                copy._metadata = MetadataMixin._deepcopy_(self, memo)
+                return copy
+
+        self._metadata_constructor_ = ExampleMetadataMixin
 
 
 class TestPositionalMetadataMixin(unittest.TestCase, ReallyEqualMixin,
@@ -52,8 +72,26 @@ class TestPositionalMetadataMixin(unittest.TestCase, ReallyEqualMixin,
             def __init__(self, axis_len, positional_metadata=None):
                 self._axis_len = axis_len
 
-                PositionalMetadataMixin.__init__(
+                PositionalMetadataMixin._init_(
                     self, positional_metadata=positional_metadata)
+
+            def __eq__(self, other):
+                return PositionalMetadataMixin._eq_(self, other)
+
+            def __ne__(self, other):
+                return PositionalMetadataMixin._ne_(self, other)
+
+            def __copy__(self):
+                copy = self.__class__(self._axis_len, positional_metadata=None)
+                copy._positional_metadata = \
+                    PositionalMetadataMixin._copy_(self)
+                return copy
+
+            def __deepcopy__(self, memo):
+                copy = self.__class__(self._axis_len, positional_metadata=None)
+                copy._positional_metadata = \
+                    PositionalMetadataMixin._deepcopy_(self, memo)
+                return copy
 
         self._positional_metadata_constructor_ = ExamplePositionalMetadataMixin
 


### PR DESCRIPTION
Refactored common code into metadata mixins. Fixes #1158.

@ebolyen shallow copying creates a new list with references to the original sequences. Is that right or should I have it create a new list *and* shallow copy each sequence? See the `TabularMSA` `copy` unit tests for current behavior.