### PR TITLE
ENH/BUG/PERF: improvements to Sequence distance calculations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,16 +4,21 @@
 
 ### Features
 * Added `skbio.io.format.stockholm` for reading Stockholm files into a `TabularMSA`. ([#967](https://github.com/biocore/scikit-bio/issues/967))
+* scikit-bio `Sequence` objects have better compatibility with numpy. For example, calling `np.asarray(sequence)` now converts the sequence to a numpy array of characters (the same as calling `sequence.values`).
+* Added `skbio.sequence.distance` subpackage for computing distances between scikit-bio `Sequence` objects ([#913](https://github.com/biocore/scikit-bio/issues/913))
 
 ### Backward-incompatible changes [stable]
 * When sniffing or reading a file (`skbio.io.sniff`, `skbio.io.read`, or the object-oriented `.read()` interface), passing `newline` as a keyword argument to `skbio.io.open` now raises a `TypeError`. This backward-incompatible change to a stable API is necessary because it fixes a bug (more details in bug fix section below).
 
 ### Backward-incompatible changes [experimental]
 * `skbio.io.format.genbank`: When reading GenBank files, the date field of the LOCUS line is no longer parsed into a `datetime.datetime` object and is left as a string. When writing GenBank files, the locus date metadata is expected to be a string instead of a `datetime.datetime` object ([#1153](https://github.com/biocore/scikit-bio/issues/1153))
+* `Sequence.distance` now converts the input sequence (`other`) to its type before passing both sequences to `metric`. Previous behavior was to always convert to `Sequence`.
 
 ### Bug fixes
 * Changed `skbio.stats.composition.multiplicative_replacement` to raise an error whenever a large value of `delta` is chosen ([#1241](https://github.com/biocore/scikit-bio/issues/1241))
 * When sniffing or reading a file (`skbio.io.sniff`, `skbio.io.read`, or the object-oriented `.read()` interface), passing `newline` as a keyword argument to `skbio.io.open` now raises a `TypeError`. The file format's `newline` character will be used when opening the file. Previous behavior allowed overriding the format's `newline` character but this could cause issues with readers that assume newline characters are those defined by the file format (which is an entirely reasonable assumption). This bug is very unlikely to have surfaced in practice as the default `newline` behavior is *universal newlines mode*.
+* Fixed bug when using `Sequence.distance` or `DistanceMatrix.from_iterable` to compute distances between `Sequence` objects with differing `metadata`/`positional_metadata` and passing `metric=scipy.spatial.distance.hamming` ([#1254](https://github.com/biocore/scikit-bio/issues/1254))
+* Fixed performance bug when computing Hamming distances between `Sequence` objects in `DistanceMatrix.from_iterable` ([#1250](https://github.com/biocore/scikit-bio/issues/1250))
 
 ### Deprecated functionality [stable]
 
@@ -23,7 +28,7 @@
 ## Version 0.4.1 (2015-12-09)
 
 ### Features
-* The ``TabularMSA`` object was added to represent and operate on tabular multiple sequence alignments. This statisfies [RFC 1](https://github.com/biocore/scikit-bio-rfcs/blob/master/active/001-tabular-msa.md). See the ``TabularMSA`` docs for full details.
+* The ``TabularMSA`` object was added to represent and operate on tabular multiple sequence alignments. This satisfies [RFC 1](https://github.com/biocore/scikit-bio-rfcs/blob/master/active/001-tabular-msa.md). See the ``TabularMSA`` docs for full details.
 * Added phylogenetic diversity metrics, including weighted UniFrac, unweighted UniFrac, and Faith's Phylogenetic Diversity. These are accessible as ``skbio.diversity.beta.unweighted_unifrac``, ``skbio.diversity.beta.weighted_unifrac``, and ``skbio.diversity.alpha.faith_pd``, respectively.
 * Addition of the function ``skbio.diversity.alpha_diversity`` to support applying an alpha diversity metric to multiple samples in one call.
 * Addition of the functions ``skbio.diversity.get_alpha_diversity_metrics`` and ``skbio.diversity.get_beta_diversity_metrics`` to support discovery of the alpha and beta diversity metrics implemented in scikit-bio.

--- a/skbio/sequence/__init__.py
+++ b/skbio/sequence/__init__.py
@@ -33,6 +33,14 @@ Classes
    Protein
    GeneticCode
 
+Subpackages
+-----------
+
+.. autosummary::
+   :toctree: generated/
+
+   distance
+
 Examples
 --------
 New sequences are created with optional metadata and positional metadata.

--- a/skbio/sequence/distance.py
+++ b/skbio/sequence/distance.py
@@ -1,0 +1,115 @@
+"""
+Sequence distance metrics (:mod:`skbio.sequence.distance`)
+==========================================================
+
+.. currentmodule:: skbio.sequence.distance
+
+This module contains functions for computing distances between scikit-bio
+``Sequence`` objects. These functions can be used directly or supplied to other
+parts of the scikit-bio API that accept a sequence distance metric as input,
+such as :meth:`skbio.sequence.Sequence.distance` and
+:meth:`skbio.stats.distance.DistanceMatrix.from_iterable`.
+
+Functions
+---------
+
+.. autosummary::
+   :toctree: generated/
+
+   hamming
+
+"""
+
+# ----------------------------------------------------------------------------
+# Copyright (c) 2013--, scikit-bio development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+# ----------------------------------------------------------------------------
+
+from __future__ import absolute_import, division, print_function
+
+import numpy as np
+import scipy.spatial.distance
+
+import skbio
+from skbio.util._decorator import experimental
+
+
+@experimental(as_of='0.4.1-dev')
+def hamming(seq1, seq2):
+    """Compute Hamming distance between two sequences.
+
+    The Hamming distance between two equal-length sequences is the proportion
+    of differing characters.
+
+    Parameters
+    ----------
+    seq1, seq2 : Sequence
+        Sequences to compute Hamming distance between.
+
+    Returns
+    -------
+    float
+        Hamming distance between `seq1` and `seq2`.
+
+    Raises
+    ------
+    TypeError
+        If `seq1` and `seq2` are not ``Sequence`` instances.
+    TypeError
+        If `seq1` and `seq2` are not the same type.
+    ValueError
+        If `seq1` and `seq2` are not the same length.
+
+    See Also
+    --------
+    scipy.spatial.distance.hamming
+
+    Notes
+    -----
+    ``np.nan`` will be returned if the sequences do not contain any characters.
+
+    This function does not make assumptions about the sequence alphabet in use.
+    Each sequence object's underlying sequence of characters are used to
+    compute Hamming distance. Characters that may be considered equivalent in
+    certain contexts (e.g., `-` and `.` as gap characters) are treated as
+    distinct characters when computing Hamming distance.
+
+    Examples
+    --------
+    >>> from skbio import Sequence
+    >>> from skbio.sequence.distance import hamming
+    >>> seq1 = Sequence('AGGGTA')
+    >>> seq2 = Sequence('CGTTTA')
+    >>> hamming(seq1, seq2)
+    0.5
+
+    """
+    for seq in seq1, seq2:
+        if not isinstance(seq, skbio.Sequence):
+            raise TypeError(
+                "`seq1` and `seq2` must be Sequence instances, not %r"
+                % type(seq).__name__)
+
+    if type(seq1) is not type(seq2):
+        raise TypeError(
+            "Sequences must have matching type. Type %r does not match type %r"
+            % (type(seq1).__name__, type(seq2).__name__))
+
+    # Hamming requires equal length sequences. We are checking this here
+    # because the error you would get otherwise is cryptic.
+    if len(seq1) != len(seq2):
+        raise ValueError(
+            "Hamming distance can only be computed between sequences of equal "
+            "length (%d != %d)" % (len(seq1), len(seq2)))
+
+    # scipy throws a RuntimeWarning when computing Hamming distance on length 0
+    # input.
+    if not seq1:
+        distance = np.nan
+    else:
+        distance = scipy.spatial.distance.hamming(seq1.values, seq2.values)
+
+    return float(distance)

--- a/skbio/sequence/tests/test_distance.py
+++ b/skbio/sequence/tests/test_distance.py
@@ -1,0 +1,130 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2013--, scikit-bio development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+# ----------------------------------------------------------------------------
+
+from __future__ import absolute_import, division, print_function
+
+import itertools
+import unittest
+
+import six
+import numpy as np
+import numpy.testing as npt
+
+from skbio import Sequence, DNA
+from skbio.sequence.distance import hamming
+
+
+class TestHamming(unittest.TestCase):
+    def test_non_sequence(self):
+        seq1 = Sequence('abc')
+        seq2 = 'abc'
+
+        with six.assertRaisesRegex(self, TypeError,
+                                   'seq1.*seq2.*Sequence.*str'):
+            hamming(seq1, seq2)
+
+        with six.assertRaisesRegex(self, TypeError,
+                                   'seq1.*seq2.*Sequence.*str'):
+            hamming(seq2, seq1)
+
+    def test_type_mismatch(self):
+        seq1 = Sequence('ABC')
+        seq2 = DNA('ACG')
+
+        with six.assertRaisesRegex(self, TypeError,
+                                   'Sequence.*does not match.*DNA'):
+            hamming(seq1, seq2)
+
+    def test_length_mismatch(self):
+        seq1 = Sequence('ABC')
+        seq2 = Sequence('ABCD')
+
+        with six.assertRaisesRegex(self, ValueError, 'equal length.*3 != 4'):
+            hamming(seq1, seq2)
+
+    def test_return_type(self):
+        seq1 = Sequence('ABC')
+        seq2 = Sequence('ABC')
+
+        distance = hamming(seq1, seq2)
+
+        self.assertIsInstance(distance, float)
+        self.assertEqual(distance, 0.0)
+
+    def test_minimum_distance(self):
+        seq1 = Sequence('ABC')
+        seq2 = Sequence('ABC')
+
+        distance = hamming(seq1, seq2)
+
+        self.assertEqual(distance, 0.0)
+
+    def test_mid_range_distance(self):
+        seq1 = Sequence("abcdefgh")
+        seq2 = Sequence("1b23ef45")
+
+        distance = hamming(seq1, seq2)
+
+        self.assertEqual(distance, 5.0/8.0)
+
+    def test_maximum_distance(self):
+        seq1 = Sequence('ABC')
+        seq2 = Sequence('CAB')
+
+        distance = hamming(seq1, seq2)
+
+        self.assertEqual(distance, 1.0)
+
+    def test_empty_sequences(self):
+        seq1 = Sequence('')
+        seq2 = Sequence('')
+
+        distance = hamming(seq1, seq2)
+
+        npt.assert_equal(distance, np.nan)
+
+    def test_single_character_sequences(self):
+        seq1 = Sequence('a')
+        seq2 = Sequence('b')
+
+        self.assertEqual(hamming(seq1, seq1), 0.0)
+        self.assertEqual(hamming(seq1, seq2), 1.0)
+
+    def test_sequence_subclass(self):
+        seq1 = DNA('ACG-T')
+        seq2 = DNA('ACCTT')
+
+        distance = hamming(seq1, seq2)
+
+        self.assertEqual(distance, 2.0/5.0)
+
+    def test_sequences_with_metadata(self):
+        # test for #1254
+        seqs1 = [
+            Sequence("ACGT"),
+            Sequence("ACGT", metadata={'id': 'abc'}),
+            Sequence("ACGT", positional_metadata={'qual': range(4)})
+        ]
+        seqs2 = [
+            Sequence("AAAA"),
+            Sequence("AAAA", metadata={'id': 'def'}),
+            Sequence("AAAA", positional_metadata={'qual': range(4, 8)})
+        ]
+
+        for seqs in seqs1, seqs2:
+            for seq1, seq2 in itertools.product(seqs, repeat=2):
+                distance = hamming(seq1, seq2)
+                self.assertEqual(distance, 0.0)
+
+        for seq1, seq2 in itertools.product(seqs1, seqs2):
+            distance = hamming(seq1, seq2)
+            self.assertEqual(distance, 0.75)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Made the following changes:

- scikit-bio `Sequence` objects have better compatibility with numpy. For example, calling `np.asarray(sequence)` now converts the sequence to a numpy array of characters (the same as calling `sequence.values`).
- Added `skbio.sequence.distance` subpackage for computing distances between scikit-bio `Sequence` objects. This plugs into `Sequence.distance` and `DistanceMatrix.from_iterable`.
- Fixed bug when using `Sequence.distance` or `DistanceMatrix.from_iterable` to compute distances between `Sequence` objects with differing `metadata`/`positional_metadata` and passing `metric=scipy.spatial.distance.hamming`
- Fixed performance bug when computing Hamming distances between `Sequence` objects in `DistanceMatrix.from_iterable`

Fixes #1254. Fixes #1250. Addresses part of #913.