### PR TITLE
ENH: TabularMSA.consensus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ constructor. ([#6240](https://github.com/biocore/scikit-bio/issues/624))
 * Added `Sequence.frequencies` method for computing character frequencies in a sequence. ([#1074](https://github.com/biocore/scikit-bio/issues/1074))
 * Added experimental class-method ``Sequence.concat`` which will produce a new sequence from an iterable of existing sequences. Parameters control how positional metadata is propagated during a concatenation.
 * ``skbio.io.format.phylip`` now supports sniffing and reading strict, sequential PHYLIP-formatted files into ``skbio.Alignment`` objects. ([#1006](https://github.com/biocore/scikit-bio/issues/1006))
+* Added `default_gap_char` class property to ``DNA``, ``RNA``, and ``Protein`` for representing gap characters in a new sequence.
 
 ### Backward-incompatible changes [stable]
 * `Sequence.kmer_frequencies` now returns a `dict`. Previous behavior was to return a `collections.Counter` if `relative=False` was passed, and a `collections.defaultdict` if `relative=True` was passed. In the case of a missing key, the `Counter` would return 0 and the `defaultdict` would return 0.0. Because the return type is now always a `dict`, attempting to access a missing key will raise a `KeyError`. This change *may* break backwards-compatibility depending on how the `Counter`/`defaultdict` is being used. We hope that in most cases this change will not break backwards-compatibility because both `Counter` and `defaultdict` are `dict` subclasses.

--- a/skbio/alignment/_tabular_msa.py
+++ b/skbio/alignment/_tabular_msa.py
@@ -10,7 +10,6 @@ from __future__ import absolute_import, division, print_function
 
 import collections
 import copy
-import operator
 
 from future.builtins import range
 from future.utils import viewkeys, viewvalues
@@ -665,6 +664,66 @@ class TabularMSA(MetadataMixin, PositionalMetadataMixin, SkbioObject):
         return (self._get_position(index) for index in indices)
 
     @experimental(as_of='0.4.0-dev')
+    def consensus(self):
+        """Compute the majority consensus sequence for this MSA.
+
+        The majority consensus sequence contains the most common character at
+        each position in this MSA. Ties will be broken in an arbitrary manner.
+
+        Returns
+        -------
+        Sequence
+            The majority consensus sequence for this MSA. The type of sequence
+            returned will be the same as this MSA's ``dtype`` or ``Sequence``
+            if this MSA does not contain any sequences. The majority consensus
+            sequence will have its positional metadata set to this MSA's
+            positional metadata if present.
+
+        Notes
+        -----
+        Gap characters are treated as distinct characters when computing the
+        majority consensus character at each MSA position.
+
+        Examples
+        --------
+        >>> from skbio import DNA, TabularMSA
+        >>> sequences = [DNA('AC---'),
+        ...              DNA('AT-C.'),
+        ...              DNA('TT-C.')]
+        >>> msa = TabularMSA(sequences,
+        ...                  positional_metadata={'prob': [2, 1, 2, 3, 5]})
+        >>> msa.consensus()
+        DNA
+        -----------------------------
+        Positional metadata:
+            'prob': <dtype: int64>
+        Stats:
+            length: 5
+            has gaps: True
+            has degenerates: False
+            has non-degenerates: True
+            GC-content: 33.33%
+        -----------------------------
+        0 AT-C.
+
+        """
+        dtype = self.dtype
+        if dtype is None:
+            dtype = Sequence
+
+        positional_metadata = None
+        if self.has_positional_metadata():
+            positional_metadata = self.positional_metadata
+
+        consensus = []
+        for position in self.iter_positions():
+            freqs = position.frequencies()
+            consensus.append(collections.Counter(freqs).most_common(1)[0][0])
+
+        return dtype(''.join(consensus),
+                     positional_metadata=positional_metadata)
+
+    @experimental(as_of='0.4.0-dev')
     def gap_frequencies(self, axis='sequence', relative=False):
         """Compute frequency of gap characters across an axis.
 
@@ -1026,57 +1085,3 @@ class TabularMSA(MetadataMixin, PositionalMetadataMixin, SkbioObject):
     @overrides(PositionalMetadataMixin)
     def _positional_metadata_axis_len_(self):
         return self.shape.position
-
-    @experimental(as_of='0.4.0-dev')
-    def consensus(self):
-        """Return the consensus sequence for the TabularMSA.
-
-        Returns
-        -------
-        skbio.Sequence
-            The consensus sequence of the `TabularMSA`. In other words, at each
-            position the most common character is chosen, and those characters
-            are combined to create a new sequence. The sequence will not have
-            its metadata or positional metadata set; only the sequence will be
-            set. The type of biological sequence that is returned will be the
-            same type as the first sequence in the alignment, or ``Sequence``
-            if the alignment is empty.
-
-        Notes
-        -----
-        If there are two characters that are equally abundant in the sequence
-        at a given position, the choice of which of those characters will be
-        present at that position in the result is arbitrary.
-
-        Examples
-        --------
-        >>> from skbio import TabularMSA
-        >>> from skbio import DNA
-        >>> sequences = [DNA('AC--', metadata={'id': "seq1"}),
-        ...              DNA('AT-C', metadata={'id': "seq2"}),
-        ...              DNA('TT-C', metadata={'id': "seq3"})]
-        >>> msa = TabularMSA(sequences)
-        >>> msa.consensus()
-        DNA
-        -----------------------------
-        Stats:
-            length: 4
-            has gaps: True
-            has degenerates: False
-            has non-degenerates: True
-            GC-content: 33.33%
-        -----------------------------
-        0 AT-C
-
-        """
-
-        if self.dtype is not None:
-            constructor = self.dtype
-        else:
-            constructor = Sequence
-        return constructor(''.join(c.most_common(1)[0][0]
-                           for c in self._position_counters()))
-
-    def _position_counters(self):
-        return [collections.Counter([str(seq) for seq in position])
-                for position in self.iter_positions()]

--- a/skbio/alignment/tests/test_tabular_msa.py
+++ b/skbio/alignment/tests/test_tabular_msa.py
@@ -1162,7 +1162,7 @@ class TestConsensus(unittest.TestCase):
 
         cons = msa.consensus()
 
-        self.assertEqual(cons, DNA('ACGT-.'))
+        self.assertEqual(cons, DNA('ACGT--'))
 
     def test_multiple_sequences(self):
         msa = TabularMSA([DNA('ACGT'),
@@ -1171,7 +1171,7 @@ class TestConsensus(unittest.TestCase):
 
         cons = msa.consensus()
 
-        self.assertEqual(cons, DNA('AC-.'))
+        self.assertEqual(cons, DNA('AC--'))
 
     def test_ties(self):
         msa = TabularMSA([DNA('A-'),
@@ -1181,6 +1181,25 @@ class TestConsensus(unittest.TestCase):
         cons = msa.consensus()
 
         self.assertTrue(cons in [DNA('A-'), DNA('C-'), DNA('G-')])
+
+    def test_ties_with_gaps(self):
+        msa = TabularMSA([DNA('-'),
+                          DNA('.'),
+                          DNA('T'),
+                          DNA('T')])
+
+        cons = msa.consensus()
+
+        self.assertTrue(cons in [DNA('T'), DNA('-')])
+
+    def test_default_gap_char(self):
+        msa = TabularMSA([DNA('.'),
+                          DNA('.'),
+                          DNA('.')])
+
+        cons = msa.consensus()
+
+        self.assertEqual(cons, DNA('-'))
 
     def test_different_dtype(self):
         msa = TabularMSA([RNA('---'),
@@ -1210,7 +1229,7 @@ class TestConsensus(unittest.TestCase):
 
         self.assertEqual(
             cons,
-            DNA('A.T', positional_metadata={'foo': [42, 43, 42],
+            DNA('A-T', positional_metadata={'foo': [42, 43, 42],
                                             'bar': ['a', 'b', 'c']}))
 
     def test_handles_missing_positional_metadata_efficiently(self):
@@ -1224,7 +1243,7 @@ class TestConsensus(unittest.TestCase):
         self.assertIsNone(msa._positional_metadata)
         self.assertIsNone(cons._positional_metadata)
 
-    def test_distinct_gap_characters(self):
+    def test_mixed_gap_characters_as_majority(self):
         seqs = [
             DNA('A'),
             DNA('A'),
@@ -1238,7 +1257,7 @@ class TestConsensus(unittest.TestCase):
 
         cons = msa.consensus()
 
-        self.assertEqual(cons, DNA('A'))
+        self.assertEqual(cons, DNA('-'))
 
 
 class TestGapFrequencies(unittest.TestCase):

--- a/skbio/alignment/tests/test_tabular_msa.py
+++ b/skbio/alignment/tests/test_tabular_msa.py
@@ -1248,6 +1248,8 @@ class TestConsensus(unittest.TestCase):
             DNA('A'),
             DNA('A'),
             DNA('A'),
+            DNA('A'),
+            DNA('.'),
             DNA('.'),
             DNA('.'),
             DNA('-'),

--- a/skbio/sequence/_dna.py
+++ b/skbio/sequence/_dna.py
@@ -55,6 +55,7 @@ class DNA(IUPACSequence, NucleotideMixin):
     positional_metadata
     alphabet
     gap_chars
+    default_gap_char
     nondegenerate_chars
     degenerate_chars
     degenerate_map

--- a/skbio/sequence/_iupac_sequence.py
+++ b/skbio/sequence/_iupac_sequence.py
@@ -16,7 +16,8 @@ import numpy as np
 
 import re
 
-from skbio.util._decorator import classproperty, overrides, stable
+from skbio.util._decorator import (classproperty, overrides, stable,
+                                   experimental)
 from skbio.util._misc import MiniRegistry
 from ._sequence import Sequence
 
@@ -33,6 +34,7 @@ class IUPACSequence(with_metaclass(ABCMeta, Sequence)):
     positional_metadata
     alphabet
     gap_chars
+    default_gap_char
     nondegenerate_chars
     degenerate_chars
     degenerate_map
@@ -119,6 +121,23 @@ class IUPACSequence(with_metaclass(ABCMeta, Sequence)):
 
         """
         return set('-.')
+
+    @classproperty
+    @experimental(as_of='0.4.0-dev')
+    def default_gap_char(cls):
+        """Gap character to use when constructing a new gapped sequence.
+
+        This character is used when it is necessary to represent gap characters
+        in a new sequence. For example, a majority consensus sequence will use
+        this character to represent gaps.
+
+        Returns
+        -------
+        str
+            Default gap character.
+
+        """
+        return '-'
 
     @classproperty
     @stable(as_of='0.4.0')

--- a/skbio/sequence/_protein.py
+++ b/skbio/sequence/_protein.py
@@ -55,6 +55,7 @@ class Protein(IUPACSequence):
     positional_metadata
     alphabet
     gap_chars
+    default_gap_char
     stop_chars
     nondegenerate_chars
     degenerate_chars

--- a/skbio/sequence/_rna.py
+++ b/skbio/sequence/_rna.py
@@ -55,6 +55,7 @@ class RNA(IUPACSequence, NucleotideMixin):
     positional_metadata
     alphabet
     gap_chars
+    default_gap_char
     nondegenerate_chars
     degenerate_chars
     degenerate_map

--- a/skbio/sequence/tests/test_iupac_sequence.py
+++ b/skbio/sequence/tests/test_iupac_sequence.py
@@ -207,6 +207,14 @@ class TestIUPACSequence(TestCase):
         with self.assertRaises(AttributeError):
             ExampleIUPACSequence('').gap_chars = set("_ =")
 
+    def test_default_gap_char(self):
+        self.assertIs(type(ExampleIUPACSequence.default_gap_char), str)
+        self.assertEqual(ExampleIUPACSequence.default_gap_char, '-')
+        self.assertEqual(ExampleIUPACSequence('').default_gap_char, '-')
+
+        with self.assertRaises(AttributeError):
+            ExampleIUPACSequence('').default_gap_char = '.'
+
     def test_alphabet(self):
         expected = set("ABC.-XYZ")
         self.assertIs(type(ExampleIUPACSequence.alphabet), set)


### PR DESCRIPTION
Contains commits in #1129. Fixes #1091.

To-do:

- [x] ~~should each gap character be treated distinctly when computing consensus for each position? This is the current behavior here and in `Alignment.majority_consensus`, not sure if this is right or not.~~ @gregcaporaso, @ebolyen, and I discussed this. For now we will treat different gap characters the same and we can add a parameter to treat them distinctly if requested by users in the future. This change will require an `IUPACSequence.default_gap_char`, which will be used to represent a consensus gap.