### PR TITLE
Deal with different lapacks

### DIFF
--- a/skbio/stats/composition.py
+++ b/skbio/stats/composition.py
@@ -405,8 +405,8 @@ def inner(x, y):
     >>> from skbio.stats.composition import inner
     >>> x = np.array([.1, .3, .4, .2])
     >>> y = np.array([.2, .4, .2, .2])
-    >>> inner(x, y)
-    0.21078524737545556
+    >>> inner(x, y)  # doctest: +ELLIPSIS
+    0.2107852473...
     """
     x = closure(x)
     y = closure(y)

--- a/skbio/stats/ordination/tests/test_redundancy_analysis.py
+++ b/skbio/stats/ordination/tests/test_redundancy_analysis.py
@@ -106,6 +106,7 @@ class TestRDAResults(TestCase):
             eigvals=eigvals)
 
         assert_ordination_results_equal(scores, exp,
+                                        ignore_directionality=True,
                                         ignore_biplot_scores_labels=True,
                                         decimal=6)
 
@@ -163,6 +164,7 @@ class TestRDAResults(TestCase):
             eigvals=eigvals)
 
         assert_ordination_results_equal(scores, exp,
+                                        ignore_directionality=True,
                                         ignore_biplot_scores_labels=True,
                                         decimal=6)
 

--- a/skbio/util/_testing.py
+++ b/skbio/util/_testing.py
@@ -1015,7 +1015,7 @@ def assert_ordination_results_equal(left, right, ignore_method_names=False,
         Ignore differences in `biplot_scores` row and column labels.
     ignore_directionality : bool, optional
         Ignore differences in directionality (i.e., differences in signs) for
-        attributes `samples` and `features`.
+        attributes `samples`, `features` and `biplot_scores`.
 
     Raises
     ------
@@ -1042,6 +1042,7 @@ def assert_ordination_results_equal(left, right, ignore_method_names=False,
     _assert_frame_equal(left.biplot_scores, right.biplot_scores,
                         ignore_biplot_scores_labels,
                         ignore_biplot_scores_labels,
+                        ignore_directionality=ignore_directionality,
                         decimal=decimal)
 
     _assert_frame_equal(left.sample_constraints, right.sample_constraints,

--- a/skbio/util/_testing.py
+++ b/skbio/util/_testing.py
@@ -1047,6 +1047,7 @@ def assert_ordination_results_equal(left, right, ignore_method_names=False,
 
     _assert_frame_equal(left.sample_constraints, right.sample_constraints,
                         ignore_columns=ignore_axis_labels,
+                        ignore_directionality=ignore_directionality,
                         decimal=decimal)
 
     _assert_series_equal(left.eigvals, right.eigvals, ignore_axis_labels,


### PR DESCRIPTION
Closes #1267.

Like the other ordination functions, directionality has to be "ignored" when comparing results. I can't reproduce the sign changes in #1267, so please @jairideout let me know if this works in your end :)