### PR TITLE
WEB: update copybutton.js for JQuery 1.9

### DIFF
--- a/doc/source/_static/copybutton.js
+++ b/doc/source/_static/copybutton.js
@@ -2,11 +2,11 @@
 $(document).ready(function() {
     /* Add a [>>>] button on the top-right corner of code samples to hide
      * the >>> and ... prompts and the output and thus make the code
-     * copyable. 
+     * copyable.
      * Note: This JS snippet was taken from the official python.org
      * documentation site.*/
     var div = $('.highlight-python .highlight,' +
-                '.highlight-python3 .highlight,' + 
+                '.highlight-python3 .highlight,' +
                 '.highlight-pycon .highlight')
     var pre = div.find('pre');
 
@@ -21,7 +21,8 @@ $(document).ready(function() {
         'cursor':'pointer', 'position': 'absolute', 'top': '0', 'right': '0',
         'border-color': border_color, 'border-style': border_style,
         'border-width': border_width, 'color': border_color, 'text-size': '75%',
-        'font-family': 'monospace', 'padding-left': '0.2em', 'padding-right': '0.2em'
+        'font-family': 'monospace', 'padding-left': '0.2em', 'padding-right': '0.2em',
+        'display': 'inline'
     }
 
     // create and add the button to all the code blocks that contain >>>
@@ -32,6 +33,25 @@ $(document).ready(function() {
             button.css(button_styles)
             button.attr('title', hide_text);
             jthis.prepend(button);
+
+            var show_output = false;
+            button.bind('click', function() {
+                if (show_output) {
+                    var button = $(this);
+                    button.parent().find('.go, .gp, .gt').show();
+                    button.next('pre').find('.gt').nextUntil('.gp, .go').css('visibility', 'visible');
+                    button.css('text-decoration', 'none');
+                    button.attr('title', hide_text);
+                    show_output = false;
+                } else {
+                    var button = $(this);
+                    button.parent().find('.go, .gp, .gt').hide();
+                    button.next('pre').find('.gt').nextUntil('.gp, .go').css('visibility', 'hidden');
+                    button.css('text-decoration', 'line-through');
+                    button.attr('title', show_text);
+                    show_output = true;
+                }
+            });
         }
         // tracebacks (.gt) contain bare text elements that need to be
         // wrapped in a span to work with .nextUntil() (see later)
@@ -39,22 +59,4 @@ $(document).ready(function() {
             return ((this.nodeType == 3) && (this.data.trim().length > 0));
         }).wrap('<span>');
     });
-
-    // define the behavior of the button when it's clicked
-    $('.copybutton').toggle(
-        function() {
-            var button = $(this);
-            button.parent().find('.go, .gp, .gt').hide();
-            button.next('pre').find('.gt').nextUntil('.gp, .go').css('visibility', 'hidden');
-            button.css('text-decoration', 'line-through');
-            button.attr('title', show_text);
-        },
-        function() {
-            var button = $(this);
-            button.parent().find('.go, .gp, .gt').show();
-            button.next('pre').find('.gt').nextUntil('.gp, .go').css('visibility', 'visible');
-            button.css('text-decoration', 'none');
-            button.attr('title', hide_text);
-        });
 });
-


### PR DESCRIPTION
JQuery deprecated `toggle` in 1.9 and replaced it with an identical function that controls visibility and animation instead. So not only did the click event stop working, calling toggle made them all disappear!