### PR TITLE
Warning fixes

### DIFF
--- a/ci/pip_requirements.txt
+++ b/ci/pip_requirements.txt
@@ -1,4 +1,4 @@
-HTTPretty
+HTTPretty <= 0.8.10
 bz2file
 contextlib2
 coveralls

--- a/skbio/diversity/alpha/_lladser.py
+++ b/skbio/diversity/alpha/_lladser.py
@@ -213,7 +213,7 @@ def _get_interval_for_r_new_otus(seq, r):
 
         # bail out if not enough unseen
         if not count or (unseen < r):
-            raise StopIteration
+            return
 
         # make a copy of seen before yielding, as we'll continue to add to the
         # set in subsequent iterations

--- a/skbio/io/format/fasta.py
+++ b/skbio/io/format/fasta.py
@@ -839,7 +839,10 @@ def _parse_fasta_raw(fh, data_parser, error_type):
 
     """
     # Skip any blank or whitespace-only lines at beginning of file
-    seq_header = next(_line_generator(fh, skip_blanks=True))
+    try:
+        seq_header = next(_line_generator(fh, skip_blanks=True))
+    except StopIteration:
+        return
 
     # header check inlined here and below for performance
     if seq_header.startswith('>'):

--- a/skbio/io/format/fastq.py
+++ b/skbio/io/format/fastq.py
@@ -326,7 +326,10 @@ def _fastq_sniffer(fh):
 def _fastq_to_generator(fh, variant=None, phred_offset=None,
                         constructor=Sequence, **kwargs):
     # Skip any blank or whitespace-only lines at beginning of file
-    seq_header = next(_line_generator(fh, skip_blanks=True))
+    try:
+        seq_header = next(_line_generator(fh, skip_blanks=True))
+    except StopIteration:
+        return
 
     if not seq_header.startswith('@'):
         raise FASTQFormatError(

--- a/skbio/io/format/tests/test_fasta.py
+++ b/skbio/io/format/tests/test_fasta.py
@@ -709,7 +709,7 @@ class WriterTests(TestCase):
         self.msa = TabularMSA(seqs)
 
         def empty_gen():
-            raise StopIteration()
+            return
             yield
 
         def single_seq_gen():

--- a/skbio/io/registry.py
+++ b/skbio/io/registry.py
@@ -512,9 +512,8 @@ class IORegistry(object):
         with _resolve_file(file, **io_kwargs) as (file, _, _):
             reader, kwargs = self._init_reader(file, fmt, into, verify, kwargs,
                                                io_kwargs)
-            generator = reader(file, **kwargs)
-            while True:
-                yield next(generator)
+            for item in reader(file, **kwargs):
+                yield item
 
     def _find_io_kwargs(self, kwargs):
         return {k: kwargs[k] for k in _open_kwargs if k in kwargs}
@@ -977,9 +976,8 @@ class Format(object):
                         file_params, file, encoding, newline, kwargs)
                     with open_files(files, mode='r', **io_kwargs) as fhs:
                         kwargs.update(zip(file_keys, fhs[:-1]))
-                        generator = reader_function(fhs[-1], **kwargs)
-                        while True:
-                            yield next(generator)
+                        for item in reader_function(fhs[-1], **kwargs):
+                            yield item
 
             self._add_reader(cls, wrapped_reader, monkey_patch, override)
             return wrapped_reader

--- a/skbio/sequence/tests/test_sequence.py
+++ b/skbio/sequence/tests/test_sequence.py
@@ -61,7 +61,7 @@ class TestSequence(TestCase, ReallyEqualMixin):
             lambda s: np.fromstring(s, dtype=np.uint8)])
 
         def empty_generator():
-            raise StopIteration()
+            return
             yield
 
         self.getitem_empty_indices = [

--- a/skbio/stats/power.py
+++ b/skbio/stats/power.py
@@ -261,7 +261,7 @@ def subsample_power(test, samples, draw_mode='ind', alpha_pwr=0.05, ratio=None,
     `scipy.stats.chisquare` to look for the difference in frequency between
     groups.
 
-    >>> from scipy.stats import chisquare, nanmean
+    >>> from scipy.stats import chisquare
     >>> test = lambda x: chisquare(np.array([x[i].sum() for i in
     ...     range(len(x))]))[1]
 
@@ -287,10 +287,10 @@ def subsample_power(test, samples, draw_mode='ind', alpha_pwr=0.05, ratio=None,
     ...                                   counts_interval=5)
     >>> counts
     array([ 5, 10, 15, 20, 25, 30, 35, 40, 45])
-    >>> nanmean(pwr_est, 0) # doctest: +NORMALIZE_WHITESPACE
+    >>> np.nanmean(pwr_est, axis=0) # doctest: +NORMALIZE_WHITESPACE
     array([ 0.056,  0.074,  0.226,  0.46 ,  0.61 ,  0.806,  0.952,  1.   ,
             1.   ])
-    >>> counts[nanmean(pwr_est, 0) > 0.8].min()
+    >>> counts[np.nanmean(pwr_est, axis=0) > 0.8].min()
     30
 
     So, we can estimate that we will see a significant difference in the
@@ -338,9 +338,9 @@ def subsample_power(test, samples, draw_mode='ind', alpha_pwr=0.05, ratio=None,
     ...                                     ratio=[2, 1])
     >>> counts2
     array([  5.,  10.,  15.,  20.,  25.,  30.])
-    >>> nanmean(pwr_est2, 0)
+    >>> np.nanmean(pwr_est2, axis=0)
     array([ 0.14 ,  0.272,  0.426,  0.646,  0.824,  0.996])
-    >>> counts2[nanmean(pwr_est2, 0) > 0.8].min()
+    >>> counts2[np.nanmean(pwr_est2, axis=0) > 0.8].min()
     25.0
 
     When we consider the number of samples per group needed in the power
@@ -610,7 +610,9 @@ def confidence_bound(vec, alpha=0.05, df=None, axis=None):
         df = num_counts - 1
 
     # Calculates the bound
-    bound = scipy.stats.nanstd(vec, axis=axis) / np.sqrt(num_counts - 1) * \
+    # In the conversion from scipy.stats.nanstd -> np.nanstd `ddof=1` had to be
+    # added to match the scipy default of `bias=False`.
+    bound = np.nanstd(vec, axis=axis, ddof=1) / np.sqrt(num_counts - 1) * \
         scipy.stats.t.ppf(1 - alpha / 2, df)
 
     return bound

--- a/skbio/stats/tests/test_gradient.py
+++ b/skbio/stats/tests/test_gradient.py
@@ -228,7 +228,7 @@ class GradientTests(BaseTests):
                                              's7': np.array([7]),
                                              's8': np.array([8])},
                                             orient='index')
-        trajectory.sort(columns=0, inplace=True)
+        trajectory.sort_values(by=0, inplace=True)
         w_vector = pd.Series(np.array([1, 5, 8, 12, 45, 80, 85, 90]),
                              ['s1', 's2', 's3', 's4',
                               's5', 's6', 's7', 's8']).astype(np.float64)
@@ -242,7 +242,7 @@ class GradientTests(BaseTests):
                                       's8': np.array([20.3428571428])},
                                      orient='index')
         obs = _weight_by_vector(trajectory, w_vector)
-        assert_data_frame_almost_equal(obs.sort(axis=0), exp.sort(axis=0))
+        assert_data_frame_almost_equal(obs.sort_index(), exp.sort_index())
 
         trajectory = pd.DataFrame.from_dict({'s1': np.array([1]),
                                              's2': np.array([2]),
@@ -253,7 +253,7 @@ class GradientTests(BaseTests):
                                              's7': np.array([7]),
                                              's8': np.array([8])},
                                             orient='index')
-        trajectory.sort(columns=0, inplace=True)
+        trajectory.sort_values(by=0, inplace=True)
         w_vector = pd.Series(np.array([1, 2, 3, 4, 5, 6, 7, 8]),
                              ['s1', 's2', 's3', 's4',
                               's5', 's6', 's7', 's8']).astype(np.float64)
@@ -264,7 +264,7 @@ class GradientTests(BaseTests):
                                       },
                                      orient='index')
         obs = _weight_by_vector(trajectory, w_vector)
-        assert_data_frame_almost_equal(obs.sort(axis=0), exp.sort(axis=0))
+        assert_data_frame_almost_equal(obs.sort_index(), exp.sort_index())
 
         trajectory = pd.DataFrame.from_dict({'s2': np.array([2]),
                                              's3': np.array([3]),
@@ -272,21 +272,21 @@ class GradientTests(BaseTests):
                                              's5': np.array([5]),
                                              's6': np.array([6])},
                                             orient='index')
-        trajectory.sort(columns=0, inplace=True)
+        trajectory.sort_values(by=0, inplace=True)
         w_vector = pd.Series(np.array([25, 30, 35, 40, 45]),
                              ['s2', 's3', 's4', 's5', 's6']).astype(np.float64)
         exp = pd.DataFrame.from_dict({'s2': np.array([2]), 's3': np.array([3]),
                                       's4': np.array([4]), 's5': np.array([5]),
                                       's6': np.array([6])}, orient='index')
         obs = _weight_by_vector(trajectory, w_vector)
-        assert_data_frame_almost_equal(obs.sort(axis=0), exp.sort(axis=0))
+        assert_data_frame_almost_equal(obs.sort_index(), exp.sort_index())
 
         trajectory = pd.DataFrame.from_dict({'s1': np.array([1, 2, 3]),
                                              's2': np.array([2, 3, 4]),
                                              's3': np.array([5, 6, 7]),
                                              's4': np.array([8, 9, 10])},
                                             orient='index')
-        trajectory.sort(columns=0, inplace=True)
+        trajectory.sort_values(by=0, inplace=True)
         w_vector = pd.Series(np.array([1, 2, 3, 4]),
                              ['s1', 's2', 's3', 's4']).astype(np.float64)
         exp = pd.DataFrame.from_dict({'s1': np.array([1, 2, 3]),
@@ -295,7 +295,7 @@ class GradientTests(BaseTests):
                                       's4': np.array([8, 9, 10])},
                                      orient='index').astype(np.float64)
         obs = _weight_by_vector(trajectory, w_vector)
-        assert_data_frame_almost_equal(obs.sort(axis=0), exp.sort(axis=0))
+        assert_data_frame_almost_equal(obs.sort_index(), exp.sort_index())
 
         sample_ids = ['PC.356', 'PC.481', 'PC.355', 'PC.593', 'PC.354']
         trajectory = pd.DataFrame.from_dict({'PC.356': np.array([5.65948525,
@@ -334,7 +334,7 @@ class GradientTests(BaseTests):
                                       }, orient='index')
         obs = _weight_by_vector(trajectory.ix[sample_ids],
                                 w_vector[sample_ids])
-        assert_data_frame_almost_equal(obs.sort(axis=0), exp.sort(axis=0))
+        assert_data_frame_almost_equal(obs.sort_index(), exp.sort_index())
 
     def test_weight_by_vector_single_element(self):
         trajectory = pd.DataFrame.from_dict({'s1': np.array([42])},
@@ -578,20 +578,20 @@ class GradientANOVATests(BaseTests):
         # Takes a subset from metadata_map
         bv = GradientANOVA(subset_coords, self.prop_expl, self.metadata_map)
         assert_data_frame_almost_equal(
-            bv._coords.sort(axis=0),
-            subset_coords.sort(axis=0))
+            bv._coords.sort_index(),
+            subset_coords.sort_index())
         assert_data_frame_almost_equal(
-            bv._metadata_map.sort(axis=0),
-            subset_metadata_map.sort(axis=0))
+            bv._metadata_map.sort_index(),
+            subset_metadata_map.sort_index())
 
         # Takes a subset from coords
         bv = GradientANOVA(self.coords, self.prop_expl, subset_metadata_map)
         assert_data_frame_almost_equal(
-            bv._coords.sort(axis=0),
-            subset_coords.sort(axis=0))
+            bv._coords.sort_index(),
+            subset_coords.sort_index())
         assert_data_frame_almost_equal(
-            bv._metadata_map.sort(axis=0),
-            subset_metadata_map.sort(axis=0))
+            bv._metadata_map.sort_index(),
+            subset_metadata_map.sort_index())
 
         # Takes a subset from metadata_map and coords at the same time
         coord_data = {
@@ -625,8 +625,8 @@ class GradientANOVATests(BaseTests):
                                  -0.0301637746424])},
             orient='index')
         assert_data_frame_almost_equal(
-            bv._coords.sort(axis=0),
-            exp_coords.sort(axis=0))
+            bv._coords.sort_index(),
+            exp_coords.sort_index())
         exp_metadata_map = pd.DataFrame.from_dict(
             {'PC.355': {'Treatment': 'Control',
                         'DOB': '20061218',
@@ -634,8 +634,8 @@ class GradientANOVATests(BaseTests):
                         'Description': 'Control_mouse_I.D._355'}},
             orient='index')
         assert_data_frame_almost_equal(
-            bv._metadata_map.sort(axis=0),
-            exp_metadata_map.sort(axis=0))
+            bv._metadata_map.sort_index(),
+            exp_metadata_map.sort_index())
 
     def test_normalize_samples_error(self):
         """Raises an error if coords and metadata_map does not have samples in

--- a/skbio/tree/_tree.py
+++ b/skbio/tree/_tree.py
@@ -1176,7 +1176,7 @@ class TreeNode(SkbioObject):
         if not self.children:
             if include_self:
                 yield self
-            raise StopIteration
+            return
         child_index_stack = [0]
         curr = self
         curr_children = self.children

--- a/skbio/util/__init__.py
+++ b/skbio/util/__init__.py
@@ -57,16 +57,17 @@ Warnings
 
 from __future__ import absolute_import, division, print_function
 
-from ._warning import EfficiencyWarning, RepresentationWarning
+from ._warning import EfficiencyWarning, RepresentationWarning, SkbioWarning
 from ._misc import (cardinal_to_ordinal, create_dir, find_duplicates,
                     is_casava_v180_or_later, remove_files, safe_md5)
 from ._testing import (get_data_path, TestRunner,
                        assert_ordination_results_equal,
                        assert_data_frame_almost_equal)
 
-__all__ = ['EfficiencyWarning', 'RepresentationWarning', 'cardinal_to_ordinal',
-           'create_dir', 'find_duplicates', 'is_casava_v180_or_later',
-           'remove_files', 'safe_md5', 'get_data_path', 'TestRunner',
-           'assert_ordination_results_equal', 'assert_data_frame_almost_equal']
+__all__ = ['SkbioWarning', 'EfficiencyWarning', 'RepresentationWarning',
+           'cardinal_to_ordinal', 'create_dir', 'find_duplicates',
+           'is_casava_v180_or_later', 'remove_files', 'safe_md5',
+           'get_data_path', 'TestRunner', 'assert_ordination_results_equal',
+           'assert_data_frame_almost_equal']
 
 test = TestRunner(__file__).test

--- a/skbio/util/_decorator.py
+++ b/skbio/util/_decorator.py
@@ -13,6 +13,7 @@ import textwrap
 import decorator
 
 from ._exception import OverrideError
+from ._warning import DeprecationWarning as SkbioDeprecationWarning
 
 
 class _state_decorator(object):
@@ -254,7 +255,7 @@ class deprecated(_state_decorator):
             warnings.warn('%s is deprecated as of scikit-bio version %s, and '
                           'will be removed in version %s. %s' %
                           (func.__name__, self.as_of, self.until, self.reason),
-                          DeprecationWarning)
+                          SkbioDeprecationWarning)
             # args[0] is the function being wrapped when this is called
             # after wrapping with decorator.decorator, but why???
             return func(*args[1:], **kwargs)

--- a/skbio/util/_misc.py
+++ b/skbio/util/_misc.py
@@ -38,14 +38,20 @@ def make_sentinel(name):
 
 def find_sentinels(function, sentinel):
     keys = []
-    function_spec = inspect.getargspec(function)
-    if function_spec.defaults is not None:
-        # Concept from http://stackoverflow.com/a/12627202/579416
-        keywords_start = -len(function_spec.defaults)
-        for key, default in zip(function_spec.args[keywords_start:],
-                                function_spec.defaults):
-            if default is sentinel:
-                keys.append(key)
+    if hasattr(inspect, 'signature'):
+        params = inspect.signature(function).parameters
+        for name, param in params.items():
+            if param.default is sentinel:
+                keys.append(name)
+    else:  # Py2
+        function_spec = inspect.getargspec(function)
+        if function_spec.defaults is not None:
+            # Concept from http://stackoverflow.com/a/12627202/579416
+            keywords_start = -len(function_spec.defaults)
+            for key, default in zip(function_spec.args[keywords_start:],
+                                    function_spec.defaults):
+                if default is sentinel:
+                    keys.append(key)
     return keys
 
 

--- a/skbio/util/_warning.py
+++ b/skbio/util/_warning.py
@@ -9,7 +9,12 @@
 from __future__ import absolute_import, division, print_function
 
 
-class EfficiencyWarning(Warning):
+class SkbioWarning(Warning):
+    """Used to filter our warnings from warnings given by 3rd parties"""
+    pass
+
+
+class EfficiencyWarning(SkbioWarning):
     """Warn about potentially accidental use of inefficient code.
 
     For example, if a user doesn't have an optimized version of a
@@ -22,7 +27,7 @@ class EfficiencyWarning(Warning):
     pass
 
 
-class RepresentationWarning(Warning):
+class RepresentationWarning(SkbioWarning):
     """Warn about assumptions made for the successful completion of a process.
 
     Warn about substitutions, assumptions, or particular alterations that were
@@ -31,4 +36,9 @@ class RepresentationWarning(Warning):
     deleterious value could be used, accompanied by this warning.
 
     """
+    pass
+
+
+class DeprecationWarning(DeprecationWarning, SkbioWarning):
+    """Used to indicate deprecated functionality in scikit-bio."""
     pass

--- a/skbio/util/tests/test_decorator.py
+++ b/skbio/util/tests/test_decorator.py
@@ -224,6 +224,8 @@ class TestStable(TestStabilityState):
 
     def test_function_signature(self):
         f = self._get_f('0.1.0')
+        # Py2: update this to use inspect.signature when we drop Python 2
+        # inspect.getargspec is deprecated and won't exist in 3.6
         expected = inspect.ArgSpec(
             args=['x', 'y'], varargs=None, keywords=None, defaults=(42,))
         self.assertEqual(inspect.getargspec(f), expected)
@@ -261,6 +263,8 @@ class TestExperimental(TestStabilityState):
 
     def test_function_signature(self):
         f = self._get_f('0.1.0')
+        # Py2: update this to use inspect.signature when we drop Python 2
+        # inspect.getargspec is deprecated and won't exist in 3.6
         expected = inspect.ArgSpec(
             args=['x', 'y'], varargs=None, keywords=None, defaults=(42,))
         self.assertEqual(inspect.getargspec(f), expected)
@@ -318,6 +322,8 @@ class TestDeprecated(TestStabilityState):
     def test_function_signature(self):
         f = self._get_f('0.1.0', until='0.1.4',
                         reason='You should now use skbio.g().')
+        # Py2: update this to use inspect.signature when we drop Python 2
+        # inspect.getargspec is deprecated and won't exist in 3.6
         expected = inspect.ArgSpec(
             args=['x', 'y'], varargs=None, keywords=None, defaults=(42,))
         self.assertEqual(inspect.getargspec(f), expected)

--- a/skbio/util/tests/test_misc.py
+++ b/skbio/util/tests/test_misc.py
@@ -286,7 +286,7 @@ class CardinalToOrdinalTests(unittest.TestCase):
 class TestFindDuplicates(unittest.TestCase):
     def test_empty_input(self):
         def empty_gen():
-            raise StopIteration()
+            return
             yield
 
         for empty in [], (), '', set(), {}, empty_gen():


### PR DESCRIPTION
This PR does 3 things:

- Drops the version of HTTPretty because their latest release has a syntax error in Py3
- Subclass all scikit-bio warnings from `SkbioWarning` this allows us to filter only those warnings in the test. Ideally this will make real warnings more noticeable.
- Fix a bunch of warnings throughout the codebase so things don't fall apart come `3.6` or new `pandas`/`scipy` release. 

@gregcaporaso could you review? The `HTTPretty` part is blocking #1242 