### PR TITLE
Test in verbose mode to track down Travis timeout

### DIFF
--- a/skbio/util/_testing.py
+++ b/skbio/util/_testing.py
@@ -930,7 +930,7 @@ class TestRunner(object):
         self._test_dir = os.path.dirname(filename)
 
     @experimental(as_of="0.4.0")
-    def test(self, verbose=False):
+    def test(self, verbose=True):
         """Performs the actual running of the tests.
 
         Parameters


### PR DESCRIPTION
**DO NOT MERGE**

Travis builds are timing out, running tests in verbose mode to figure out why.