### PR TITLE
MAINT: remove empty metadata optimizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@
 ### Bug fixes
 * Fixed bug when using `Sequence.iter_kmers` on empty `Sequence` object. Previously this raised a `ValueError`, now it returns
 an empty generator.
+* Fixed minor bug where adding sequences to an empty `TabularMSA` with MSA-wide `positional_metadata` would result in a `TabularMSA` object in an inconsistent state. This could happen using `TabularMSA.append` or `TabularMSA.extend`. This bug only affects a `TabularMSA` object *without* sequences that has MSA-wide `positional_metadata` (for example, `TabularMSA([], positional_metadata={'column': []})`).
+
+### Deprecated functionality [stable]
+* Deprecated `Sequence.has_metadata` and `TabularMSA.has_metadata` methods, which will be removed in scikit-bio 0.5.2. Use `bool(obj.metadata)` to determine if the metadata dict is empty.
+* Deprecated `Sequence.has_positional_metadata` and `TabularMSA.has_positional_metadata` methods, which will be removed in scikit-bio 0.5.2. Use `len(obj.positional_metadata.columns)` to determine if positional metadata columns are present, or `obj.positional_metadata.empty` to determine if the positional metadata DataFrame is empty (empty index OR empty columns).
 
 ### Deprecated functionality [experimental]
 * Deprecated function `skbio.util.create_dir`. This function will be removed in scikit-bio 0.5.1. Please use the Python standard library

--- a/skbio/alignment/_tabular_msa.py
+++ b/skbio/alignment/_tabular_msa.py
@@ -753,10 +753,9 @@ class TabularMSA(MetadataMixin, PositionalMetadataMixin, SkbioObject):
     def __init__(self, sequences, metadata=None, positional_metadata=None,
                  minter=None, index=None):
         if isinstance(sequences, TabularMSA):
-            if metadata is None and sequences.has_metadata():
+            if metadata is None:
                 metadata = sequences.metadata
-            if (positional_metadata is None and
-                    sequences.has_positional_metadata()):
+            if positional_metadata is None:
                 positional_metadata = sequences.positional_metadata
             if minter is None and index is None:
                 index = sequences.index
@@ -781,15 +780,9 @@ class TabularMSA(MetadataMixin, PositionalMetadataMixin, SkbioObject):
         override values.
         """
         if metadata is NotImplemented:
-            if self.has_metadata():
-                metadata = self.metadata
-            else:
-                metadata = None
+            metadata = self.metadata
         if positional_metadata is NotImplemented:
-            if self.has_positional_metadata():
-                positional_metadata = self.positional_metadata
-            else:
-                positional_metadata = None
+            positional_metadata = self.positional_metadata
 
         if index is NotImplemented:
             if isinstance(sequences, pd.Series):
@@ -1177,14 +1170,16 @@ class TabularMSA(MetadataMixin, PositionalMetadataMixin, SkbioObject):
 
     def _get_position_(self, i):
         seq = Sequence.concat([s[i] for s in self._seqs], how='outer')
-        if self.has_positional_metadata():
+        # TODO: change for #1198
+        if len(self):
             seq.metadata = dict(self.positional_metadata.iloc[i])
         return seq
 
     def _slice_positions_(self, i):
         seqs = self._seqs.apply(lambda seq: seq[i])
+        # TODO: change for #1198
         pm = None
-        if self.has_positional_metadata():
+        if len(self):
             pm = self.positional_metadata.iloc[i]
         return self._constructor_(seqs, positional_metadata=pm)
     # end of helpers
@@ -1367,9 +1362,7 @@ class TabularMSA(MetadataMixin, PositionalMetadataMixin, SkbioObject):
         if dtype is None:
             dtype = Sequence
 
-        positional_metadata = None
-        if self.has_positional_metadata():
-            positional_metadata = self.positional_metadata
+        positional_metadata = self.positional_metadata
 
         consensus = []
         for position in self.iter_positions():
@@ -1892,7 +1885,21 @@ class TabularMSA(MetadataMixin, PositionalMetadataMixin, SkbioObject):
             raise ValueError(
                 "Number of sequences (%d) must match index length (%d)" %
                 (len(sequences), len(index)))
+
+        # When extending a TabularMSA without sequences, the number of
+        # positions in the TabularMSA may change from zero to non-zero. If this
+        # happens, the TabularMSA's positional_metadata must be reset to its
+        # default "empty" representation for the new number of positions,
+        # otherwise the number of positions in the TabularMSA and
+        # positional_metadata will differ.
+        #
+        # TODO: change for #1198
+        prev_num_positions = self.shape.position
         self._seqs = self._seqs.append(pd.Series(sequences, index=index))
+        curr_num_positions = self.shape.position
+        if curr_num_positions != prev_num_positions:
+            assert prev_num_positions == 0
+            del self.positional_metadata
 
     def _assert_valid_sequences(self, sequences):
         if not sequences:
@@ -2141,17 +2148,8 @@ class TabularMSA(MetadataMixin, PositionalMetadataMixin, SkbioObject):
                 [self.positional_metadata, other.positional_metadata],
                 ignore_index=True, **concat_kwargs)
 
-            if not self.has_positional_metadata():
-                del self.positional_metadata
-            if not other.has_positional_metadata():
-                del other.positional_metadata
-
         joined = self.__class__(joined_seqs, index=join_index,
                                 positional_metadata=joined_positional_metadata)
-
-        if not joined.has_positional_metadata():
-            del joined.positional_metadata
-
         return joined
 
     def _assert_joinable(self, other):
@@ -2182,12 +2180,6 @@ class TabularMSA(MetadataMixin, PositionalMetadataMixin, SkbioObject):
 
             diff = self.positional_metadata.columns.sym_diff(
                 other.positional_metadata.columns)
-
-            if not self.has_positional_metadata():
-                del self.positional_metadata
-            if not other.has_positional_metadata():
-                del other.positional_metadata
-
             if len(diff) > 0:
                 raise ValueError(
                     "Positional metadata columns must all match with "

--- a/skbio/alignment/tests/test_tabular_msa.py
+++ b/skbio/alignment/tests/test_tabular_msa.py
@@ -210,15 +210,13 @@ class TestTabularMSA(unittest.TestCase, ReallyEqualMixin):
         self.assertIsInstance(msa.index, pd.MultiIndex)
         assert_index_equal(msa.index, pd.Index([('foo', 42), ('bar', 43)]))
 
-    def test_copy_constructor_handles_missing_metadata_efficiently(self):
+    def test_copy_constructor_without_metadata(self):
         msa = TabularMSA([DNA('ACGT'), DNA('----')])
 
         copy = TabularMSA(msa)
 
-        self.assertIsNone(msa._metadata)
-        self.assertIsNone(msa._positional_metadata)
-        self.assertIsNone(copy._metadata)
-        self.assertIsNone(copy._positional_metadata)
+        self.assertEqual(msa, copy)
+        self.assertIsNot(msa, copy)
 
     def test_copy_constructor_with_metadata(self):
         msa = TabularMSA([DNA('ACGT'),
@@ -2234,6 +2232,17 @@ class TestExtend(unittest.TestCase):
             TabularMSA([DNA('AA'),
                         DNA('GG')], index=['foo', 'bar']))
 
+    def test_extending_on_empty_with_positional_metadata(self):
+        # bug in 0.4.2
+        msa = TabularMSA([], positional_metadata={'foo': []})
+
+        msa.extend([DNA('AA'), DNA('GG')])
+
+        self.assertEqual(
+            msa,
+            TabularMSA([DNA('AA'),
+                        DNA('GG')]))
+
 
 class TestJoin(unittest.TestCase):
     def test_invalid_how(self):
@@ -2265,7 +2274,7 @@ class TestJoin(unittest.TestCase):
             TabularMSA([DNA('AC'), DNA('--')]).join(
                 TabularMSA([DNA('GT'), DNA('..')], index=[0, 0]))
 
-    def test_handles_missing_metadata_efficiently(self):
+    def test_no_metadata(self):
         msa1 = TabularMSA([DNA('AC'),
                            DNA('G.')])
         msa2 = TabularMSA([DNA('-C'),
@@ -2277,12 +2286,6 @@ class TestJoin(unittest.TestCase):
             joined,
             TabularMSA([DNA('AC-C'),
                         DNA('G..G')]))
-        self.assertIsNone(msa1._metadata)
-        self.assertIsNone(msa1._positional_metadata)
-        self.assertIsNone(msa2._metadata)
-        self.assertIsNone(msa2._positional_metadata)
-        self.assertIsNone(joined._metadata)
-        self.assertIsNone(joined._positional_metadata)
 
     def test_ignores_metadata(self):
         msa1 = TabularMSA([DNA('AC', metadata={'id': 'a'}),
@@ -2670,16 +2673,6 @@ class TestIterPositions(unittest.TestCase):
                       positional_metadata={'foo': [42, np.nan, -1],
                                            'bar': [np.nan, np.nan, 'baz']})])
 
-    def test_handles_missing_positional_metadata_efficiently(self):
-        msa = TabularMSA([DNA('AC'),
-                          DNA('A-')])
-
-        self.assertIsNone(msa._positional_metadata)
-
-        list(msa.iter_positions())
-
-        self.assertIsNone(msa._positional_metadata)
-
 
 class TestConsensus(unittest.TestCase):
     def test_no_sequences(self):
@@ -2771,17 +2764,6 @@ class TestConsensus(unittest.TestCase):
             cons,
             DNA('A-T', positional_metadata={'foo': [42, 43, 42],
                                             'bar': ['a', 'b', 'c']}))
-
-    def test_handles_missing_positional_metadata_efficiently(self):
-        msa = TabularMSA([DNA('AC'),
-                          DNA('AC')])
-
-        self.assertIsNone(msa._positional_metadata)
-
-        cons = msa.consensus()
-
-        self.assertIsNone(msa._positional_metadata)
-        self.assertIsNone(cons._positional_metadata)
 
     def test_mixed_gap_characters_as_majority(self):
         seqs = [
@@ -3353,14 +3335,6 @@ class TestGetPosition(unittest.TestCase):
 
         self.assertEqual(position,
                          Sequence('C-', metadata={'foo': 43, 'bar': 'def'}))
-
-    def test_handles_positional_metadata_efficiently(self):
-        msa = TabularMSA([DNA('AA'),
-                          DNA('--')])
-
-        msa._get_position_(1)
-
-        self.assertIsNone(msa._positional_metadata)
 
 
 class TestIsSequenceAxis(unittest.TestCase):

--- a/skbio/io/format/stockholm.py
+++ b/skbio/io/format/stockholm.py
@@ -631,42 +631,38 @@ def _tabular_msa_to_stockholm(obj, fh):
     fh.write("# STOCKHOLM 1.0\n")
 
     # Writes GF data to file
-    if obj.has_metadata():
-        for gf_feature, gf_feature_data in obj.metadata.items():
-            if gf_feature == 'NH' and isinstance(gf_feature_data, dict):
-                for tree_id, tree in obj.metadata[gf_feature].items():
-                    fh.write("#=GF TN %s\n" % tree_id)
-                    fh.write("#=GF NH %s\n" % tree)
-            else:
-                fh.write("#=GF %s %s\n" % (gf_feature, gf_feature_data))
+    for gf_feature, gf_feature_data in obj.metadata.items():
+        if gf_feature == 'NH' and isinstance(gf_feature_data, dict):
+            for tree_id, tree in obj.metadata[gf_feature].items():
+                fh.write("#=GF TN %s\n" % tree_id)
+                fh.write("#=GF NH %s\n" % tree)
+        else:
+            fh.write("#=GF %s %s\n" % (gf_feature, gf_feature_data))
 
     unpadded_data = []
     # Writes GS data to file, retrieves GR data, and retrieves sequence data
     for seq, seq_name in zip(obj, obj.index):
         seq_name = str(seq_name)
-        if seq.has_metadata():
-            for gs_feature, gs_feature_data in seq.metadata.items():
-                fh.write("#=GS %s %s %s\n" % (seq_name, gs_feature,
-                                              gs_feature_data))
+        for gs_feature, gs_feature_data in seq.metadata.items():
+            fh.write("#=GS %s %s %s\n" % (seq_name, gs_feature,
+                                          gs_feature_data))
         unpadded_data.append((seq_name, str(seq)))
-        if seq.has_positional_metadata():
-            df = _format_positional_metadata(seq.positional_metadata,
-                                             'Sequence-specific positional '
-                                             'metadata (GR)')
-            for gr_feature in df.columns:
-                gr_feature_data = ''.join(df[gr_feature])
-                gr_string = "#=GR %s %s" % (seq_name, gr_feature)
-                unpadded_data.append((gr_string, gr_feature_data))
+        df = _format_positional_metadata(seq.positional_metadata,
+                                         'Sequence-specific positional '
+                                         'metadata (GR)')
+        for gr_feature in df.columns:
+            gr_feature_data = ''.join(df[gr_feature])
+            gr_string = "#=GR %s %s" % (seq_name, gr_feature)
+            unpadded_data.append((gr_string, gr_feature_data))
 
     # Retrieves GC data
-    if obj.has_positional_metadata():
-        df = _format_positional_metadata(obj.positional_metadata,
-                                         'Multiple sequence alignment '
-                                         'positional metadata (GC)')
-        for gc_feature in df.columns:
-            gc_feature_data = ''.join(df[gc_feature])
-            gc_string = "#=GC %s" % gc_feature
-            unpadded_data.append((gc_string, gc_feature_data))
+    df = _format_positional_metadata(obj.positional_metadata,
+                                     'Multiple sequence alignment '
+                                     'positional metadata (GC)')
+    for gc_feature in df.columns:
+        gc_feature_data = ''.join(df[gc_feature])
+        gc_string = "#=GC %s" % gc_feature
+        unpadded_data.append((gc_string, gc_feature_data))
 
     # Writes GR, GC, and raw data to file with padding
     _write_padded_data(unpadded_data, fh)

--- a/skbio/io/format/tests/test_stockholm.py
+++ b/skbio/io/format/tests/test_stockholm.py
@@ -384,14 +384,6 @@ class TestStockholmReader(unittest.TestCase):
                                     '`constructor`.*`GrammaredSequence`'):
             _stockholm_to_tabular_msa(fp, constructor=TabularMSA)
 
-    def test_handles_missing_metadata_efficiently(self):
-        msa = _stockholm_to_tabular_msa(get_data_path('stockholm_minimal'),
-                                        constructor=DNA)
-        self.assertIsNone(msa._metadata)
-        self.assertIsNone(msa._positional_metadata)
-        self.assertIsNone(msa[0]._metadata)
-        self.assertIsNone(msa[0]._positional_metadata)
-
 
 class TestStockholmWriter(unittest.TestCase):
     def test_msa_to_stockholm_extensive(self):
@@ -597,15 +589,6 @@ class TestStockholmWriter(unittest.TestCase):
         with io.open(fp) as fh:
             exp = fh.read()
         self.assertEqual(obs, exp)
-
-    def test_handles_missing_metadata_efficiently(self):
-        msa = TabularMSA([DNA('ACTG'), DNA('GTCA')], index=['seq1', 'seq2'])
-        fh = io.StringIO()
-        _tabular_msa_to_stockholm(msa, fh)
-        self.assertIsNone(msa._metadata)
-        self.assertIsNone(msa._positional_metadata)
-        self.assertIsNone(msa[0]._metadata)
-        self.assertIsNone(msa[0]._positional_metadata)
 
     def test_unoriginal_index_error(self):
         msa = TabularMSA([DNA('ATCGCCAGCT'), DNA('TTGTGCTGGC')],

--- a/skbio/metadata/_mixin.py
+++ b/skbio/metadata/_mixin.py
@@ -12,7 +12,7 @@ import copy
 import numpy as np
 import pandas as pd
 
-from skbio.util._decorator import stable
+from skbio.util._decorator import stable, deprecated
 
 
 class MetadataMixin(metaclass=abc.ABCMeta):
@@ -61,18 +61,11 @@ class MetadataMixin(metaclass=abc.ABCMeta):
 
         Delete metadata:
 
-        >>> seq.has_metadata()
-        True
         >>> del seq.metadata
         >>> seq.metadata
         {}
-        >>> seq.has_metadata()
-        False
 
         """
-        if self._metadata is None:
-            # Not using setter to avoid copy.
-            self._metadata = {}
         return self._metadata
 
     @metadata.setter
@@ -84,7 +77,8 @@ class MetadataMixin(metaclass=abc.ABCMeta):
 
     @metadata.deleter
     def metadata(self):
-        self._metadata = None
+        # Not using setter to avoid copy.
+        self._metadata = {}
 
     @abc.abstractmethod
     def __init__(self, metadata=None):
@@ -92,7 +86,7 @@ class MetadataMixin(metaclass=abc.ABCMeta):
 
     def _init_(self, metadata=None):
         if metadata is None:
-            self._metadata = None
+            del self.metadata
         else:
             self.metadata = metadata
 
@@ -101,20 +95,7 @@ class MetadataMixin(metaclass=abc.ABCMeta):
         pass
 
     def _eq_(self, other):
-        # We're not simply comparing self.metadata to other.metadata in order
-        # to avoid creating "empty" metadata representations on the objects if
-        # they don't have metadata.
-        if self.has_metadata() and other.has_metadata():
-            if self.metadata != other.metadata:
-                return False
-        elif not (self.has_metadata() or other.has_metadata()):
-            # Both don't have metadata.
-            pass
-        else:
-            # One has metadata while the other does not.
-            return False
-
-        return True
+        return self.metadata == other.metadata
 
     @abc.abstractmethod
     def __ne__(self, other):
@@ -128,22 +109,18 @@ class MetadataMixin(metaclass=abc.ABCMeta):
         pass
 
     def _copy_(self):
-        if self.has_metadata():
-            return self.metadata.copy()
-        else:
-            return None
+        return self.metadata.copy()
 
     @abc.abstractmethod
     def __deepcopy__(self, memo):
         pass
 
     def _deepcopy_(self, memo):
-        if self.has_metadata():
-            return copy.deepcopy(self.metadata, memo)
-        else:
-            return None
+        return copy.deepcopy(self.metadata, memo)
 
-    @stable(as_of="0.4.0")
+    @deprecated(as_of="0.4.2-dev", until="0.5.2",
+                reason="Use `bool(obj.metadata)` to determine if the metadata "
+                       "dict is empty.")
     def has_metadata(self):
         """Determine if the object has metadata.
 
@@ -175,7 +152,7 @@ class MetadataMixin(metaclass=abc.ABCMeta):
         True
 
         """
-        return self._metadata is not None and bool(self.metadata)
+        return bool(self.metadata)
 
 
 class PositionalMetadataMixin(metaclass=abc.ABCMeta):
@@ -199,7 +176,8 @@ class PositionalMetadataMixin(metaclass=abc.ABCMeta):
         Notes
         -----
         This property can be set and deleted. When setting new positional
-        metadata a shallow copy is made.
+        metadata, a shallow copy is made and the index is set to the pandas
+        default integer index.
 
         Examples
         --------
@@ -262,21 +240,13 @@ class PositionalMetadataMixin(metaclass=abc.ABCMeta):
 
         Delete positional metadata:
 
-        >>> seq.has_positional_metadata()
-        True
         >>> del seq.positional_metadata
         >>> seq.positional_metadata
         Empty DataFrame
         Columns: []
         Index: [0, 1, 2, 3]
-        >>> seq.has_positional_metadata()
-        False
 
         """
-        if self._positional_metadata is None:
-            # Not using setter to avoid copy.
-            self._positional_metadata = pd.DataFrame(
-                index=np.arange(self._positional_metadata_axis_len_()))
         return self._positional_metadata
 
     @positional_metadata.setter
@@ -303,7 +273,9 @@ class PositionalMetadataMixin(metaclass=abc.ABCMeta):
 
     @positional_metadata.deleter
     def positional_metadata(self):
-        self._positional_metadata = None
+        # Not using setter to avoid copy.
+        self._positional_metadata = pd.DataFrame(
+            index=np.arange(self._positional_metadata_axis_len_()))
 
     @abc.abstractmethod
     def __init__(self, positional_metadata=None):
@@ -311,7 +283,7 @@ class PositionalMetadataMixin(metaclass=abc.ABCMeta):
 
     def _init_(self, positional_metadata=None):
         if positional_metadata is None:
-            self._positional_metadata = None
+            del self.positional_metadata
         else:
             self.positional_metadata = positional_metadata
 
@@ -320,22 +292,7 @@ class PositionalMetadataMixin(metaclass=abc.ABCMeta):
         pass
 
     def _eq_(self, other):
-        # We're not simply comparing self.positional_metadata to
-        # other.positional_metadata in order to avoid creating "empty"
-        # positional metadata representations on the objects if they don't have
-        # positional metadata.
-        if self.has_positional_metadata() and other.has_positional_metadata():
-            if not self.positional_metadata.equals(other.positional_metadata):
-                return False
-        elif not (self.has_positional_metadata() or
-                  other.has_positional_metadata()):
-            # Both don't have positional metadata.
-            pass
-        else:
-            # One has positional metadata while the other does not.
-            return False
-
-        return True
+        return self.positional_metadata.equals(other.positional_metadata)
 
     @abc.abstractmethod
     def __ne__(self, other):
@@ -349,23 +306,22 @@ class PositionalMetadataMixin(metaclass=abc.ABCMeta):
         pass
 
     def _copy_(self):
-        if self.has_positional_metadata():
-            # deep=True makes a shallow copy of the underlying data buffer.
-            return self.positional_metadata.copy(deep=True)
-        else:
-            return None
+        # deep=True makes a shallow copy of the underlying data buffer.
+        return self.positional_metadata.copy(deep=True)
 
     @abc.abstractmethod
     def __deepcopy__(self, memo):
         pass
 
     def _deepcopy_(self, memo):
-        if self.has_positional_metadata():
-            return copy.deepcopy(self.positional_metadata, memo)
-        else:
-            return None
+        return copy.deepcopy(self.positional_metadata, memo)
 
-    @stable(as_of="0.4.0")
+    @deprecated(as_of="0.4.2-dev", until="0.5.2",
+                reason="Use `len(obj.positional_metadata.columns)` to "
+                       "determine if positional metadata columns are present, "
+                       "or `obj.positional_metadata.empty` to determine if "
+                       "the positional metadata DataFrame is empty (empty "
+                       "index OR empty columns).")
     def has_positional_metadata(self):
         """Determine if the object has positional metadata.
 
@@ -398,5 +354,4 @@ class PositionalMetadataMixin(metaclass=abc.ABCMeta):
         True
 
         """
-        return (self._positional_metadata is not None and
-                len(self.positional_metadata.columns) > 0)
+        return len(self.positional_metadata.columns) > 0

--- a/skbio/metadata/_repr.py
+++ b/skbio/metadata/_repr.py
@@ -54,7 +54,7 @@ class _MetadataReprBuilder(metaclass=ABCMeta):
         return self._lines.to_str()
 
     def _process_metadata(self):
-        if self._obj.has_metadata():
+        if self._obj.metadata:
             self._lines.add_line('Metadata:')
             # Python 3 doesn't allow sorting of mixed types so we can't just
             # use sorted() on the metadata keys. Sort first by type then sort
@@ -112,7 +112,7 @@ class _MetadataReprBuilder(metaclass=ABCMeta):
         return self._wrap_text_with_indent(value_repr, key_fmt, extra_indent)
 
     def _process_positional_metadata(self):
-        if self._obj.has_positional_metadata():
+        if len(self._obj.positional_metadata.columns):
             self._lines.add_line('Positional metadata:')
             for key in self._obj.positional_metadata.columns.values.tolist():
                 dtype = self._obj.positional_metadata[key].dtype

--- a/skbio/metadata/_testing.py
+++ b/skbio/metadata/_testing.py
@@ -25,7 +25,6 @@ class MetadataMixinTests:
         for md in None, {}:
             obj = self._metadata_constructor_(metadata=md)
 
-            self.assertFalse(obj.has_metadata())
             self.assertEqual(obj.metadata, {})
 
     def test_constructor_with_metadata(self):
@@ -35,10 +34,6 @@ class MetadataMixinTests:
         obj = self._metadata_constructor_(
                 metadata={'': '', 123: {'a': 'b', 'c': 'd'}})
         self.assertEqual(obj.metadata, {'': '', 123: {'a': 'b', 'c': 'd'}})
-
-    def test_constructor_handles_missing_metadata_efficiently(self):
-        self.assertIsNone(self._metadata_constructor_()._metadata)
-        self.assertIsNone(self._metadata_constructor_(metadata=None)._metadata)
 
     def test_constructor_makes_shallow_copy_of_metadata(self):
         md = {'foo': 'bar', 42: []}
@@ -70,14 +65,6 @@ class MetadataMixinTests:
         self.assertReallyEqual(self._metadata_constructor_(metadata={}),
                                self._metadata_constructor_(metadata={}))
 
-    def test_eq_handles_missing_metadata_efficiently(self):
-        obj1 = self._metadata_constructor_()
-        obj2 = self._metadata_constructor_()
-        self.assertReallyEqual(obj1, obj2)
-
-        self.assertIsNone(obj1._metadata)
-        self.assertIsNone(obj2._metadata)
-
     def test_ne(self):
         # Both have metadata.
         obj1 = self._metadata_constructor_(metadata={'id': 'foo'})
@@ -96,8 +83,9 @@ class MetadataMixinTests:
         self.assertEqual(obj, obj_copy)
         self.assertIsNot(obj, obj_copy)
 
-        self.assertIsNone(obj._metadata)
-        self.assertIsNone(obj_copy._metadata)
+        self.assertEqual(obj.metadata, {})
+        self.assertEqual(obj_copy.metadata, {})
+        self.assertIsNot(obj.metadata, obj_copy.metadata)
 
     def test_copy_metadata_empty(self):
         obj = self._metadata_constructor_(metadata={})
@@ -106,8 +94,9 @@ class MetadataMixinTests:
         self.assertEqual(obj, obj_copy)
         self.assertIsNot(obj, obj_copy)
 
-        self.assertEqual(obj._metadata, {})
-        self.assertIsNone(obj_copy._metadata)
+        self.assertEqual(obj.metadata, {})
+        self.assertEqual(obj_copy.metadata, {})
+        self.assertIsNot(obj.metadata, obj_copy.metadata)
 
     def test_copy_with_metadata(self):
         obj = self._metadata_constructor_(metadata={'foo': [1]})
@@ -116,8 +105,10 @@ class MetadataMixinTests:
         self.assertEqual(obj, obj_copy)
         self.assertIsNot(obj, obj_copy)
 
-        self.assertIsNot(obj._metadata, obj_copy._metadata)
-        self.assertIs(obj._metadata['foo'], obj_copy._metadata['foo'])
+        self.assertEqual(obj.metadata, {'foo': [1]})
+        self.assertEqual(obj_copy.metadata, {'foo': [1]})
+        self.assertIsNot(obj.metadata, obj_copy.metadata)
+        self.assertIs(obj.metadata['foo'], obj_copy.metadata['foo'])
 
         obj_copy.metadata['foo'].append(2)
         obj_copy.metadata['foo2'] = 42
@@ -132,8 +123,9 @@ class MetadataMixinTests:
         self.assertEqual(obj, obj_copy)
         self.assertIsNot(obj, obj_copy)
 
-        self.assertIsNone(obj._metadata)
-        self.assertIsNone(obj_copy._metadata)
+        self.assertEqual(obj.metadata, {})
+        self.assertEqual(obj_copy.metadata, {})
+        self.assertIsNot(obj.metadata, obj_copy.metadata)
 
     def test_deepcopy_metadata_empty(self):
         obj = self._metadata_constructor_(metadata={})
@@ -142,8 +134,9 @@ class MetadataMixinTests:
         self.assertEqual(obj, obj_copy)
         self.assertIsNot(obj, obj_copy)
 
-        self.assertEqual(obj._metadata, {})
-        self.assertIsNone(obj_copy._metadata)
+        self.assertEqual(obj.metadata, {})
+        self.assertEqual(obj_copy.metadata, {})
+        self.assertIsNot(obj.metadata, obj_copy.metadata)
 
     def test_deepcopy_with_metadata(self):
         obj = self._metadata_constructor_(metadata={'foo': [1]})
@@ -152,8 +145,10 @@ class MetadataMixinTests:
         self.assertEqual(obj, obj_copy)
         self.assertIsNot(obj, obj_copy)
 
-        self.assertIsNot(obj._metadata, obj_copy._metadata)
-        self.assertIsNot(obj._metadata['foo'], obj_copy._metadata['foo'])
+        self.assertEqual(obj.metadata, {'foo': [1]})
+        self.assertEqual(obj_copy.metadata, {'foo': [1]})
+        self.assertIsNot(obj.metadata, obj_copy.metadata)
+        self.assertIsNot(obj.metadata['foo'], obj_copy.metadata['foo'])
 
         obj_copy.metadata['foo'].append(2)
         obj_copy.metadata['foo2'] = 42
@@ -182,22 +177,17 @@ class MetadataMixinTests:
     def test_metadata_getter_no_metadata(self):
         obj = self._metadata_constructor_()
 
-        self.assertIsNone(obj._metadata)
         self.assertIsInstance(obj.metadata, dict)
         self.assertEqual(obj.metadata, {})
-        self.assertIsNotNone(obj._metadata)
 
     def test_metadata_setter(self):
         obj = self._metadata_constructor_()
-
-        self.assertFalse(obj.has_metadata())
+        self.assertEqual(obj.metadata, {})
 
         obj.metadata = {'hello': 'world'}
-        self.assertTrue(obj.has_metadata())
         self.assertEqual(obj.metadata, {'hello': 'world'})
 
         obj.metadata = {}
-        self.assertFalse(obj.has_metadata())
         self.assertEqual(obj.metadata, {})
 
     def test_metadata_setter_makes_shallow_copy(self):
@@ -230,28 +220,22 @@ class MetadataMixinTests:
         self.assertEqual(obj.metadata, {'foo': 'bar'})
 
         del obj.metadata
-        self.assertIsNone(obj._metadata)
-        self.assertFalse(obj.has_metadata())
+        self.assertEqual(obj.metadata, {})
 
         # Delete again.
         del obj.metadata
-        self.assertIsNone(obj._metadata)
-        self.assertFalse(obj.has_metadata())
+        self.assertEqual(obj.metadata, {})
 
         obj = self._metadata_constructor_()
 
-        self.assertIsNone(obj._metadata)
-        self.assertFalse(obj.has_metadata())
+        self.assertEqual(obj.metadata, {})
         del obj.metadata
-        self.assertIsNone(obj._metadata)
-        self.assertFalse(obj.has_metadata())
+        self.assertEqual(obj.metadata, {})
 
     def test_has_metadata(self):
         obj = self._metadata_constructor_()
 
         self.assertFalse(obj.has_metadata())
-        # Handles metadata efficiently.
-        self.assertIsNone(obj._metadata)
 
         self.assertFalse(
                 self._metadata_constructor_(metadata={}).has_metadata())
@@ -306,13 +290,17 @@ class PositionalMetadataMixinTests:
             self._positional_metadata_constructor_(
                 4, positional_metadata=pd.DataFrame({'quality': range(5)}))
 
+        # Empty DataFrame wrong size.
+        with self.assertRaisesRegex(ValueError, '\(2\).*\(3\)'):
+            self._positional_metadata_constructor_(
+                3, positional_metadata=pd.DataFrame(index=range(2)))
+
     def test_constructor_no_positional_metadata(self):
         # Length zero with missing/empty positional metadata.
         for empty in None, {}, pd.DataFrame():
             obj = self._positional_metadata_constructor_(
                 0, positional_metadata=empty)
 
-            self.assertFalse(obj.has_positional_metadata())
             assert_data_frame_almost_equal(obj.positional_metadata,
                                            pd.DataFrame(index=np.arange(0)))
 
@@ -320,7 +308,6 @@ class PositionalMetadataMixinTests:
         obj = self._positional_metadata_constructor_(
             3, positional_metadata=None)
 
-        self.assertFalse(obj.has_positional_metadata())
         assert_data_frame_almost_equal(obj.positional_metadata,
                                        pd.DataFrame(index=np.arange(3)))
 
@@ -329,7 +316,6 @@ class PositionalMetadataMixinTests:
             obj = self._positional_metadata_constructor_(
                 0, positional_metadata={'foo': data})
 
-            self.assertTrue(obj.has_positional_metadata())
             assert_data_frame_almost_equal(
                 obj.positional_metadata,
                 pd.DataFrame({'foo': data}, index=np.arange(0)))
@@ -339,7 +325,6 @@ class PositionalMetadataMixinTests:
             obj = self._positional_metadata_constructor_(
                 1, positional_metadata={'foo': data})
 
-            self.assertTrue(obj.has_positional_metadata())
             assert_data_frame_almost_equal(
                 obj.positional_metadata,
                 pd.DataFrame({'foo': data}, index=np.arange(1)))
@@ -351,7 +336,6 @@ class PositionalMetadataMixinTests:
             obj = self._positional_metadata_constructor_(
                 9, positional_metadata={'foo': data})
 
-            self.assertTrue(obj.has_positional_metadata())
             assert_data_frame_almost_equal(
                 obj.positional_metadata,
                 pd.DataFrame({'foo': data}, index=np.arange(9)))
@@ -361,7 +345,6 @@ class PositionalMetadataMixinTests:
             5, positional_metadata={'foo': np.arange(5),
                                     'bar': np.arange(5)[::-1]})
 
-        self.assertTrue(obj.has_positional_metadata())
         assert_data_frame_almost_equal(
             obj.positional_metadata,
             pd.DataFrame({'foo': np.arange(5),
@@ -373,19 +356,10 @@ class PositionalMetadataMixinTests:
         obj = self._positional_metadata_constructor_(
             5, positional_metadata=df)
 
-        self.assertTrue(obj.has_positional_metadata())
         assert_data_frame_almost_equal(
             obj.positional_metadata,
             pd.DataFrame({'foo': np.arange(5),
                           'bar': np.arange(5)[::-1]}, index=np.arange(5)))
-
-    def test_constructor_handles_missing_positional_metadata_efficiently(self):
-        obj = self._positional_metadata_constructor_(4)
-        self.assertIsNone(obj._positional_metadata)
-
-        obj = self._positional_metadata_constructor_(
-            4, positional_metadata=None)
-        self.assertIsNone(obj._positional_metadata)
 
     def test_constructor_makes_shallow_copy_of_positional_metadata(self):
         df = pd.DataFrame({'foo': [22, 22, 0], 'bar': [[], [], []]},
@@ -465,14 +439,6 @@ class PositionalMetadataMixinTests:
                 self._positional_metadata_constructor_(
                     2, positional_metadata=empty))
 
-    def test_eq_handles_missing_positional_metadata_efficiently(self):
-        obj1 = self._positional_metadata_constructor_(1)
-        obj2 = self._positional_metadata_constructor_(1)
-        self.assertReallyEqual(obj1, obj2)
-
-        self.assertIsNone(obj1._positional_metadata)
-        self.assertIsNone(obj2._positional_metadata)
-
     def test_ne_len_zero(self):
         # Both have positional metadata.
         obj1 = self._positional_metadata_constructor_(
@@ -501,6 +467,13 @@ class PositionalMetadataMixinTests:
         obj2 = self._positional_metadata_constructor_(3)
         self.assertReallyNotEqual(obj1, obj2)
 
+    def test_ne_len_mismatch(self):
+        obj1 = self._positional_metadata_constructor_(
+            3, positional_metadata=pd.DataFrame(index=range(3)))
+        obj2 = self._positional_metadata_constructor_(
+            2, positional_metadata=pd.DataFrame(index=range(2)))
+        self.assertReallyNotEqual(obj1, obj2)
+
     def test_copy_positional_metadata_none(self):
         obj = self._positional_metadata_constructor_(3)
         obj_copy = copy.copy(obj)
@@ -508,8 +481,11 @@ class PositionalMetadataMixinTests:
         self.assertEqual(obj, obj_copy)
         self.assertIsNot(obj, obj_copy)
 
-        self.assertIsNone(obj._positional_metadata)
-        self.assertIsNone(obj_copy._positional_metadata)
+        assert_data_frame_almost_equal(obj.positional_metadata,
+                                       pd.DataFrame(index=range(3)))
+        assert_data_frame_almost_equal(obj_copy.positional_metadata,
+                                       pd.DataFrame(index=range(3)))
+        self.assertIsNot(obj.positional_metadata, obj_copy.positional_metadata)
 
     def test_copy_positional_metadata_empty(self):
         obj = self._positional_metadata_constructor_(
@@ -519,9 +495,11 @@ class PositionalMetadataMixinTests:
         self.assertEqual(obj, obj_copy)
         self.assertIsNot(obj, obj_copy)
 
-        assert_data_frame_almost_equal(obj._positional_metadata,
+        assert_data_frame_almost_equal(obj.positional_metadata,
                                        pd.DataFrame(index=range(3)))
-        self.assertIsNone(obj_copy._positional_metadata)
+        assert_data_frame_almost_equal(obj_copy.positional_metadata,
+                                       pd.DataFrame(index=range(3)))
+        self.assertIsNot(obj.positional_metadata, obj_copy.positional_metadata)
 
     def test_copy_with_positional_metadata(self):
         obj = self._positional_metadata_constructor_(
@@ -532,12 +510,21 @@ class PositionalMetadataMixinTests:
         self.assertEqual(obj, obj_copy)
         self.assertIsNot(obj, obj_copy)
 
-        self.assertIsNot(obj._positional_metadata,
-                         obj_copy._positional_metadata)
-        self.assertIsNot(obj._positional_metadata.values,
-                         obj_copy._positional_metadata.values)
-        self.assertIs(obj._positional_metadata.loc[0, 'bar'],
-                      obj_copy._positional_metadata.loc[0, 'bar'])
+        assert_data_frame_almost_equal(
+            obj.positional_metadata,
+            pd.DataFrame({'bar': [[], [], [], []],
+                          'baz': [42, 42, 42, 42]}, index=range(4)))
+        assert_data_frame_almost_equal(
+            obj_copy.positional_metadata,
+            pd.DataFrame({'bar': [[], [], [], []],
+                          'baz': [42, 42, 42, 42]}, index=range(4)))
+
+        self.assertIsNot(obj.positional_metadata,
+                         obj_copy.positional_metadata)
+        self.assertIsNot(obj.positional_metadata.values,
+                         obj_copy.positional_metadata.values)
+        self.assertIs(obj.positional_metadata.loc[0, 'bar'],
+                      obj_copy.positional_metadata.loc[0, 'bar'])
 
         obj_copy.positional_metadata.loc[0, 'bar'].append(1)
         obj_copy.positional_metadata.loc[0, 'baz'] = 43
@@ -558,8 +545,11 @@ class PositionalMetadataMixinTests:
         self.assertEqual(obj, obj_copy)
         self.assertIsNot(obj, obj_copy)
 
-        self.assertIsNone(obj._positional_metadata)
-        self.assertIsNone(obj_copy._positional_metadata)
+        assert_data_frame_almost_equal(obj.positional_metadata,
+                                       pd.DataFrame(index=range(3)))
+        assert_data_frame_almost_equal(obj_copy.positional_metadata,
+                                       pd.DataFrame(index=range(3)))
+        self.assertIsNot(obj.positional_metadata, obj_copy.positional_metadata)
 
     def test_deepcopy_positional_metadata_empty(self):
         obj = self._positional_metadata_constructor_(
@@ -569,9 +559,11 @@ class PositionalMetadataMixinTests:
         self.assertEqual(obj, obj_copy)
         self.assertIsNot(obj, obj_copy)
 
-        assert_data_frame_almost_equal(obj._positional_metadata,
+        assert_data_frame_almost_equal(obj.positional_metadata,
                                        pd.DataFrame(index=range(3)))
-        self.assertIsNone(obj_copy._positional_metadata)
+        assert_data_frame_almost_equal(obj_copy.positional_metadata,
+                                       pd.DataFrame(index=range(3)))
+        self.assertIsNot(obj.positional_metadata, obj_copy.positional_metadata)
 
     def test_deepcopy_with_positional_metadata(self):
         obj = self._positional_metadata_constructor_(
@@ -582,12 +574,20 @@ class PositionalMetadataMixinTests:
         self.assertEqual(obj, obj_copy)
         self.assertIsNot(obj, obj_copy)
 
-        self.assertIsNot(obj._positional_metadata,
-                         obj_copy._positional_metadata)
-        self.assertIsNot(obj._positional_metadata.values,
-                         obj_copy._positional_metadata.values)
-        self.assertIsNot(obj._positional_metadata.loc[0, 'bar'],
-                         obj_copy._positional_metadata.loc[0, 'bar'])
+        assert_data_frame_almost_equal(
+            obj.positional_metadata,
+            pd.DataFrame({'bar': [[], [], [], []],
+                          'baz': [42, 42, 42, 42]}, index=range(4)))
+        assert_data_frame_almost_equal(
+            obj_copy.positional_metadata,
+            pd.DataFrame({'bar': [[], [], [], []],
+                          'baz': [42, 42, 42, 42]}, index=range(4)))
+
+        self.assertIsNot(obj.positional_metadata, obj_copy.positional_metadata)
+        self.assertIsNot(obj.positional_metadata.values,
+                         obj_copy.positional_metadata.values)
+        self.assertIsNot(obj.positional_metadata.loc[0, 'bar'],
+                         obj_copy.positional_metadata.loc[0, 'bar'])
 
         obj_copy.positional_metadata.loc[0, 'bar'].append(1)
         obj_copy.positional_metadata.loc[0, 'baz'] = 43
@@ -633,12 +633,10 @@ class PositionalMetadataMixinTests:
     def test_positional_metadata_getter_no_positional_metadata(self):
         obj = self._positional_metadata_constructor_(4)
 
-        self.assertIsNone(obj._positional_metadata)
         self.assertIsInstance(obj.positional_metadata, pd.DataFrame)
         assert_data_frame_almost_equal(
             obj.positional_metadata,
             pd.DataFrame(index=np.arange(4)))
-        self.assertIsNotNone(obj._positional_metadata)
 
     def test_positional_metadata_getter_set_column_series(self):
         length = 8
@@ -671,31 +669,29 @@ class PositionalMetadataMixinTests:
     def test_positional_metadata_setter_pandas_consumable(self):
         obj = self._positional_metadata_constructor_(3)
 
-        self.assertFalse(obj.has_positional_metadata())
+        assert_data_frame_almost_equal(obj.positional_metadata,
+                                       pd.DataFrame(index=range(3)))
 
         obj.positional_metadata = {'foo': [3, 2, 1]}
-        self.assertTrue(obj.has_positional_metadata())
         assert_data_frame_almost_equal(obj.positional_metadata,
                                        pd.DataFrame({'foo': [3, 2, 1]}))
 
         obj.positional_metadata = pd.DataFrame(index=np.arange(3))
-        self.assertFalse(obj.has_positional_metadata())
         assert_data_frame_almost_equal(obj.positional_metadata,
                                        pd.DataFrame(index=np.arange(3)))
 
     def test_positional_metadata_setter_data_frame(self):
         obj = self._positional_metadata_constructor_(3)
 
-        self.assertFalse(obj.has_positional_metadata())
+        assert_data_frame_almost_equal(obj.positional_metadata,
+                                       pd.DataFrame(index=range(3)))
 
         obj.positional_metadata = pd.DataFrame({'foo': [3, 2, 1]},
                                                index=['a', 'b', 'c'])
-        self.assertTrue(obj.has_positional_metadata())
         assert_data_frame_almost_equal(obj.positional_metadata,
                                        pd.DataFrame({'foo': [3, 2, 1]}))
 
         obj.positional_metadata = pd.DataFrame(index=np.arange(3))
-        self.assertFalse(obj.has_positional_metadata())
         assert_data_frame_almost_equal(obj.positional_metadata,
                                        pd.DataFrame(index=np.arange(3)))
 
@@ -703,14 +699,12 @@ class PositionalMetadataMixinTests:
         obj = self._positional_metadata_constructor_(
             0, positional_metadata={'foo': []})
 
-        self.assertTrue(obj.has_positional_metadata())
         assert_data_frame_almost_equal(obj.positional_metadata,
                                        pd.DataFrame({'foo': []}))
 
         # `None` behavior differs from constructor.
         obj.positional_metadata = None
 
-        self.assertFalse(obj.has_positional_metadata())
         assert_data_frame_almost_equal(obj.positional_metadata,
                                        pd.DataFrame(index=np.arange(0)))
 
@@ -791,26 +785,25 @@ class PositionalMetadataMixinTests:
                                        pd.DataFrame({'foo': [1, 2, 3]}))
 
         del obj.positional_metadata
-        self.assertIsNone(obj._positional_metadata)
-        self.assertFalse(obj.has_positional_metadata())
+        assert_data_frame_almost_equal(obj.positional_metadata,
+                                       pd.DataFrame(index=range(3)))
 
         # Delete again.
         del obj.positional_metadata
-        self.assertIsNone(obj._positional_metadata)
-        self.assertFalse(obj.has_positional_metadata())
+        assert_data_frame_almost_equal(obj.positional_metadata,
+                                       pd.DataFrame(index=range(3)))
 
         obj = self._positional_metadata_constructor_(3)
 
-        self.assertIsNone(obj._positional_metadata)
-        self.assertFalse(obj.has_positional_metadata())
+        assert_data_frame_almost_equal(obj.positional_metadata,
+                                       pd.DataFrame(index=range(3)))
         del obj.positional_metadata
-        self.assertIsNone(obj._positional_metadata)
-        self.assertFalse(obj.has_positional_metadata())
+        assert_data_frame_almost_equal(obj.positional_metadata,
+                                       pd.DataFrame(index=range(3)))
 
     def test_has_positional_metadata(self):
         obj = self._positional_metadata_constructor_(4)
         self.assertFalse(obj.has_positional_metadata())
-        self.assertIsNone(obj._positional_metadata)
 
         obj = self._positional_metadata_constructor_(0, positional_metadata={})
         self.assertFalse(obj.has_positional_metadata())

--- a/skbio/metadata/tests/test_mixin.py
+++ b/skbio/metadata/tests/test_mixin.py
@@ -74,3 +74,7 @@ class TestPositionalMetadataMixin(unittest.TestCase, ReallyEqualMixin,
                 return copy
 
         self._positional_metadata_constructor_ = ExamplePositionalMetadataMixin
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/skbio/sequence/_dna.py
+++ b/skbio/sequence/_dna.py
@@ -204,17 +204,9 @@ class DNA(GrammaredSequence, NucleotideMixin,
         """
         seq = self._string.replace(b'T', b'U')
 
-        metadata = None
-        if self.has_metadata():
-            metadata = self.metadata
-
-        positional_metadata = None
-        if self.has_positional_metadata():
-            positional_metadata = self.positional_metadata
-
         # turn off validation because `seq` is guaranteed to be valid
-        return skbio.RNA(seq, metadata=metadata,
-                         positional_metadata=positional_metadata,
+        return skbio.RNA(seq, metadata=self.metadata,
+                         positional_metadata=self.positional_metadata,
                          validate=False)
 
     @stable(as_of="0.4.0")

--- a/skbio/sequence/_genetic_code.py
+++ b/skbio/sequence/_genetic_code.py
@@ -582,12 +582,8 @@ class GeneticCode(SkbioObject):
             elif stop == 'require':
                 self._raise_require_error('stop', reading_frame)
 
-        metadata = None
-        if sequence.has_metadata():
-            metadata = sequence.metadata
-
         # turn off validation because `translated` is guaranteed to be valid
-        return Protein(translated, metadata=metadata, validate=False)
+        return Protein(translated, metadata=sequence.metadata, validate=False)
 
     def _validate_translate_inputs(self, sequence, reading_frame, start, stop):
         if not isinstance(sequence, RNA):

--- a/skbio/sequence/_grammared_sequence.py
+++ b/skbio/sequence/_grammared_sequence.py
@@ -611,9 +611,11 @@ class GrammaredSequence(Sequence, metaclass=GrammaredSequenceMeta):
             else:
                 expansions.append(degen_chars[char])
 
-        result = product(*expansions)
-        return (self._to(sequence=''.join(nondegen_seq)) for nondegen_seq in
-                result)
+        for nondegen_seq in product(*expansions):
+            yield self._constructor(
+                sequence=''.join(nondegen_seq),
+                metadata=self.metadata,
+                positional_metadata=self.positional_metadata)
 
     @stable(as_of='0.4.1')
     def to_regex(self):

--- a/skbio/sequence/_nucleotide_mixin.py
+++ b/skbio/sequence/_nucleotide_mixin.py
@@ -145,7 +145,11 @@ class NucleotideMixin(metaclass=ABCMeta):
 
         """
         result = self._complement_lookup[self._bytes]
-        complement = self._to(sequence=result)
+        complement = self._constructor(
+            sequence=result,
+            metadata=self.metadata,
+            positional_metadata=self.positional_metadata)
+
         if reverse:
             complement = complement[::-1]
         return complement

--- a/skbio/sequence/_rna.py
+++ b/skbio/sequence/_rna.py
@@ -204,17 +204,9 @@ class RNA(GrammaredSequence, NucleotideMixin,
         """
         seq = self._string.replace(b'U', b'T')
 
-        metadata = None
-        if self.has_metadata():
-            metadata = self.metadata
-
-        positional_metadata = None
-        if self.has_positional_metadata():
-            positional_metadata = self.positional_metadata
-
         # turn off validation because `seq` is guaranteed to be valid
-        return skbio.DNA(seq, metadata=metadata,
-                         positional_metadata=positional_metadata,
+        return skbio.DNA(seq, metadata=self.metadata,
+                         positional_metadata=self.positional_metadata,
                          validate=False)
 
     @stable(as_of="0.4.0")

--- a/skbio/sequence/_sequence.py
+++ b/skbio/sequence/_sequence.py
@@ -505,13 +505,10 @@ class Sequence(MetadataMixin, PositionalMetadataMixin, collections.Sequence,
 
         if how == 'strict':
             how = 'inner'
-            cols = []
+            cols = set()
             for s in seqs:
-                if s.has_positional_metadata():
-                    cols.append(frozenset(s.positional_metadata))
-                else:
-                    cols.append(frozenset())
-            if len(set(cols)) > 1:
+                cols.add(frozenset(s.positional_metadata))
+            if len(cols) > 1:
                 raise ValueError("The positional metadata of the sequences do"
                                  " not have matching columns. Consider setting"
                                  " how='inner' or how='outer'")
@@ -520,8 +517,6 @@ class Sequence(MetadataMixin, PositionalMetadataMixin, collections.Sequence,
         for seq in seqs:
             seq_data.append(seq._bytes)
             pm_data.append(seq.positional_metadata)
-            if not seq.has_positional_metadata():
-                del seq.positional_metadata
 
         pm = pd.concat(pm_data, join=how, ignore_index=True)
         bytes_ = np.concatenate(seq_data)
@@ -560,21 +555,15 @@ class Sequence(MetadataMixin, PositionalMetadataMixin, collections.Sequence,
             # Sequence casting is acceptable between direct
             # decendants/ancestors
             sequence._assert_can_cast_to(type(self))
-            # we're not simply accessing sequence.metadata in order to avoid
-            # creating "empty" metadata representations on both sequence
-            # objects if they don't have metadata. same strategy is used below
-            # for positional metadata
-            if metadata is None and sequence.has_metadata():
+
+            if metadata is None:
                 metadata = sequence.metadata
-            if (positional_metadata is None and
-                    sequence.has_positional_metadata()):
+            if positional_metadata is None:
                 positional_metadata = sequence.positional_metadata
+
             sequence = sequence._bytes
-
             self._owns_bytes = False
-
             self._set_bytes(sequence)
-
         else:
             # Encode as ascii to raise UnicodeEncodeError if necessary.
             if isinstance(sequence, str):
@@ -858,14 +847,14 @@ class Sequence(MetadataMixin, PositionalMetadataMixin, collections.Sequence,
                         list(_slices_from_iter(self._bytes, indexable)))
                     index = _as_slice_if_single_index(indexable)
 
-                    positional_metadata = None
-                    if self.has_positional_metadata():
-                        pos_md_slices = list(_slices_from_iter(
-                                             self.positional_metadata, index))
-                        positional_metadata = pd.concat(pos_md_slices)
+                    pos_md_slices = list(_slices_from_iter(
+                                         self.positional_metadata, index))
+                    positional_metadata = pd.concat(pos_md_slices)
 
-                    return self._to(sequence=seq,
-                                    positional_metadata=positional_metadata)
+                    return self._constructor(
+                        sequence=seq,
+                        metadata=self.metadata,
+                        positional_metadata=positional_metadata)
         elif (isinstance(indexable, str) or
                 isinstance(indexable, bool)):
             raise IndexError("Cannot index with %s type: %r" %
@@ -886,17 +875,17 @@ class Sequence(MetadataMixin, PositionalMetadataMixin, collections.Sequence,
         seq = self._bytes[indexable]
         positional_metadata = self._slice_positional_metadata(indexable)
 
-        return self._to(sequence=seq, positional_metadata=positional_metadata)
+        return self._constructor(
+            sequence=seq,
+            metadata=self.metadata,
+            positional_metadata=positional_metadata)
 
     def _slice_positional_metadata(self, indexable):
-        if self.has_positional_metadata():
-            if _is_single_index(indexable):
-                index = _single_index_to_slice(indexable)
-            else:
-                index = indexable
-            return self.positional_metadata.iloc[index]
+        if _is_single_index(indexable):
+            index = _single_index_to_slice(indexable)
         else:
-            return None
+            index = indexable
+        return self.positional_metadata.iloc[index]
 
     @stable(as_of="0.4.0")
     def __len__(self):
@@ -1467,11 +1456,12 @@ class Sequence(MetadataMixin, PositionalMetadataMixin, collections.Sequence,
         index = self._munge_to_index_array(where)
         seq_bytes = self._bytes.copy()
         seq_bytes[index] = character
-        metadata = self.metadata if self.has_metadata() else None
-        positional_metadata = self.positional_metadata if \
-            self.has_positional_metadata() else None
-        return self.__class__(seq_bytes, metadata=metadata,
-                              positional_metadata=positional_metadata)
+
+        # Use __class__ instead of _constructor so that validations are
+        # performed for subclasses (the user could have introduced invalid
+        # characters).
+        return self.__class__(seq_bytes, metadata=self.metadata,
+                              positional_metadata=self.positional_metadata)
 
     @stable(as_of="0.4.0")
     def index(self, subsequence, start=None, end=None):
@@ -1937,15 +1927,20 @@ class Sequence(MetadataMixin, PositionalMetadataMixin, collections.Sequence,
             step = k
             count = len(self) // k
 
-        if len(self) == 0 or self.has_positional_metadata():
+        if len(self) == 0 or len(self.positional_metadata.columns):
+            # Slower path when sequence is empty or positional metadata needs
+            # to be sliced.
             for i in range(0, len(self) - k + 1, step):
                 yield self[i:i+k]
-        # Optimized path when no positional metadata
         else:
+            # Optimized path when positional metadata doesn't need slicing.
             kmers = np.lib.stride_tricks.as_strided(
                 self._bytes, shape=(k, count), strides=(1, step)).T
             for s in kmers:
-                yield self._to(sequence=s)
+                yield self._constructor(
+                    sequence=s,
+                    metadata=self.metadata,
+                    positional_metadata=None)
 
     @stable(as_of="0.4.0")
     def kmer_frequencies(self, k, overlap=True, relative=False):
@@ -2117,53 +2112,6 @@ class Sequence(MetadataMixin, PositionalMetadataMixin, collections.Sequence,
             r = self[contig]
             if len(r) >= min_length:
                 yield r
-
-    def _to(self, sequence=None, metadata=None, positional_metadata=None):
-        """Return a copy of this sequence.
-
-        Returns a copy of this sequence, optionally with updated attributes
-        specified as keyword arguments.
-
-        Arguments are the same as those passed to the ``Sequence`` constructor.
-        The returned copy will have its attributes updated based on the
-        arguments. If an attribute is missing, the copy will keep the same
-        attribute as this sequence. Valid attribute names are `'sequence'`,
-        `'metadata'`, and `'positional_metadata'`. Default behavior is to
-        return a copy of this sequence without changing any attributes.
-
-        Parameters
-        ----------
-        sequence : optional
-        metadata : optional
-        positional_metadata : optional
-
-        Returns
-        -------
-        Sequence
-            Copy of this sequence, optionally with updated attributes based on
-            arguments. Will be the same type as this sequence (`self`).
-
-        Notes
-        -----
-        By default, `metadata` and `positional_metadata` are shallow-copied and
-        the reference to `sequence` is used (without copying) for efficiency
-        since `sequence` is immutable. This differs from the behavior of
-        `Sequence.copy`, which will actually copy `sequence`.
-
-        This method is the preferred way of creating new instances from an
-        existing sequence, instead of calling ``self.__class__(...)``, as the
-        latter can be error-prone (e.g., it's easy to forget to propagate
-        attributes to the new instance).
-
-        """
-        if sequence is None:
-            sequence = self._bytes
-        if metadata is None and self.has_metadata():
-            metadata = self._metadata
-        if positional_metadata is None and self.has_positional_metadata():
-            positional_metadata = self._positional_metadata
-        return self._constructor(sequence=sequence, metadata=metadata,
-                                 positional_metadata=positional_metadata)
 
     def _constructor(self, **kwargs):
         return self.__class__(**kwargs)

--- a/skbio/sequence/tests/test_grammared_sequence.py
+++ b/skbio/sequence/tests/test_grammared_sequence.py
@@ -10,9 +10,11 @@ from unittest import TestCase, main
 
 import numpy as np
 import numpy.testing as npt
+import pandas as pd
 
 from skbio.sequence import GrammaredSequence
 from skbio.util import classproperty
+from skbio.util._testing import assert_data_frame_almost_equal
 
 
 class ExampleGrammaredSequence(GrammaredSequence):
@@ -141,8 +143,9 @@ class TestGrammaredSequence(TestCase):
         seq = ExampleGrammaredSequence('.-ABCXYZ')
 
         npt.assert_equal(seq.values, np.array('.-ABCXYZ', dtype='c'))
-        self.assertFalse(seq.has_metadata())
-        self.assertFalse(seq.has_positional_metadata())
+        self.assertEqual(seq.metadata, {})
+        assert_data_frame_almost_equal(seq.positional_metadata,
+                                       pd.DataFrame(index=range(8)))
 
     def test_init_nondefault_parameters(self):
         seq = ExampleGrammaredSequence(
@@ -151,11 +154,9 @@ class TestGrammaredSequence(TestCase):
             positional_metadata={'quality': range(8)})
 
         npt.assert_equal(seq.values, np.array('.-ABCXYZ', dtype='c'))
-        self.assertTrue(seq.has_metadata())
-        self.assertEqual(seq.metadata['id'], 'foo')
-        self.assertTrue(seq.has_positional_metadata())
-        npt.assert_equal(seq.positional_metadata['quality'], np.array(range(8),
-                         dtype='int'))
+        self.assertEqual(seq.metadata, {'id': 'foo'})
+        assert_data_frame_almost_equal(seq.positional_metadata,
+                                       pd.DataFrame({'quality': range(8)}))
 
     def test_init_valid_empty_sequence(self):
         # just make sure we can instantiate an empty sequence regardless of


### PR DESCRIPTION
Removed memory optimizations for storing empty `metadata` and `positional_metadata`, currently on `Sequence` and `TabularMSA`.

Previously, empty metadata was stored internally as `None`, and an empty metadata representation (e.g., `{}` or `pd.DataFrame(index=range(axis_len))` was created and stored on the object when `.metadata` or `.positional_metadata` properties were accessed for the first time.

While this optimization resulted in some memory savings, its implementation is not sustainable because scikit-bio devs must remember to use `has_metadata` or `has_positional_metadata` to handle empty metadata efficiently, otherwise any memory savings are lost. Every routine interacting with metadata needed a unit test ensuring empty metadata is handled efficiently, and worse, these tests had to interact with private state. As metadata will be applied to more, if not all, scikit-bio objects in the future, the maintenance and cognitive burden placed on developers is not worth the memory savings at this time. Further, this memory optimization caused the memory footprints of scikit-bio objects to be unpredictable. For example, a user may not understand why they are running out of memory when accessing `.metadata`, `.positional_metadata`, or a routine that doesn't handle empty metadata efficiently.

Now, empty `metadata` will be stored as `{}` and empty `positional_metadata` as a `DataFrame` with default index matching the object's axis length. The empty dict shouldn't be too heavy but the empty `DataFrame` is problematic. To fix #1308 we will use the new default `RangeIndex` in pandas 0.18.0, which is much more memory-efficient (essentially storing 3 integers: start, stop, and end). Thus, empty `positional_metadata` will have a much smaller memory footprint soon. If more memory savings are needed in the future, we could implement proxy objects.

Deprecated `has_metadata` and `has_positional_metadata`, as they mainly existed for scikit-bio devs to check whether metadata exists without creating empty metadata objects.

Related to #1308.