### PR TITLE
WEB: fixed style of signatures

### DIFF
--- a/doc/source/_static/style.css
+++ b/doc/source/_static/style.css
@@ -19,6 +19,10 @@ code {
     font-size: 100% !important;
 }
 
+code.descclassname, code.descname {
+    padding: 2px 0px;
+}
+
 cite, code.docutils.literal:not(.xref) {
     padding: 1px 4px !important;
     font-size: 100% !important;


### PR DESCRIPTION
fixes #1268 

Point 2. seems to have been a transient issue with some version of sphinx/sphinx-bootstrap-theme. It appears to be resolved in the latest versions of both.