### PR TITLE
Allow subclasses of TreeNode to be used

### DIFF
--- a/skbio/tree/_majority_rule.py
+++ b/skbio/tree/_majority_rule.py
@@ -116,7 +116,8 @@ def _filter_clades(clade_counts, cutoff_threshold):
     return accepted_clades
 
 
-def _build_trees(clade_counts, edge_lengths, support_attr):
+def _build_trees(clade_counts, edge_lengths, support_attr,
+                 tree_node_class=TreeNode):
     """Construct the trees with support
 
     Parameters
@@ -127,6 +128,9 @@ def _build_trees(clade_counts, edge_lengths, support_attr):
         Keyed by the frozenset of the clade and valued by the weighted length
     support_attr : str
         The name of the attribute to hold the support value
+    tree_node_class: Python class
+        Either TreeNode (the default) or a class that implements the same
+        interface (most usefully, a subclass of TreeNode).
 
     Returns
     -------
@@ -169,7 +173,7 @@ def _build_trees(clade_counts, edge_lengths, support_attr):
         children = [nodes.pop(c) for c in clade if c in nodes]
         length = edge_lengths[clade]
 
-        node = TreeNode(children=children, length=length, name=name)
+        node = tree_node_class(children=children, length=length, name=name)
         setattr(node, support_attr, clade_counts[clade])
         nodes[clade] = node
 
@@ -179,7 +183,8 @@ def _build_trees(clade_counts, edge_lengths, support_attr):
 
 
 @experimental(as_of="0.4.0")
-def majority_rule(trees, weights=None, cutoff=0.5, support_attr='support'):
+def majority_rule(trees, weights=None, cutoff=0.5, support_attr='support',
+                  tree_node_class=TreeNode):
     r"""Determines consensus trees from a list of rooted trees
 
     Parameters
@@ -197,10 +202,13 @@ def majority_rule(trees, weights=None, cutoff=0.5, support_attr='support'):
     support_attr : str
         The attribute to be decorated onto the resulting trees that contain the
         consensus support.
+    tree_node_class: Python class
+        Either TreeNode (the default) or a class that implements the same
+        interface (most usefully, a subclass of TreeNode).
 
     Returns
     -------
-    list of TreeNode
+    list of tree_node_class instances
         Multiple trees can be returned in the case of two or more disjoint sets
         of tips represented on input.
 
@@ -278,6 +286,7 @@ def majority_rule(trees, weights=None, cutoff=0.5, support_attr='support'):
 
     clade_counts, edge_lengths = _walk_clades(trees, weights)
     clade_counts = _filter_clades(clade_counts, cutoff_threshold)
-    trees = _build_trees(clade_counts, edge_lengths, support_attr)
+    trees = _build_trees(clade_counts, edge_lengths, support_attr,
+                         tree_node_class)
 
     return trees

--- a/skbio/tree/_tree.py
+++ b/skbio/tree/_tree.py
@@ -1889,7 +1889,7 @@ class TreeNode(SkbioObject):
                     cur_node.append(new_node)
                     cur_node = new_node
 
-            cur_node.append(TreeNode(name=id_))
+            cur_node.append(self.__class__(name=id_))
 
         # scrub the lookups
         for node in root.non_tips(include_self=True):
@@ -1945,10 +1945,10 @@ class TreeNode(SkbioObject):
         node_lookup = np.empty(lookup_len, dtype=TreeNode)
 
         for i, name in enumerate(id_list):
-            node_lookup[i] = TreeNode(name=name)
+            node_lookup[i] = self.__class__(name=name)
 
         for i in range(tip_width, lookup_len):
-            node_lookup[i] = TreeNode()
+            node_lookup[i] = self.__class__()
 
         newest_cluster_index = cluster_count + 1
         for link in linkage_matrix:

--- a/skbio/tree/_tree.py
+++ b/skbio/tree/_tree.py
@@ -1889,7 +1889,7 @@ class TreeNode(SkbioObject):
                     cur_node.append(new_node)
                     cur_node = new_node
 
-            cur_node.append(self.__class__(name=id_))
+            cur_node.append(cls(name=id_))
 
         # scrub the lookups
         for node in root.non_tips(include_self=True):
@@ -1945,10 +1945,10 @@ class TreeNode(SkbioObject):
         node_lookup = np.empty(lookup_len, dtype=TreeNode)
 
         for i, name in enumerate(id_list):
-            node_lookup[i] = self.__class__(name=name)
+            node_lookup[i] = cls(name=name)
 
         for i in range(tip_width, lookup_len):
-            node_lookup[i] = self.__class__()
+            node_lookup[i] = cls()
 
         newest_cluster_index = cluster_count + 1
         for link in linkage_matrix:


### PR DESCRIPTION
I've just started using scikit-bio (thanks!) and ran into something a little inflexible that I think could be improved quite easily.

I'd like to have my own `TreeNode` class so I can store attributes and methods on it. This issue has come up in various other guises, see e.g., #1117, #809, and #465.

If I can't use my own subclass, I need to keep per-node metadata somewhere else, and keep it up to date, etc. E.g., I could make a class, `MyClass`, that keeps a `TreeNode` instance (e.g., called `tree`) plus some other metadata. This is quite inconvenient and un-Pythonic. It means I need to call the extra methods of my class using things like

```python
myClass = MyClass()
for node in myClass.tree.children:
    if myClass.nodeSupport(node) > 0:
        # pass
```

rather than the simpler approach in which I subclass `TreeNode` and add the methods and attributes I want.  The simpler approach also makes testing easier.

Anyway, the usual way to do this is to pass around a class that is used to make new tree nodes, and have it default to the original simple base class (`TreeNode` in this case).

I'm not proposing that this pull request gets merged at the moment, but would like to see what people think of the idea and the simple diff.  If this seems like a good direction, I can add some tests that subclass `TreeNode` and which pass a `tree_node_class` argument to `majority_rule`.

Thanks again for scikit-bio!