### PR TITLE
ENH: hook `TabularMSA` up to `skbio.io`

### DIFF
--- a/skbio/alignment/_alignment.py
+++ b/skbio/alignment/_alignment.py
@@ -751,6 +751,12 @@ class Alignment(SequenceCollection):
             self._score = None
         self._start_end_positions = start_end_positions
 
+    def __str__(self):
+        lines = []
+        for id_, seq in self.iteritems():
+            lines.append('>%s\n%s\n' % (id_, seq))
+        return ''.join(lines)
+
     @experimental(as_of="0.4.0")
     def distances(self, distance_fn=None):
         """Compute distances between all pairs of sequences

--- a/skbio/alignment/_tabular_msa.py
+++ b/skbio/alignment/_tabular_msa.py
@@ -78,6 +78,7 @@ class TabularMSA(MetadataMixin, PositionalMetadataMixin, SkbioObject):
     used: integer labels ``0..(N-1)``, where ``N`` is the number of sequences.
 
     """
+    default_write_format = 'fasta'
 
     @property
     @experimental(as_of='0.4.0-dev')

--- a/skbio/io/__init__.py
+++ b/skbio/io/__init__.py
@@ -80,12 +80,12 @@ Reading and writing files (I/O) can be a complicated task:
 
 * A file format can sometimes be read into more than one in-memory
   representation (i.e., object). For example, a FASTA file can be read into an
-  :mod:`skbio.alignment.SequenceCollection` or :mod:`skbio.alignment.Alignment`
-  depending on the file's contents and what operations you'd like to perform on
-  your data.
+  :mod:`skbio.alignment.SequenceCollection` or
+  :mod:`skbio.alignment.TabularMSA` depending on the file's contents and what
+  operations you'd like to perform on your data.
 * A single object might be writeable to more than one file format. For example,
-  an :mod:`skbio.alignment.Alignment` object could be written to FASTA, FASTQ,
-  QSEQ, or PHYLIP formats, just to name a few.
+  an :mod:`skbio.alignment.TabularMSA` object could be written to FASTA, FASTQ,
+  CLUSTAL, or PHYLIP formats, just to name a few.
 * You might not know the exact file format of your file, but you want to read
   it into an appropriate object.
 * You might want to read multiple files into a single object, or write an

--- a/skbio/io/_exception.py
+++ b/skbio/io/_exception.py
@@ -72,7 +72,7 @@ class FASTQFormatError(FileFormatError):
 class PhylipFormatError(FileFormatError):
     """Raised when a ``phylip`` formatted file cannot be parsed.
 
-    May also be raised when an object (e.g., ``Alignment``) cannot be written
+    May also be raised when an object (e.g., ``TabularMSA``) cannot be written
     in ``phylip`` format.
 
     """

--- a/skbio/io/format/_base.py
+++ b/skbio/io/format/_base.py
@@ -164,7 +164,7 @@ def _format_fasta_like_records(generator, id_whitespace_replacement,
             id_ = _whitespace_regex.sub(id_whitespace_replacement, id_)
 
         if 'description' in seq.metadata:
-            desc = seq.metadata['description']
+            desc = '%s' % seq.metadata['description']
         else:
             desc = ''
 

--- a/skbio/io/format/fasta.py
+++ b/skbio/io/format/fasta.py
@@ -35,7 +35,7 @@ Format Support
 +------+------+---------------------------------------------------------------+
 |Yes   |Yes   |:mod:`skbio.alignment.SequenceCollection`                      |
 +------+------+---------------------------------------------------------------+
-|Yes   |Yes   |:mod:`skbio.alignment.Alignment`                               |
+|Yes   |Yes   |:mod:`skbio.alignment.TabularMSA`                              |
 +------+------+---------------------------------------------------------------+
 |Yes   |Yes   |:mod:`skbio.sequence.Sequence`                                 |
 +------+------+---------------------------------------------------------------+
@@ -84,11 +84,18 @@ Sequence Header
 ~~~~~~~~~~~~~~~
 Each sequence header consists of a single line beginning with a greater-than
 (``>``) symbol. Immediately following this is a sequence identifier (ID) and
-description separated by one or more whitespace characters. The sequence ID and
-description are stored in the sequence `metadata` attribute, under the `'id'`
-and `'description'` keys, repectively. Both are optional. Each will be
-represented as the empty string (``''``) in `metadata` if it is not present
-in the header.
+description separated by one or more whitespace characters.
+
+.. note:: When reading a FASTA-formatted file, the sequence ID and description
+   are stored in the sequence `metadata` attribute, under the `'id'` and
+   `'description'` keys, repectively. Both are optional. Each will be
+   represented as the empty string (``''``) in `metadata` if it is not present
+   in the header.
+
+   When writing a FASTA-formatted file, sequence `metadata` identified by keys
+   `'id'` and `'description'` will be converted to strings and written as the
+   sequence identifier and description, respectively. Each will be written as
+   the empty string if not present in sequence `metadata`.
 
 A sequence ID consists of a single *word*: all characters after the greater-
 than symbol and before the first whitespace character (if any) are taken as the
@@ -96,14 +103,6 @@ sequence ID. Unique sequence IDs are not strictly enforced by the FASTA format
 itself. A single standardized ID format is similarly not enforced by the FASTA
 format, though it is often common to use a unique library accession number for
 a sequence ID (e.g., NCBI's FASTA defline format [5]_).
-
-.. note:: scikit-bio will enforce sequence ID uniqueness depending on the type
-   of object that the FASTA file is read into. For example, reading a FASTA
-   file as a generator of ``Sequence`` objects will not enforce
-   unique IDs since it simply yields each sequence it finds in the FASTA file.
-   However, if the FASTA file is read into a ``SequenceCollection`` object, ID
-   uniqueness will be enforced because that is a requirement of a
-   ``SequenceCollection``.
 
 If a description is present, it is taken as the remaining characters that
 follow the sequence ID and initial whitespace(s). The description is considered
@@ -134,14 +133,14 @@ the standard IUPAC lexicon (single-letter codes).
    case. Other sequence objects do, but all provide the `lowercase` parameter
    to control case functionality. Refer to each class's respective constructor
    documentation for details.
-.. note:: Both ``-`` and ``.`` are supported as gap characters. See
-   :mod:`skbio.sequence` for more details on how scikit-bio interprets
-   sequence data in its in-memory objects.
 
-   Validation is performed for all scikit-bio objects which support it. This
-   consists of all objects which enforce usage of IUPAC characters. If any
-   invalid IUPAC characters are found in the sequence while reading from the
-   FASTA file, an exception is raised.
+   Both ``-`` and ``.`` are supported as gap characters when reading into
+   ``DNA``, ``RNA``, and ``Protein`` sequence objects.
+
+   Validation is performed when reading into scikit-bio sequence objects that
+   enforce an alphabet (e.g., ``DNA``, ``RNA``, ``Protein``). If any invalid
+   characters are found while reading from the FASTA file, an exception is
+   raised.
 
 QUAL Format
 ^^^^^^^^^^^
@@ -152,13 +151,16 @@ containing a sequence ID and description. The same rules apply to QUAL headers
 as FASTA headers (see the above sections for details). scikit-bio processes
 FASTA and QUAL headers in exactly the same way.
 
-Quality scores are automatically stored in the object's `positional_metadata`
-attribute, under the `'quality'` column.
-
 Instead of storing biological sequence data in each record, a QUAL file stores
 a Phred quality score for each base in the corresponding sequence. Quality
 scores are represented as nonnegative integers separated by whitespace
 (typically a single space or newline), and can span multiple lines.
+
+.. note:: When reading a QUAL-formatted file, quality scores are stored in the
+   sequence's `positional_metadata` attribute under the `'quality'` column.
+
+   When writing a QUAL-formatted file, a sequence's `positional_metadata`
+   `'quality'` column will be written as the quality scores.
 
 .. note:: When reading FASTA and QUAL files, scikit-bio requires records to be
    in the same order in both files (i.e., each FASTA and QUAL record must have
@@ -191,19 +193,25 @@ Reader-specific Parameters
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 The available reader parameters differ depending on which reader is used.
 
-Generator, SequenceCollection, and Alignment Reader Parameters
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Generator, SequenceCollection, and TabularMSA Reader Parameters
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 The ``constructor`` parameter can be used with the ``Sequence``
-generator, ``SequenceCollection``, and ``Alignment`` FASTA readers.
-``constructor`` specifies the in-memory type of each sequence that is parsed,
-and defaults to ``Sequence``. ``constructor`` should be a subclass of
-``Sequence``. For example, if you know that the FASTA file you're
-reading contains protein sequences, you would pass
-``constructor=Protein`` to the reader call.
+generator, ``SequenceCollection``, and ``TabularMSA`` FASTA readers.
+``constructor`` specifies the type of in-memory sequence object to read each
+sequence into. For example, if you know that the FASTA file you're reading
+contains protein sequences, you would pass ``constructor=Protein`` to the
+reader call.
+
+When reading into a ``Sequence`` generator or ``SequenceCollection``,
+``constructor`` defaults to ``Sequence`` and must be a subclass of
+``Sequence`` if supplied.
+
+When reading into a ``TabularMSA``, ``constructor`` is a required format
+parameter and must be a subclass of ``IUPACSequence`` (e.g., ``DNA``, ``RNA``,
+``Protein``).
 
 .. note:: The FASTA sniffer will not attempt to guess the ``constructor``
-   parameter, so it will always default to ``Sequence`` if another
-   type is not provided to the reader.
+   parameter.
 
 Sequence Reader Parameters
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -334,61 +342,35 @@ We see that all 5 sequences have 42 characters, and that each of the sequence
 IDs were successfully read into memory.
 
 Since these sequences are of equal length (presumably because they've been
-aligned), let's load the FASTA file into an ``Alignment`` object, which is a
+aligned), let's load the FASTA file into a ``TabularMSA`` object, which is a
 more appropriate data structure:
 
->>> from skbio import Alignment
->>> aln = Alignment.read(fl)
->>> aln.sequence_length()
-42
+>>> from skbio import TabularMSA, DNA
+>>> msa = TabularMSA.read(fl, constructor=DNA)
+>>> msa
+TabularMSA[DNA]
+------------------------------------------
+Stats:
+    sequence count: 5
+    position count: 42
+------------------------------------------
+AAGCTNGGGCATTTCAGGGTGAGCCCGGGCAATACAGGGTAT
+AAGCCTTGGCAGTGCAGGGTGAGCCGTGGCCGGGCACGGTAT
+ACCGGTTGGCCGTTCAGGGTACAGGTTGGCCGTTCAGGGTAA
+AAACCCTTGCCGTTACGCTTAAACCGAGGCCGGGACACTCAT
+AAACCCTTGCCGGTACGCTTAAACCATTGCCGGTACGCTTAA
 
 Note that we were able to read the FASTA file into two different data
-structures (``SequenceCollection`` and ``Alignment``) using the exact same
-``read`` method call (and underlying reading/parsing logic). Also note that we
-didn't specify a file format in the ``read`` call. The FASTA sniffer detected
-the correct file format for us!
+structures (``SequenceCollection`` and ``TabularMSA``) using similar ``read``
+method calls (and underlying reading/parsing logic). Also note that we didn't
+specify a file format in the ``read`` call. The FASTA sniffer detected the
+correct file format for us!
 
-Let's inspect the type of sequences stored in the ``Alignment``:
-
->>> aln[0]
-Sequence
-------------------------------------------------
-Metadata:
-    'description': 'Turkey'
-    'id': 'seq1'
-Stats:
-    length: 42
-------------------------------------------------
-0 AAGCTNGGGC ATTTCAGGGT GAGCCCGGGC AATACAGGGT AT
-
-By default, sequences are loaded as ``Sequence`` objects. We can
-change the type of sequence via the ``constructor`` parameter:
-
->>> from skbio import DNA
->>> aln = Alignment.read(fl, constructor=DNA)
->>> aln[0] # doctest: +NORMALIZE_WHITESPACE
-DNA
-------------------------------------------------
-Metadata:
-    'description': 'Turkey'
-    'id': 'seq1'
-Stats:
-    length: 42
-    has gaps: False
-    has degenerates: True
-    has non-degenerates: True
-    GC-content: 54.76%
-------------------------------------------------
-0 AAGCTNGGGC ATTTCAGGGT GAGCCCGGGC AATACAGGGT AT
-
-We now have an ``Alignment`` of ``DNA`` objects instead of
-``Sequence`` objects.
-
-To write the alignment in FASTA format:
+To write the ``TabularMSA`` in FASTA format:
 
 >>> from io import StringIO
 >>> with StringIO() as fh:
-...     print(aln.write(fh).getvalue())
+...     print(msa.write(fh).getvalue())
 >seq1 Turkey
 AAGCTNGGGCATTTCAGGGTGAGCCCGGGCAATACAGGGTAT
 >seq2 Salmo gair
@@ -401,7 +383,7 @@ AAACCCTTGCCGTTACGCTTAAACCGAGGCCGGGACACTCAT
 AAACCCTTGCCGGTACGCTTAAACCATTGCCGGTACGCTTAA
 <BLANKLINE>
 
-Both ``SequenceCollection`` and ``Alignment`` load all of the sequences from
+Both ``SequenceCollection`` and ``TabularMSA`` load all of the sequences from
 the FASTA file into memory at once. If the FASTA file is large (which is often
 the case), this may be infeasible if you don't have enough memory. To work
 around this issue, you can stream the sequences using scikit-bio's
@@ -496,7 +478,7 @@ Stats:
 ------------------------------------------------
 0 AAACCCTTGC CGGTACGCTT AAACCATTGC CGGTACGCTT AA
 
-We can use the same API to read the fifth sequence into a ``DNA``:
+We can use the same API to read the fifth sequence into a ``DNA`` sequence:
 
 >>> dna_seq = DNA.read(fl, seq_num=5)
 >>> dna_seq
@@ -524,8 +506,8 @@ AAACCCTTGCCGGTACGCTTAAACCATTGCCGGTACGCTTAA
 
 Reading and Writing FASTA/QUAL Files
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In addition to reading and writing standalone FASTA files, scikit-bio also
-supports reading and writing FASTA and QUAL files together. Suppose we have the
+In addition to reading and writing standalone FASTA files, scikit-bio supports
+reading and writing FASTA and QUAL files together. Suppose we have the
 following FASTA file::
 
     >seq1 db-accession-149855
@@ -596,7 +578,7 @@ Now let's load the sequences and their quality scores into a
 <SequenceCollection: n=2; mean +/- std length=6.00 +/- 1.00>
 
 To write the sequence data and quality scores in the ``SequenceCollection`` to
-FASTA and QUAL files, respectively, we run:
+FASTA and QUAL files, respectively:
 
 >>> new_fasta_fh = StringIO()
 >>> new_qual_fh = StringIO()
@@ -656,7 +638,7 @@ from skbio.io.format._base import (_get_nth_sequence,
                                    _format_fasta_like_records, _line_generator,
                                    _too_many_blanks)
 from skbio.util._misc import chunk_str
-from skbio.alignment import SequenceCollection, Alignment
+from skbio.alignment import SequenceCollection, TabularMSA
 from skbio.sequence import Sequence, DNA, RNA, Protein
 
 
@@ -785,11 +767,13 @@ def _fasta_to_sequence_collection(fh, qual=FileSentinel,
                                  **kwargs)))
 
 
-@fasta.reader(Alignment)
-def _fasta_to_alignment(fh, qual=FileSentinel, constructor=Sequence, **kwargs):
-    return Alignment(
-        list(_fasta_to_generator(fh, qual=qual, constructor=constructor,
-                                 **kwargs)))
+@fasta.reader(TabularMSA)
+def _fasta_to_tabular_msa(fh, qual=FileSentinel, constructor=None, **kwargs):
+    if constructor is None:
+        raise ValueError("Must provide `constructor`.")
+
+    return TabularMSA(
+        _fasta_to_generator(fh, qual=qual, constructor=constructor, **kwargs))
 
 
 @fasta.writer(None)
@@ -870,11 +854,11 @@ def _sequence_collection_to_fasta(obj, fh, qual=FileSentinel,
                         description_newline_replacement, max_width, lowercase)
 
 
-@fasta.writer(Alignment)
-def _alignment_to_fasta(obj, fh, qual=FileSentinel,
-                        id_whitespace_replacement='_',
-                        description_newline_replacement=' ', max_width=None,
-                        lowercase=None):
+@fasta.writer(TabularMSA)
+def _tabular_msa_to_fasta(obj, fh, qual=FileSentinel,
+                          id_whitespace_replacement='_',
+                          description_newline_replacement=' ', max_width=None,
+                          lowercase=None):
     _sequences_to_fasta(obj, fh, qual, id_whitespace_replacement,
                         description_newline_replacement, max_width, lowercase)
 

--- a/skbio/io/format/phylip.py
+++ b/skbio/io/format/phylip.py
@@ -32,7 +32,7 @@ Format Support
 +------+------+---------------------------------------------------------------+
 |Reader|Writer|                          Object Class                         |
 +======+======+===============================================================+
-|Yes   |Yes   |:mod:`skbio.alignment.Alignment`                               |
+|Yes   |Yes   |:mod:`skbio.alignment.TabularMSA`                              |
 +------+------+---------------------------------------------------------------+
 
 Format Specification
@@ -81,14 +81,16 @@ must have spaces appended to them to reach the 10 character fixed width. Within
 an ID, all characters except newlines are supported, including spaces,
 underscores, and numbers.
 
-.. note:: While not explicitly stated in the original PHYLIP format
-   description, scikit-bio only supports reading and writing unique sequence
-   identifiers (i.e., duplicates are not allowed). Uniqueness is required
-   because an ``skbio.alignment.Alignment`` cannot be created with duplicate
-   IDs.
+.. note:: When reading a PHYLIP-formatted file into an
+   ``skbio.alignment.TabularMSA`` object, sequence identifiers/labels are
+   stored as ``TabularMSA`` index labels (``index`` property).
+
+   When writing an ``skbio.alignment.TabularMSA`` object as a PHYLIP-formatted
+   file, ``TabularMSA`` index labels will be converted to strings and written
+   as sequence identifiers/labels.
 
    scikit-bio supports the empty string (``''``) as a valid sequence ID. An
-   empty ID will be padded with 10 spaces.
+   empty ID will be padded with 10 spaces when writing.
 
 Sequence characters immediately follow the sequence ID. They *must* start at
 the 11th character in the line, as the first 10 characters are reserved for the
@@ -108,8 +110,8 @@ improve readability), and both upper and lower case characters are supported.
    details.
 
    Since scikit-bio supports both ``-`` and ``.`` as gap characters (e.g., in
-   ``skbio.alignment.Alignment``), both are supported when reading/writing a
-   PHYLIP-formatted file.
+   ``DNA``, ``RNA``, and ``Protein`` sequence objects), both are supported when
+   reading/writing a PHYLIP-formatted file.
 
    When writing a PHYLIP-formatted file, scikit-bio will split up each sequence
    into chunks that are 10 characters long. Each chunk will be separated by a
@@ -123,34 +125,40 @@ improve readability), and both upper and lower case characters are supported.
 Format Parameters
 -----------------
 The only supported format parameter is ``constructor``, which specifies the
-type of in-memory sequence object to read each aligned sequence into. This is
-``Sequence`` by default. ``constructor`` can only be used with the
-``Alignment`` PHYLIP reader. ``constructor`` should be a subclass of
-``Sequence``. For example, if you know that the PHYLIP file you're reading
-contains DNA sequences, you would pass ``constructor=DNA`` to the reader call.
-
-.. note:: The PHYLIP sniffer will not attempt to guess the ``constructor``
-   parameter, so it will always default to ``Sequence`` if another type is not
-   provided to the reader.
+type of in-memory sequence object to read each aligned sequence into. This must
+be a subclass of ``IUPACSequence`` (e.g., ``DNA``, ``RNA``, ``Protein``) and is
+a required format parameter. For example, if you know that the PHYLIP file
+you're reading contains DNA sequences, you would pass ``constructor=DNA`` to
+the reader call.
 
 Examples
 --------
-Let's create an alignment with three DNA sequences of equal length:
+Let's create a ``TabularMSA`` with three DNA sequences:
 
->>> from skbio import Alignment, DNA
+>>> from skbio import TabularMSA, DNA
 >>> seqs = [DNA('ACCGTTGTA-GTAGCT', metadata={'id':'seq1'}),
 ...         DNA('A--GTCGAA-GTACCT', metadata={'id':'sequence-2'}),
 ...         DNA('AGAGTTGAAGGTATCT', metadata={'id':'3'})]
->>> aln = Alignment(seqs)
->>> aln
-<Alignment: n=3; mean +/- std length=16.00 +/- 0.00>
+>>> msa = TabularMSA(seqs, minter='id')
+>>> msa
+TabularMSA[DNA]
+----------------------
+Stats:
+    sequence count: 3
+    position count: 16
+----------------------
+ACCGTTGTA-GTAGCT
+A--GTCGAA-GTACCT
+AGAGTTGAAGGTATCT
+>>> msa.index
+Index(['seq1', 'sequence-2', '3'], dtype='object')
 
-Now let's write the alignment to file in PHYLIP format, and take a look at the
-output:
+Now let's write the ``TabularMSA`` to file in PHYLIP format and take a look at
+the output:
 
 >>> from io import StringIO
 >>> fh = StringIO()
->>> print(aln.write(fh, format='phylip').getvalue())
+>>> print(msa.write(fh, format='phylip').getvalue())
 3 16
 seq1      ACCGTTGTA- GTAGCT
 sequence-2A--GTCGAA- GTACCT
@@ -163,40 +171,36 @@ each sequence appears on a single line (sequential format). Also note that each
 sequence ID is padded with spaces to 10 characters in order to produce a fixed
 width column.
 
-If the sequence IDs in an alignment surpass the 10-character limit, an error
-will be raised when we try to write a PHYLIP file:
+If the index labels in a ``TabularMSA`` surpass the 10-character limit, an
+error will be raised when writing:
 
->>> long_id_seqs = [DNA('ACCGT', metadata={'id':'seq1'}),
-...                 DNA('A--GT', metadata={'id':'long-sequence-2'}),
-...                 DNA('AGAGT', metadata={'id':'seq3'})]
->>> long_id_aln = Alignment(long_id_seqs)
+>>> msa.index = ['seq1', 'long-sequence-2', 'seq3']
 >>> fh = StringIO()
->>> long_id_aln.write(fh, format='phylip')
+>>> msa.write(fh, format='phylip')
 Traceback (most recent call last):
     ...
-skbio.io._exception.PhylipFormatError: Alignment can only be written in \
-PHYLIP format if all sequence IDs have 10 or fewer characters. Found sequence \
-with ID 'long-sequence-2' that exceeds this limit. Use Alignment.update_ids \
-to assign shorter IDs.
+skbio.io._exception.PhylipFormatError: ``TabularMSA`` can only be written in \
+PHYLIP format if all sequence index labels have 10 or fewer characters. Found \
+sequence with index label 'long-sequence-2' that exceeds this limit. Use \
+``TabularMSA.reassign_index`` to assign shorter index labels.
 >>> fh.close()
 
-One way to work around this is to update the IDs to be shorter. The recommended
-way of accomplishing this is via ``Alignment.update_ids``, which provides a
-flexible way of creating a new ``Alignment`` with updated IDs. For example, to
-remap each of the IDs to integer-based IDs:
+One way to work around this is to assign shorter index labels. The recommended
+way to do this is via ``TabularMSA.reassign_index``. For example, to reassign
+default integer index labels:
 
->>> short_id_aln, _ = long_id_aln.update_ids()
->>> short_id_aln.ids()
-['1', '2', '3']
+>>> msa.reassign_index()
+>>> msa.index
+Int64Index([0, 1, 2], dtype='int64')
 
-We can now write the new alignment in PHYLIP format:
+We can now write the ``TabularMSA`` in PHYLIP format:
 
 >>> fh = StringIO()
->>> print(short_id_aln.write(fh, format='phylip').getvalue())
-3 5
-1         ACCGT
-2         A--GT
-3         AGAGT
+>>> print(msa.write(fh, format='phylip').getvalue())
+3 16
+0         ACCGTTGTA- GTAGCT
+1         A--GTCGAA- GTACCT
+2         AGAGTTGAAG GTATCT
 <BLANKLINE>
 >>> fh.close()
 
@@ -222,8 +226,7 @@ References
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-from skbio.alignment import Alignment
-from skbio.sequence import Sequence
+from skbio.alignment import TabularMSA
 from skbio.io import create_format, PhylipFormatError
 from skbio.util._misc import chunk_str
 
@@ -248,42 +251,50 @@ def _phylip_sniffer(fh):
     return True, {}
 
 
-@phylip.reader(Alignment)
-def _phylip_to_alignment(fh, constructor=Sequence):
-    return Alignment([constructor(seq, metadata={'id': ID})
-                      for (seq, ID) in _parse_phylip_raw(fh)])
+@phylip.reader(TabularMSA)
+def _phylip_to_tabular_msa(fh, constructor=None):
+    if constructor is None:
+        raise ValueError("Must provide `constructor`.")
+
+    seqs = []
+    index = []
+    for seq, ID in _parse_phylip_raw(fh):
+        seqs.append(constructor(seq))
+        index.append(ID)
+    return TabularMSA(seqs, index=index)
 
 
-@phylip.writer(Alignment)
-def _alignment_to_phylip(obj, fh):
-    if obj.is_empty():
+@phylip.writer(TabularMSA)
+def _tabular_msa_to_phylip(obj, fh):
+    sequence_count = obj.shape.sequence
+    if sequence_count < 1:
         raise PhylipFormatError(
-            "Alignment can only be written in PHYLIP format if there is at "
+            "TabularMSA can only be written in PHYLIP format if there is at "
             "least one sequence in the alignment.")
 
-    sequence_length = obj.sequence_length()
-    if sequence_length == 0:
+    sequence_length = obj.shape.position
+    if sequence_length < 1:
         raise PhylipFormatError(
-            "Alignment can only be written in PHYLIP format if there is at "
+            "TabularMSA can only be written in PHYLIP format if there is at "
             "least one position in the alignment.")
 
     chunk_size = 10
-    for id_ in obj.ids():
-        if len(id_) > chunk_size:
+    labels = [str(label) for label in obj.index]
+    for label in labels:
+        if len(label) > chunk_size:
             raise PhylipFormatError(
-                "Alignment can only be written in PHYLIP format if all "
-                "sequence IDs have %d or fewer characters. Found sequence "
-                "with ID '%s' that exceeds this limit. Use "
-                "Alignment.update_ids to assign shorter IDs." %
-                (chunk_size, id_))
+                "``TabularMSA`` can only be written in PHYLIP format if all "
+                "sequence index labels have %d or fewer characters. Found "
+                "sequence with index label '%s' that exceeds this limit. Use "
+                "``TabularMSA.reassign_index`` to assign shorter index labels."
+                % (chunk_size, label))
 
-    sequence_count = obj.sequence_count()
     fh.write('{0:d} {1:d}\n'.format(sequence_count, sequence_length))
 
     fmt = '{0:%d}{1}\n' % chunk_size
-    for seq in obj:
+    for label, seq in zip(labels, obj):
         chunked_seq = chunk_str(str(seq), chunk_size, ' ')
-        fh.write(fmt.format(seq.metadata['id'], chunked_seq))
+        fh.write(fmt.format(label, chunked_seq))
 
 
 def _validate_header(header):

--- a/skbio/io/format/tests/data/phylip_variable_length_ids
+++ b/skbio/io/format/tests/data/phylip_variable_length_ids
@@ -1,7 +1,7 @@
 6 6
-          .-ACGU
-a         UGCA-.
-bb        .ACGU-
-1         ugca-.
-abcdefghijAaAaAa
+          .-ACGT
+a         TGCA-.
+bb        .ACGT-
+1         TGCA-.
+abcdefghijAAAAAA
 ab def42ijGGGGGG

--- a/skbio/io/format/tests/test_fastq.py
+++ b/skbio/io/format/tests/test_fastq.py
@@ -11,19 +11,21 @@ from future.builtins import zip
 import six
 
 import io
+import string
 import unittest
 import warnings
 from functools import partial
 
 from skbio import (read, write, Sequence, DNA, RNA, Protein,
-                   SequenceCollection, Alignment)
+                   SequenceCollection, TabularMSA)
 from skbio.io import FASTQFormatError
 from skbio.io.format.fastq import (
     _fastq_sniffer, _fastq_to_generator, _fastq_to_sequence_collection,
-    _fastq_to_alignment, _generator_to_fastq, _sequence_collection_to_fastq,
-    _alignment_to_fastq)
-
+    _fastq_to_tabular_msa, _generator_to_fastq, _sequence_collection_to_fastq,
+    _tabular_msa_to_fastq)
+from skbio.sequence._iupac_sequence import IUPACSequence
 from skbio.util import get_data_path
+from skbio.util._decorator import classproperty, overrides
 
 import numpy as np
 
@@ -414,18 +416,36 @@ class TestReaders(unittest.TestCase):
                                                              **observed_kwargs)
                     self.assertEqual(observed, expected)
 
-    def test_fastq_to_alignment(self):
+    def test_fastq_to_tabular_msa(self):
+        class CustomSequence(IUPACSequence):
+            @classproperty
+            @overrides(IUPACSequence)
+            def gap_chars(cls):
+                return set('-.')
+
+            @classproperty
+            @overrides(IUPACSequence)
+            def nondegenerate_chars(cls):
+                return set(string.ascii_letters)
+
+            @classproperty
+            @overrides(IUPACSequence)
+            def degenerate_map(cls):
+                return {}
+
         for valid_files, kwargs, components in self.valid_configurations:
             for valid in valid_files:
                 for observed_kwargs in kwargs:
                     _drop_kwargs(observed_kwargs, 'seq_num')
-                    constructor = observed_kwargs.get('constructor', Sequence)
+                    if 'constructor' not in observed_kwargs:
+                        observed_kwargs['constructor'] = CustomSequence
+                    constructor = observed_kwargs['constructor']
 
                     expected_kwargs = {}
                     expected_kwargs['lowercase'] = 'introns'
                     observed_kwargs['lowercase'] = 'introns'
 
-                    expected = Alignment(
+                    expected = TabularMSA(
                         [constructor(
                             c[2], metadata={'id': c[0],
                                             'description': c[1]},
@@ -434,8 +454,12 @@ class TestReaders(unittest.TestCase):
                             **expected_kwargs)
                          for c in components])
 
-                    observed = _fastq_to_alignment(valid, **observed_kwargs)
+                    observed = _fastq_to_tabular_msa(valid, **observed_kwargs)
                     self.assertEqual(observed, expected)
+
+    def test_fastq_to_tabular_msa_no_constructor(self):
+        with six.assertRaisesRegex(self, ValueError, '`constructor`'):
+            _fastq_to_tabular_msa(get_data_path('fastq_multi_seq_sanger'))
 
 
 class TestWriters(unittest.TestCase):
@@ -535,10 +559,10 @@ class TestWriters(unittest.TestCase):
 
                 self.assertEqual(observed, expected)
 
-    def test_alignment_to_fastq_kwargs_passed(self):
+    def test_tabular_msa_to_fastq_kwargs_passed(self):
         for components, kwargs_expected_fp in self.valid_files:
             for kwargs, expected_fp in kwargs_expected_fp:
-                obj = Alignment([
+                obj = TabularMSA([
                     Protein(c[2], metadata={'id': c[0], 'description': c[1]},
                             positional_metadata={'quality': c[3]},
                             lowercase='introns')
@@ -546,7 +570,7 @@ class TestWriters(unittest.TestCase):
 
                 fh = io.StringIO()
                 kwargs['lowercase'] = 'introns'
-                _alignment_to_fastq(obj, fh, **kwargs)
+                _tabular_msa_to_fastq(obj, fh, **kwargs)
                 observed = fh.getvalue()
                 fh.close()
 


### PR DESCRIPTION
Removed `Alignment` from I/O. Updated I/O format docs as necessary. Fixes #1197.