### PR TITLE
ENH: pandas 0.18.0 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,13 @@
 ### Features
 * Added `skbio.sequence.distance.kmer_distance` for computing the kmer distance between two sequences. ([#913](https://github.com/biocore/scikit-bio/issues/913))
 * Added `skbio.sequence.Sequence.replace` for assigning a character to positions in a `Sequence`. ([#1222](https://github.com/biocore/scikit-bio/issues/1222))
+* Added support for `pandas.RangeIndex`, lowering the memory footprint of default integer index objects. `Sequence.positional_metadata` and `TabularMSA.positional_metadata` now use `pd.RangeIndex` as the positional metadata index. `TabularMSA` now uses `pd.RangeIndex` as the default index. Usage of `pd.RangeIndex` over the previous `pd.Int64Index` [should be transparent](http://pandas.pydata.org/pandas-docs/version/0.18.0/whatsnew.html#range-index), so these changes should be non-breaking to users. scikit-bio now depends on pandas >= 0.18.0 ([#1308](https://github.com/biocore/scikit-bio/issues/1308))
+* Added `reset_index=False` parameter to `TabularMSA.append` and `TabularMSA.extend` for resetting the MSA's index to the default index after appending/extending.
 
 ### Backward-incompatible changes [stable]
 
 ### Backward-incompatible changes [experimental]
+* `TabularMSA.append` and `TabularMSA.extend` now require one of `minter`, `index`, or `reset_index` to be provided when incorporating new sequences into an MSA. Previous behavior was to auto-increment the index labels if `minter` and `index` weren't provided and the MSA had a default integer index, otherwise error. Use `reset_index=True` to obtain the previous behavior in a more explicit way.
 
 ### Bug fixes
 * Fixed bug when using `Sequence.iter_kmers` on empty `Sequence` object. Previously this raised a `ValueError`, now it returns

--- a/ci/conda_requirements.txt
+++ b/ci/conda_requirements.txt
@@ -2,7 +2,7 @@ pip
 numpy
 scipy
 matplotlib
-pandas>=0.17.0,<0.18.0
+pandas
 nose
 pep8
 ipython

--- a/setup.py
+++ b/setup.py
@@ -118,7 +118,7 @@ setup(name='scikit-bio',
           'matplotlib >= 1.4.3',
           'natsort >= 4.0.3',
           'numpy >= 1.9.2',
-          'pandas >= 0.17.0',
+          'pandas >= 0.18.0',
           'scipy >= 0.15.1',
           'nose >= 1.3.7'
       ],

--- a/skbio/alignment/_tabular_msa.py
+++ b/skbio/alignment/_tabular_msa.py
@@ -1642,7 +1642,7 @@ class TabularMSA(MetadataMixin, PositionalMetadataMixin, SkbioObject):
 
         Parameters
         ----------
-        mapping : dict-like or callable, optional
+        mapping : dict or callable, optional
             Dictionary or callable that maps existing labels to new labels. Any
             label without a mapping will remain the same.
         minter : callable or metadata key, optional
@@ -1701,7 +1701,15 @@ class TabularMSA(MetadataMixin, PositionalMetadataMixin, SkbioObject):
                 "Cannot use both `mapping` and `minter` at the same time.")
 
         if mapping is not None:
-            self._seqs.rename(mapping, inplace=True)
+            if isinstance(mapping, dict):
+                self.index = [mapping[label] if label in mapping else label
+                              for label in self.index]
+            elif callable(mapping):
+                self.index = [mapping(label) for label in self.index]
+            else:
+                raise TypeError(
+                    "`mapping` must be a dict or callable, not type %r"
+                    % type(mapping).__name__)
         elif minter is not None:
             self.index = [resolve_key(seq, minter) for seq in self._seqs]
         else:

--- a/skbio/alignment/_tabular_msa.py
+++ b/skbio/alignment/_tabular_msa.py
@@ -1918,7 +1918,9 @@ class TabularMSA(MetadataMixin, PositionalMetadataMixin, SkbioObject):
         RangeIndex(start=0, stop=6, step=1)
 
         """
-        if sum([minter is not None, index is not None, reset_index]) != 1:
+        if sum([minter is not None,
+                index is not None,
+                bool(reset_index)]) != 1:
             raise ValueError(
                 "Must provide exactly one of the following parameters: "
                 "`minter`, `index`, `reset_index`")

--- a/skbio/alignment/_tabular_msa.py
+++ b/skbio/alignment/_tabular_msa.py
@@ -50,11 +50,12 @@ class TabularMSA(MetadataMixin, PositionalMetadataMixin, SkbioObject):
     minter : callable or metadata key, optional
         If provided, defines an index label for each sequence in `sequences`.
         Can either be a callable accepting a single argument (each sequence) or
-        a key into each sequence's ``metadata`` attribute.
+        a key into each sequence's ``metadata`` attribute. Note that `minter`
+        cannot be combined with `index`.
     index : pd.Index consumable, optional
         Index containing labels for `sequences`. Must be the same length as
         `sequences`. Must be able to be passed directly to ``pd.Index``
-        constructor.
+        constructor. Note that `index` cannot be combined with `minter`.
 
     Raises
     ------
@@ -62,6 +63,14 @@ class TabularMSA(MetadataMixin, PositionalMetadataMixin, SkbioObject):
         If `minter` and `index` are both provided.
     ValueError
         If `index` is not the same length as `sequences`.
+    TypeError
+        If `sequences` contains an object that isn't a ``GrammaredSequence``.
+    TypeError
+        If `sequences` does not contain exactly the same type of
+        ``GrammaredSequence`` objects.
+    ValueError
+        If `sequences` does not contain ``GrammaredSequence`` objects of the
+        same length.
 
     See Also
     --------
@@ -70,11 +79,12 @@ class TabularMSA(MetadataMixin, PositionalMetadataMixin, SkbioObject):
     skbio.sequence.Protein
     pandas.DataFrame
     pandas.Index
+    reassign_index
 
     Notes
     -----
-    If `minter` or `index` are not provided, default pandas labels will be
-    used: integer labels ``0..(N-1)``, where ``N`` is the number of sequences.
+    If neither `minter` nor `index` are provided, default index labels will be
+    used: ``pd.RangeIndex(start=0, stop=len(sequences), step=1)``.
 
     Examples
     --------
@@ -98,10 +108,11 @@ class TabularMSA(MetadataMixin, PositionalMetadataMixin, SkbioObject):
     AG-T
     -C-T
 
-    The MSA has default index labels:
+    Since `minter` or `index` wasn't provided, the MSA has default index
+    labels:
 
     >>> msa.index
-    Int64Index([0, 1, 2], dtype='int64')
+    RangeIndex(start=0, stop=3, step=1)
 
     Create an MSA with metadata, positional metadata, and non-default index
     labels:
@@ -218,25 +229,27 @@ class TabularMSA(MetadataMixin, PositionalMetadataMixin, SkbioObject):
 
         >>> from skbio import DNA, TabularMSA
         >>> seqs = [DNA('ACG', metadata={'id': 'a'}),
-        ...         DNA('AC-', metadata={'id': 'b'})]
+        ...         DNA('AC-', metadata={'id': 'b'}),
+        ...         DNA('AC-', metadata={'id': 'c'})]
         >>> msa = TabularMSA(seqs, minter='id')
 
         Retrieve index:
 
         >>> msa.index
-        Index(['a', 'b'], dtype='object')
+        Index(['a', 'b', 'c'], dtype='object')
 
         Set index:
 
-        >>> msa.index = ['seq1', 'seq2']
+        >>> msa.index = ['seq1', 'seq2', 'seq3']
         >>> msa.index
-        Index(['seq1', 'seq2'], dtype='object')
+        Index(['seq1', 'seq2', 'seq3'], dtype='object')
 
-        Delete index:
+        Deleting the index resets it to the ``TabularMSA`` constructor's
+        default:
 
         >>> del msa.index
         >>> msa.index
-        Int64Index([0, 1], dtype='int64')
+        RangeIndex(start=0, stop=3, step=1)
 
         """
         return self._seqs.index
@@ -246,13 +259,13 @@ class TabularMSA(MetadataMixin, PositionalMetadataMixin, SkbioObject):
         # Cast to Index to identify tuples as a MultiIndex to match
         # pandas constructor. Just setting would make an index of tuples.
         if not isinstance(index, pd.Index):
-            self._seqs.index = pd.Index(index)
-        else:
-            self._seqs.index = index
+            index = pd.Index(index)
+        self._seqs.index = index
 
     @index.deleter
     def index(self):
-        self.reassign_index()
+        # Create a memory-efficient integer index as the default MSA index.
+        self._seqs.index = pd.RangeIndex(start=0, stop=len(self), step=1)
 
     @property
     @experimental(as_of="0.4.1")
@@ -760,8 +773,14 @@ class TabularMSA(MetadataMixin, PositionalMetadataMixin, SkbioObject):
             if minter is None and index is None:
                 index = sequences.index
 
+        # Give a better error message than the one raised by `extend` (it
+        # references `reset_index`, which isn't a constructor parameter).
+        if minter is not None and index is not None:
+            raise ValueError(
+                "Cannot use both `minter` and `index` at the same time.")
         self._seqs = pd.Series([])
-        self.extend(sequences, minter=minter, index=index)
+        self.extend(sequences, minter=minter, index=index,
+                    reset_index=minter is None and index is None)
 
         MetadataMixin._init_(self, metadata=metadata)
         PositionalMetadataMixin._init_(
@@ -848,6 +867,7 @@ class TabularMSA(MetadataMixin, PositionalMetadataMixin, SkbioObject):
 
         """
         # It is impossible to have 0 sequences and >0 positions.
+        # TODO: change for #1198
         return self.shape.position > 0
 
     @experimental(as_of='0.4.1')
@@ -1641,9 +1661,8 @@ class TabularMSA(MetadataMixin, PositionalMetadataMixin, SkbioObject):
 
         Notes
         -----
-        If neither `mapping` nor `minter` are provided, default pandas labels
-        will be used: integer labels ``0..(N-1)``, where ``N`` is the number of
-        sequences.
+        If neither `mapping` nor `minter` are provided, index labels will be
+        reset to the ``TabularMSA`` constructor's default.
 
         Examples
         --------
@@ -1651,47 +1670,45 @@ class TabularMSA(MetadataMixin, PositionalMetadataMixin, SkbioObject):
 
         >>> from skbio import DNA, TabularMSA
         >>> seqs = [DNA('ACG', metadata={'id': 'a'}),
-        ...         DNA('AC-', metadata={'id': 'b'})]
+        ...         DNA('AC-', metadata={'id': 'b'}),
+        ...         DNA('CCG', metadata={'id': 'c'})]
         >>> msa = TabularMSA(seqs)
         >>> msa.index
-        Int64Index([0, 1], dtype='int64')
+        RangeIndex(start=0, stop=3, step=1)
 
         Assign new index to the MSA using each sequence's ID as a label:
 
         >>> msa.reassign_index(minter='id')
         >>> msa.index
-        Index(['a', 'b'], dtype='object')
+        Index(['a', 'b', 'c'], dtype='object')
 
         Assign default index:
 
         >>> msa.reassign_index()
         >>> msa.index
-        Int64Index([0, 1], dtype='int64')
+        RangeIndex(start=0, stop=3, step=1)
 
         Alternatively, a mapping of existing labels to new labels may be passed
         via `mapping`:
 
         >>> msa.reassign_index(mapping={0: 'seq1', 1: 'seq2'})
         >>> msa.index
-        Index(['seq1', 'seq2'], dtype='object')
+        Index(['seq1', 'seq2', 2], dtype='object')
 
         """
         if mapping is not None and minter is not None:
             raise ValueError(
                 "Cannot use both `mapping` and `minter` at the same time.")
+
         if mapping is not None:
             self._seqs.rename(mapping, inplace=True)
         elif minter is not None:
-            index = [resolve_key(seq, minter) for seq in self._seqs]
-
-            # Cast to Index to identify tuples as a MultiIndex to match
-            # pandas constructor. Just setting would make an index of tuples.
-            self.index = pd.Index(index)
+            self.index = [resolve_key(seq, minter) for seq in self._seqs]
         else:
-            self._seqs.reset_index(drop=True, inplace=True)
+            del self.index
 
     @experimental(as_of='0.4.1')
-    def append(self, sequence, minter=None, index=None):
+    def append(self, sequence, minter=None, index=None, reset_index=False):
         """Append a sequence to the MSA without recomputing alignment.
 
         Parameters
@@ -1703,18 +1720,20 @@ class TabularMSA(MetadataMixin, PositionalMetadataMixin, SkbioObject):
             Used to create an index label for the sequence being appended. If
             callable, it generates a label directly. Otherwise it's treated as
             a key into the sequence metadata. Note that `minter` cannot be
-            combined with `index`.
+            combined with `index` nor `reset_index`.
         index : object, optional
             Index label to use for the appended sequence. Note that `index`
-            cannot be combined with `minter`.
+            cannot be combined with `minter` nor `reset_index`.
+        reset_index : bool, optional
+            If ``True``, this MSA's index is reset to the ``TabularMSA``
+            constructor's default after appending. Note that `reset_index`
+            cannot be combined with `minter` nor `index`.
 
         Raises
         ------
         ValueError
-            If both `minter` and `index` are provided.
-        ValueError
-            If neither `minter` nor `index` are provided and the MSA has a
-            non-default index.
+            If exactly one choice of `minter`, `index`, or `reset_index` is not
+            provided.
         TypeError
             If the sequence object isn't a ``GrammaredSequence``.
         TypeError
@@ -1730,16 +1749,15 @@ class TabularMSA(MetadataMixin, PositionalMetadataMixin, SkbioObject):
 
         Notes
         -----
-        If neither `minter` nor `index` are provided and this MSA has default
-        index labels, the new index label will be auto-incremented.
-
         The MSA is not automatically re-aligned when a sequence is appended.
         Therefore, this operation is not necessarily meaningful on its own.
 
         Examples
         --------
+        Create an MSA with a single sequence labeled ``'seq1'``:
+
         >>> from skbio import DNA, TabularMSA
-        >>> msa = TabularMSA([DNA('ACGT')])
+        >>> msa = TabularMSA([DNA('ACGT')], index=['seq1'])
         >>> msa
         TabularMSA[DNA]
         ---------------------
@@ -1748,7 +1766,13 @@ class TabularMSA(MetadataMixin, PositionalMetadataMixin, SkbioObject):
             position count: 4
         ---------------------
         ACGT
-        >>> msa.append(DNA('AG-T'))
+        >>> msa.index
+        Index(['seq1'], dtype='object')
+
+        Append a new sequence to the MSA, providing its index label via
+        `index`:
+
+        >>> msa.append(DNA('AG-T'), index='seq2')
         >>> msa
         TabularMSA[DNA]
         ---------------------
@@ -1758,22 +1782,36 @@ class TabularMSA(MetadataMixin, PositionalMetadataMixin, SkbioObject):
         ---------------------
         ACGT
         AG-T
-
-        Auto-incrementing index labels:
-
         >>> msa.index
-        Int64Index([0, 1], dtype='int64')
-        >>> msa.append(DNA('ACGA'))
+        Index(['seq1', 'seq2'], dtype='object')
+
+        Append another sequence, this time resetting the MSA's index labels to
+        the default with `reset_index`. Note that since the MSA's index is
+        reset, we do not need to provide an index label for the new sequence
+        via `index` or `minter`:
+
+        >>> msa.append(DNA('ACGA'), reset_index=True)
+        >>> msa
+        TabularMSA[DNA]
+        ---------------------
+        Stats:
+            sequence count: 3
+            position count: 4
+        ---------------------
+        ACGT
+        AG-T
+        ACGA
         >>> msa.index
-        Int64Index([0, 1, 2], dtype='int64')
+        RangeIndex(start=0, stop=3, step=1)
 
         """
         if index is not None:
             index = [index]
-        self.extend([sequence], minter=minter, index=index)
+        self.extend([sequence], minter=minter, index=index,
+                    reset_index=reset_index)
 
     @experimental(as_of='0.4.1')
-    def extend(self, sequences, minter=None, index=None):
+    def extend(self, sequences, minter=None, index=None, reset_index=False):
         """Extend this MSA with sequences without recomputing alignment.
 
         Parameters
@@ -1785,27 +1823,29 @@ class TabularMSA(MetadataMixin, PositionalMetadataMixin, SkbioObject):
             Used to create index labels for the sequences being appended. If
             callable, it generates a label directly. Otherwise it's treated as
             a key into the sequence metadata. Note that `minter` cannot be
-            combined with `index`.
+            combined with `index` nor `reset_index`.
         index : pd.Index consumable, optional
             Index labels to use for the appended sequences. Must be the same
             length as `sequences`. Must be able to be passed directly to
             ``pd.Index`` constructor. Note that `index` cannot be combined
-            with `minter`.
+            with `minter` nor `reset_index`.
+        reset_index : bool, optional
+            If ``True``, this MSA's index is reset to the ``TabularMSA``
+            constructor's default after extending. Note that `reset_index`
+            cannot be combined with `minter` nor `index`.
 
         Raises
         ------
         ValueError
-            If both `minter` and `index` are both provided.
-        ValueError
-            If neither `minter` nor `index` are provided and the MSA has a
-            non-default index.
+            If exactly one choice of `minter`, `index`, or `reset_index` is not
+            provided.
         ValueError
             If `index` is not the same length as `sequences`.
         TypeError
             If `sequences` contains an object that isn't a
             ``GrammaredSequence``.
         TypeError
-            If `sequence` contains a type that does not match the dtype of the
+            If `sequences` contains a type that does not match the dtype of the
             MSA.
         ValueError
             If the length of a sequence does not match the number of positions
@@ -1818,16 +1858,15 @@ class TabularMSA(MetadataMixin, PositionalMetadataMixin, SkbioObject):
 
         Notes
         -----
-        If neither `minter` nor `index` are provided and this MSA has default
-        index labels, the new index labels will be auto-incremented.
-
         The MSA is not automatically re-aligned when appending sequences.
         Therefore, this operation is not necessarily meaningful on its own.
 
         Examples
         --------
+        Create an MSA with a single sequence labeled ``'seq1'``:
+
         >>> from skbio import DNA, TabularMSA
-        >>> msa = TabularMSA([DNA('ACGT')])
+        >>> msa = TabularMSA([DNA('ACGT')], index=['seq1'])
         >>> msa
         TabularMSA[DNA]
         ---------------------
@@ -1836,7 +1875,13 @@ class TabularMSA(MetadataMixin, PositionalMetadataMixin, SkbioObject):
             position count: 4
         ---------------------
         ACGT
-        >>> msa.extend([DNA('AG-T'), DNA('-G-T')])
+        >>> msa.index
+        Index(['seq1'], dtype='object')
+
+        Extend the MSA with sequences, providing their index labels via
+        `index`:
+
+        >>> msa.extend([DNA('AG-T'), DNA('-G-T')], index=['seq2', 'seq3'])
         >>> msa
         TabularMSA[DNA]
         ---------------------
@@ -1847,59 +1892,89 @@ class TabularMSA(MetadataMixin, PositionalMetadataMixin, SkbioObject):
         ACGT
         AG-T
         -G-T
-
-        Auto-incrementing index labels:
-
         >>> msa.index
-        Int64Index([0, 1, 2], dtype='int64')
-        >>> msa.extend([DNA('ACGA'), DNA('AC-T'), DNA('----')])
+        Index(['seq1', 'seq2', 'seq3'], dtype='object')
+
+        Extend with more sequences, this time resetting the MSA's index labels
+        to the default with `reset_index`. Note that since the MSA's index is
+        reset, we do not need to provide index labels for the new sequences via
+        `index` or `minter`:
+
+        >>> msa.extend([DNA('ACGA'), DNA('AC-T'), DNA('----')],
+        ...            reset_index=True)
+        >>> msa
+        TabularMSA[DNA]
+        ---------------------
+        Stats:
+            sequence count: 6
+            position count: 4
+        ---------------------
+        ACGT
+        AG-T
+        ...
+        AC-T
+        ----
         >>> msa.index
-        Int64Index([0, 1, 2, 3, 4, 5], dtype='int64')
+        RangeIndex(start=0, stop=6, step=1)
 
         """
-        if minter is not None and index is not None:
+        if sum([minter is not None, index is not None, reset_index]) != 1:
             raise ValueError(
-                "Cannot use both `minter` and `index` at the same time.")
+                "Must provide exactly one of the following parameters: "
+                "`minter`, `index`, `reset_index`")
 
+        # Verify `sequences` first because `minter` could interact with each
+        # sequence's `metadata`.
         sequences = list(sequences)
-
-        if minter is None and index is None:
-            if self.index.equals(pd.Index(np.arange(len(self)))):
-                index = range(len(self), len(self) + len(sequences))
-            else:
-                raise ValueError(
-                    "MSA does not have default index labels, must provide "
-                    "a `minter` or `index` for sequence(s).")
-        elif minter is not None:
-            index = [resolve_key(seq, minter) for seq in sequences]
-
-        # Cast to Index to identify tuples as a MultiIndex to match
-        # pandas constructor. Just setting would make an index of tuples.
-        if not isinstance(index, pd.Index):
-            index = pd.Index(index)
-
         self._assert_valid_sequences(sequences)
 
-        # pandas doesn't give a user-friendly error message if we pass through.
-        if len(sequences) != len(index):
-            raise ValueError(
-                "Number of sequences (%d) must match index length (%d)" %
-                (len(sequences), len(index)))
+        if minter is not None:
+            # Convert to Index to identify tuples as a MultiIndex instead of an
+            # index of tuples.
+            index = pd.Index([resolve_key(seq, minter) for seq in sequences])
+        elif index is not None:
+            # Convert to Index to identify tuples as a MultiIndex instead of an
+            # index of tuples.
+            if not isinstance(index, pd.Index):
+                index = pd.Index(index)
 
-        # When extending a TabularMSA without sequences, the number of
-        # positions in the TabularMSA may change from zero to non-zero. If this
-        # happens, the TabularMSA's positional_metadata must be reset to its
-        # default "empty" representation for the new number of positions,
-        # otherwise the number of positions in the TabularMSA and
-        # positional_metadata will differ.
-        #
-        # TODO: change for #1198
-        prev_num_positions = self.shape.position
-        self._seqs = self._seqs.append(pd.Series(sequences, index=index))
-        curr_num_positions = self.shape.position
-        if curr_num_positions != prev_num_positions:
-            assert prev_num_positions == 0
-            del self.positional_metadata
+            # pandas doesn't give a user-friendly error message if we pass
+            # through.
+            if len(sequences) != len(index):
+                raise ValueError(
+                    "Number of sequences (%d) must match index length (%d)" %
+                    (len(sequences), len(index)))
+        else:
+            # Case for `reset_index=True`. We could simply set `index=None`
+            # since it will be reset after appending below, but we can avoid a
+            # memory spike if Series.append creates a new RangeIndex from
+            # adjacent RangeIndexes in the future (pandas 0.18.0 creates an
+            # Int64Index).
+            index = pd.RangeIndex(start=len(self),
+                                  stop=len(self) + len(sequences),
+                                  step=1)
+
+        if len(self):
+            self._seqs = self._seqs.append(pd.Series(sequences, index=index))
+        else:
+            # Not using Series.append to avoid turning a RangeIndex supplied
+            # via `index` parameter into an Int64Index (this happens in pandas
+            # 0.18.0).
+            self._seqs = pd.Series(sequences, index=index)
+
+            # When extending a TabularMSA without sequences, the number of
+            # positions in the TabularMSA may change from zero to non-zero. If
+            # this happens, the TabularMSA's positional_metadata must be reset
+            # to its default "empty" representation for the new number of
+            # positions, otherwise the number of positions in the TabularMSA
+            # and positional_metadata will differ.
+            #
+            # TODO: change for #1198
+            if self.shape.position > 0:
+                del self.positional_metadata
+
+        if reset_index:
+            self.reassign_index()
 
     def _assert_valid_sequences(self, sequences):
         if not sequences:
@@ -2117,8 +2192,8 @@ class TabularMSA(MetadataMixin, PositionalMetadataMixin, SkbioObject):
         Index(['a', 'b', 'c', 'z'], dtype='object')
         >>> joined.positional_metadata
            col1  col2 col3
-        0    42     1  NaN
-        1    43     2  NaN
+        0  42.0     1  NaN
+        1  43.0     2  NaN
         2   NaN     3    f
         3   NaN     4    o
         4   NaN     5    o

--- a/skbio/alignment/tests/test_tabular_msa.py
+++ b/skbio/alignment/tests/test_tabular_msa.py
@@ -102,15 +102,23 @@ class TestTabularMSA(unittest.TestCase, ReallyEqualMixin):
         with self.assertRaises(TypeError):
             TabularMSA(42)
 
-    def test_constructor_non_unique_labels(self):
-        msa = TabularMSA([DNA('ACGT'), DNA('ACGT')], index=[1, 1])
-
-        assert_index_equal(msa.index, pd.Int64Index([1, 1]))
-
     def test_constructor_minter_and_index_both_provided(self):
         with self.assertRaisesRegex(ValueError, 'both.*minter.*index'):
             TabularMSA([DNA('ACGT'), DNA('TGCA')], minter=str,
                        index=['a', 'b'])
+
+    def test_constructor_invalid_minter_callable(self):
+        with self.assertRaises(TypeError):
+            TabularMSA([DNA('ACGT'), DNA('TGCA')], minter=float)
+
+    def test_constructor_missing_minter_metadata_key(self):
+        with self.assertRaises(KeyError):
+            TabularMSA([DNA('ACGT', metadata={'foo': 'bar'}), DNA('TGCA')],
+                       minter='foo')
+
+    def test_constructor_unhashable_minter_metadata_key(self):
+        with self.assertRaises(TypeError):
+            TabularMSA([DNA('ACGT'), DNA('TGCA')], minter=[])
 
     def test_constructor_index_length_mismatch_iterable(self):
         with self.assertRaisesRegex(ValueError,
@@ -122,12 +130,21 @@ class TestTabularMSA(unittest.TestCase, ReallyEqualMixin):
                                     'sequences.*2.*index length.*0'):
             TabularMSA([DNA('ACGT'), DNA('TGCA')], index=pd.Index([]))
 
+    def test_constructor_invalid_index_scalar(self):
+        with self.assertRaises(TypeError):
+            TabularMSA([DNA('ACGT'), DNA('TGCA')], index=42)
+
+    def test_constructor_non_unique_labels(self):
+        msa = TabularMSA([DNA('ACGT'), DNA('ACGT')], index=[1, 1])
+
+        assert_index_equal(msa.index, pd.Int64Index([1, 1]))
+
     def test_constructor_empty_no_index(self):
         # sequence empty
         msa = TabularMSA([])
         self.assertIsNone(msa.dtype)
         self.assertEqual(msa.shape, (0, 0))
-        assert_index_equal(msa.index, pd.Index([]))
+        assert_index_equal(msa.index, pd.RangeIndex(0))
         with self.assertRaises(StopIteration):
             next(iter(msa))
 
@@ -136,7 +153,7 @@ class TestTabularMSA(unittest.TestCase, ReallyEqualMixin):
         msa = TabularMSA(seqs)
         self.assertIs(msa.dtype, DNA)
         self.assertEqual(msa.shape, (2, 0))
-        assert_index_equal(msa.index, pd.Int64Index([0, 1]))
+        assert_index_equal(msa.index, pd.RangeIndex(2))
         self.assertEqual(list(msa), seqs)
 
     def test_constructor_empty_with_labels(self):
@@ -161,7 +178,7 @@ class TestTabularMSA(unittest.TestCase, ReallyEqualMixin):
         msa = TabularMSA(seqs)
         self.assertIs(msa.dtype, DNA)
         self.assertEqual(msa.shape, (1, 3))
-        assert_index_equal(msa.index, pd.Index([0]))
+        assert_index_equal(msa.index, pd.RangeIndex(1))
         self.assertEqual(list(msa), seqs)
 
         # 3x1
@@ -169,7 +186,7 @@ class TestTabularMSA(unittest.TestCase, ReallyEqualMixin):
         msa = TabularMSA(seqs)
         self.assertIs(msa.dtype, DNA)
         self.assertEqual(msa.shape, (3, 1))
-        assert_index_equal(msa.index, pd.Index([0, 1, 2]))
+        assert_index_equal(msa.index, pd.RangeIndex(3))
         self.assertEqual(list(msa), seqs)
 
     def test_constructor_non_empty_with_labels_provided(self):
@@ -210,6 +227,16 @@ class TestTabularMSA(unittest.TestCase, ReallyEqualMixin):
         self.assertIsInstance(msa.index, pd.MultiIndex)
         assert_index_equal(msa.index, pd.Index([('foo', 42), ('bar', 43)]))
 
+    def test_copy_constructor_respects_default_index(self):
+        msa = TabularMSA([DNA('ACGT'), DNA('----'), DNA('AAAA')])
+
+        copy = TabularMSA(msa)
+
+        self.assertEqual(msa, copy)
+        self.assertIsNot(msa, copy)
+        assert_index_equal(msa.index, pd.RangeIndex(3))
+        assert_index_equal(copy.index, pd.RangeIndex(3))
+
     def test_copy_constructor_without_metadata(self):
         msa = TabularMSA([DNA('ACGT'), DNA('----')])
 
@@ -217,6 +244,7 @@ class TestTabularMSA(unittest.TestCase, ReallyEqualMixin):
 
         self.assertEqual(msa, copy)
         self.assertIsNot(msa, copy)
+        assert_index_equal(copy.index, pd.RangeIndex(2))
 
     def test_copy_constructor_with_metadata(self):
         msa = TabularMSA([DNA('ACGT'),
@@ -231,7 +259,8 @@ class TestTabularMSA(unittest.TestCase, ReallyEqualMixin):
         self.assertIsNot(msa, copy)
         self.assertIsNot(msa.metadata, copy.metadata)
         self.assertIsNot(msa.positional_metadata, copy.positional_metadata)
-        self.assertIsNot(msa.index, copy.index)
+        # pd.Index is immutable, no copy necessary.
+        self.assertIs(msa.index, copy.index)
 
     def test_copy_constructor_state_override_with_minter(self):
         msa = TabularMSA([DNA('ACGT'),
@@ -275,6 +304,12 @@ class TestTabularMSA(unittest.TestCase, ReallyEqualMixin):
                        positional_metadata={'bar': range(4, 8)},
                        index=['a', 'b']))
 
+    def test_copy_constructor_with_minter_and_index(self):
+        msa = TabularMSA([DNA('ACGT'), DNA('----')], index=['idx1', 'idx2'])
+
+        with self.assertRaisesRegex(ValueError, 'both.*minter.*index'):
+            TabularMSA(msa, index=['a', 'b'], minter=str)
+
     def test_dtype(self):
         self.assertIsNone(TabularMSA([]).dtype)
         self.assertIs(TabularMSA([Protein('')]).dtype, Protein)
@@ -298,6 +333,17 @@ class TestTabularMSA(unittest.TestCase, ReallyEqualMixin):
 
         with self.assertRaises(AttributeError):
             del TabularMSA([]).shape
+
+    def test_index_getter_default_index(self):
+        msa = TabularMSA([DNA('AC'), DNA('AG'), DNA('AT')])
+
+        assert_index_equal(msa.index, pd.RangeIndex(3))
+
+        # immutable
+        with self.assertRaises(TypeError):
+            msa.index[1] = 2
+        # original state is maintained
+        assert_index_equal(msa.index, pd.RangeIndex(3))
 
     def test_index_getter(self):
         index = TabularMSA([DNA('AC'), DNA('AG'), DNA('AT')], minter=str).index
@@ -324,9 +370,9 @@ class TestTabularMSA(unittest.TestCase, ReallyEqualMixin):
     def test_index_setter_non_empty(self):
         msa = TabularMSA([DNA('AC'), DNA('AG'), DNA('AT')])
         msa.index = range(3)
-        assert_index_equal(msa.index, pd.Index([0, 1, 2]))
+        assert_index_equal(msa.index, pd.RangeIndex(3))
         msa.index = range(3, 6)
-        assert_index_equal(msa.index, pd.Index([3, 4, 5]))
+        assert_index_equal(msa.index, pd.RangeIndex(3, 6))
 
     def test_index_setter_length_mismatch(self):
         msa = TabularMSA([DNA('ACGT'), DNA('TGCA')], minter=str)
@@ -357,11 +403,24 @@ class TestTabularMSA(unittest.TestCase, ReallyEqualMixin):
             msa.index,
             pd.Index([('foo', 42), ('bar', 43)], tupleize_cols=True))
 
+    def test_index_setter_preserves_range_index(self):
+        msa = TabularMSA([RNA('UUU'), RNA('AAA')], minter=str)
+
+        msa.index = pd.RangeIndex(2)
+
+        self.assertEqual(msa, TabularMSA([RNA('UUU'), RNA('AAA')]))
+        assert_index_equal(msa.index, pd.RangeIndex(2))
+
     def test_index_deleter(self):
         msa = TabularMSA([RNA('UUU'), RNA('AAA')], minter=str)
         assert_index_equal(msa.index, pd.Index(['UUU', 'AAA']))
+
         del msa.index
-        assert_index_equal(msa.index, pd.Index([0, 1]))
+        assert_index_equal(msa.index, pd.RangeIndex(2))
+
+        # Delete again.
+        del msa.index
+        assert_index_equal(msa.index, pd.RangeIndex(2))
 
     def test_bool(self):
         self.assertFalse(TabularMSA([]))
@@ -481,12 +540,21 @@ class TestTabularMSA(unittest.TestCase, ReallyEqualMixin):
         msa2 = TabularMSA([DNA('ACGT', metadata={'id': 'a'})], minter='id')
         self.assertReallyEqual(msa1, msa2)
 
+    def test_eq_default_index_and_equivalent_provided_index(self):
+        msa1 = TabularMSA([DNA('ACGT'), DNA('----'), DNA('....')])
+        msa2 = TabularMSA([DNA('ACGT'), DNA('----'), DNA('....')],
+                          index=[0, 1, 2])
+
+        self.assertReallyEqual(msa1, msa2)
+        assert_index_equal(msa1.index, pd.RangeIndex(3))
+        assert_index_equal(msa2.index, pd.Int64Index([0, 1, 2]))
+
     def test_reassign_index_empty(self):
         # sequence empty
         msa = TabularMSA([])
         msa.reassign_index()
         self.assertEqual(msa, TabularMSA([]))
-        assert_index_equal(msa.index, pd.Int64Index([]))
+        assert_index_equal(msa.index, pd.RangeIndex(0))
 
         msa.reassign_index(minter=str)
         self.assertEqual(msa, TabularMSA([], minter=str))
@@ -496,7 +564,7 @@ class TestTabularMSA(unittest.TestCase, ReallyEqualMixin):
         msa = TabularMSA([DNA('')])
         msa.reassign_index()
         self.assertEqual(msa, TabularMSA([DNA('')]))
-        assert_index_equal(msa.index, pd.Index([0]))
+        assert_index_equal(msa.index, pd.RangeIndex(1))
 
         msa.reassign_index(minter=str)
         self.assertEqual(msa, TabularMSA([DNA('')], minter=str))
@@ -522,7 +590,7 @@ class TestTabularMSA(unittest.TestCase, ReallyEqualMixin):
         assert_index_equal(msa.index, pd.Index([5, 2]))
 
         msa.reassign_index()
-        assert_index_equal(msa.index, pd.Index([0, 1]))
+        assert_index_equal(msa.index, pd.RangeIndex(2))
 
     def test_reassign_index_minter_and_mapping_both_provided(self):
         msa = TabularMSA([DNA('ACGT'), DNA('TGCA')], minter=str)
@@ -562,7 +630,7 @@ class TestTabularMSA(unittest.TestCase, ReallyEqualMixin):
         seqs = [DNA("A"), DNA("C"), DNA("G")]
 
         msa = TabularMSA(seqs, index=[0, 1, 2])
-        msa.reassign_index(mapping=str)
+        msa.reassign_index(mapping=lambda e: str(e))
 
         self.assertEqual(msa, TabularMSA(seqs, index=['0', '1', '2']))
 
@@ -690,6 +758,20 @@ class TestTabularMSA(unittest.TestCase, ReallyEqualMixin):
                 DNA('TTT', metadata={'id': 'b'}),
                 DNA('TTT', metadata={'id': 'c'})], minter=str))
 
+    def test_sort_default_index(self):
+        msa = TabularMSA([DNA('TC'), DNA('GG'), DNA('CC')])
+        msa.sort()
+        self.assertEqual(
+            msa,
+            TabularMSA([DNA('TC'), DNA('GG'), DNA('CC')]))
+
+    def test_sort_default_index_descending(self):
+        msa = TabularMSA([DNA('TC'), DNA('GG'), DNA('CC')])
+        msa.sort(ascending=False)
+        self.assertEqual(
+            msa,
+            TabularMSA([DNA('CC'), DNA('GG'), DNA('TC')], index=[2, 1, 0]))
+
     def test_sort_already_sorted(self):
         msa = TabularMSA([DNA('TC'), DNA('GG'), DNA('CC')], index=[1, 2, 3])
         msa.sort()
@@ -749,6 +831,13 @@ class TestTabularMSA(unittest.TestCase, ReallyEqualMixin):
                 Protein('WAP', metadata={'id': -999})]
         msa = TabularMSA(seqs, minter='id')
         self.assertEqual(msa.to_dict(), {42: seqs[0], -999: seqs[1]})
+
+    def test_to_dict_default_index(self):
+        msa = TabularMSA([RNA('UUA'), RNA('-C-'), RNA('AAA')])
+
+        d = msa.to_dict()
+
+        self.assertEqual(d, {0: RNA('UUA'), 1: RNA('-C-'), 2: RNA('AAA')})
 
     def test_to_dict_duplicate_labels(self):
         msa = TabularMSA([DNA("A"), DNA("G")], index=[0, 0])
@@ -815,7 +904,7 @@ class TestCopy(unittest.TestCase):
         self.assertIsNot(msa[0], msa_copy[0])
         self.assertIsNot(msa[1], msa_copy[1])
 
-        msa_copy.append(DNA('AAAA'))
+        msa_copy.append(DNA('AAAA'), reset_index=True)
         self.assertEqual(
             msa,
             TabularMSA([DNA('ACGT', metadata={'foo': [1]}), DNA('TGCA')]))
@@ -836,7 +925,8 @@ class TestCopy(unittest.TestCase):
 
         self.assertEqual(msa, msa_copy)
         self.assertIsNot(msa, msa_copy)
-        self.assertIsNot(msa.index, msa_copy.index)
+        # pd.Index is immutable, no copy necessary.
+        self.assertIs(msa.index, msa_copy.index)
 
         msa_copy.index = [1, 2]
         assert_index_equal(msa_copy.index, pd.Index([1, 2]))
@@ -864,7 +954,7 @@ class TestDeepCopy(unittest.TestCase):
         self.assertIsNot(msa[0], msa_copy[0])
         self.assertIsNot(msa[1], msa_copy[1])
 
-        msa_copy.append(DNA('AAAA'))
+        msa_copy.append(DNA('AAAA'), reset_index=True)
         self.assertEqual(
             msa,
             TabularMSA([DNA('ACGT', metadata={'foo': [1]}), DNA('TGCA')]))
@@ -885,7 +975,8 @@ class TestDeepCopy(unittest.TestCase):
 
         self.assertEqual(msa, msa_copy)
         self.assertIsNot(msa, msa_copy)
-        self.assertIsNot(msa.index, msa_copy.index)
+        # pd.Index is immutable, no copy necessary.
+        self.assertIs(msa.index, msa_copy.index)
 
         msa_copy.index = [1, 2]
         assert_index_equal(msa_copy.index, pd.Index([1, 2]))
@@ -1793,46 +1884,59 @@ class TestConstructor(unittest.TestCase):
 
 
 class TestAppend(unittest.TestCase):
-    def test_to_empty_msa(self):
+    # Error cases
+    def test_invalid_minter_index_reset_index_parameter_combos(self):
         msa = TabularMSA([])
 
-        msa.append(DNA('ACGT'))
+        param_combos = (
+            {},
+            {'minter': str, 'index': 'foo', 'reset_index': True},
+            {'minter': str, 'index': 'foo'},
+            {'minter': str, 'reset_index': True},
+            {'index': 'foo', 'reset_index': True}
+        )
 
-        self.assertEqual(msa, TabularMSA([DNA('ACGT')]))
+        for params in param_combos:
+            with self.assertRaisesRegex(ValueError,
+                                        "one of.*minter.*index.*reset_index"):
+                msa.append(DNA('ACGT'), **params)
 
-    def test_to_empty_with_minter(self):
-        msa = TabularMSA([], minter=str)
+            self.assertEqual(msa, TabularMSA([]))
 
-        msa.append(DNA('ACGT'))
-
-        self.assertEqual(msa, TabularMSA([DNA('ACGT')]))
-
-    def test_to_empty_msa_with_index(self):
-        msa = TabularMSA([])
-
-        msa.append(DNA('ACGT'), index='a')
-
-        self.assertEqual(
-            msa,
-            TabularMSA([DNA('ACGT')], index=['a']))
-
-    def test_to_empty_msa_invalid_dtype(self):
+    def test_invalid_dtype(self):
         msa = TabularMSA([])
 
         with self.assertRaisesRegex(TypeError, 'GrammaredSequence.*Sequence'):
-            msa.append(Sequence(''))
+            msa.append(Sequence(''), reset_index=True)
 
         self.assertEqual(msa, TabularMSA([]))
 
-    def test_to_empty_msa_invalid_minter(self):
-        msa = TabularMSA([])
+    def test_dtype_mismatch_rna(self):
+        msa = TabularMSA([DNA('ACGT'), DNA('TGCA')])
 
-        with self.assertRaises(KeyError):
-            msa.append(DNA('ACGT'), minter='id')
+        with self.assertRaisesRegex(TypeError, 'matching type.*RNA.*DNA'):
+            msa.append(RNA('UUUU'), reset_index=True)
 
-        self.assertEqual(msa, TabularMSA([]))
+        self.assertEqual(msa, TabularMSA([DNA('ACGT'), DNA('TGCA')]))
 
-    def test_to_non_empty_msa_invalid_minter(self):
+    def test_dtype_mismatch_float(self):
+        msa = TabularMSA([DNA('ACGT'), DNA('TGCA')])
+
+        with self.assertRaisesRegex(TypeError, 'matching type.*float.*DNA'):
+            msa.append(42.0, reset_index=True)
+
+        self.assertEqual(msa, TabularMSA([DNA('ACGT'), DNA('TGCA')]))
+
+    def test_length_mismatch(self):
+        msa = TabularMSA([DNA('ACGT'), DNA('TGCA')])
+
+        with self.assertRaisesRegex(
+                ValueError, 'must match the number of positions.*5 != 4'):
+            msa.append(DNA('ACGTA'), reset_index=True)
+
+        self.assertEqual(msa, TabularMSA([DNA('ACGT'), DNA('TGCA')]))
+
+    def test_invalid_minter(self):
         msa = TabularMSA([DNA('ACGT')], index=['foo'])
 
         with self.assertRaises(KeyError):
@@ -1840,32 +1944,15 @@ class TestAppend(unittest.TestCase):
 
         self.assertEqual(msa, TabularMSA([DNA('ACGT')], index=['foo']))
 
-    def test_wrong_dtype_rna(self):
-        msa = TabularMSA([DNA('ACGT'), DNA('TGCA')])
+    # Valid cases: `minter`
+    def test_minter_empty_msa(self):
+        msa = TabularMSA([])
 
-        with self.assertRaisesRegex(TypeError, 'matching type.*RNA.*DNA'):
-            msa.append(RNA('UUUU'))
+        msa.append(DNA('ACGT'), minter=str)
 
-        self.assertEqual(msa, TabularMSA([DNA('ACGT'), DNA('TGCA')]))
+        self.assertEqual(msa, TabularMSA([DNA('ACGT')], minter=str))
 
-    def test_wrong_dtype_float(self):
-        msa = TabularMSA([DNA('ACGT'), DNA('TGCA')])
-
-        with self.assertRaisesRegex(TypeError, 'matching type.*float.*DNA'):
-            msa.append(42.0)
-
-        self.assertEqual(msa, TabularMSA([DNA('ACGT'), DNA('TGCA')]))
-
-    def test_wrong_length(self):
-        msa = TabularMSA([DNA('ACGT'), DNA('TGCA')])
-
-        with self.assertRaisesRegex(
-                ValueError, 'must match the number of positions.*5 != 4'):
-            msa.append(DNA('ACGTA'))
-
-        self.assertEqual(msa, TabularMSA([DNA('ACGT'), DNA('TGCA')]))
-
-    def test_with_minter_metadata_key(self):
+    def test_minter_metadata_key(self):
         msa = TabularMSA([DNA('', metadata={'id': 'a'}),
                           DNA('', metadata={'id': 'b'})],
                          minter='id')
@@ -1879,7 +1966,7 @@ class TestAppend(unittest.TestCase):
                 DNA('', metadata={'id': 'b'}),
                 DNA('', metadata={'id': 'c'})], minter='id'))
 
-    def test_with_minter_callable(self):
+    def test_minter_callable(self):
         msa = TabularMSA([DNA('', metadata={'id': 'a'}),
                           DNA('', metadata={'id': 'b'})],
                          minter='id')
@@ -1893,77 +1980,7 @@ class TestAppend(unittest.TestCase):
                 DNA('', metadata={'id': 'b'}),
                 DNA('')], index=['a', 'b', '']))
 
-    def test_with_index(self):
-        msa = TabularMSA([DNA('AC'), DNA('GT')], index=['a', 'b'])
-
-        msa.append(DNA('--'), index='foo')
-
-        self.assertEqual(
-            msa,
-            TabularMSA([DNA('AC'), DNA('GT'), DNA('--')],
-                       index=['a', 'b', 'foo']))
-
-    def test_no_index_no_minter(self):
-        msa = TabularMSA([DNA('ACGT'), DNA('TGCA')])
-
-        msa.append(DNA('AAAA'))
-
-        self.assertEqual(
-            msa,
-            TabularMSA([DNA('ACGT'), DNA('TGCA'), DNA('AAAA')]))
-
-    def test_no_index_no_minter_msa_has_non_default_labels(self):
-        msa = TabularMSA([DNA(''), DNA('')], index=['a', 'b'])
-
-        with self.assertRaisesRegex(ValueError, "provide.*minter.*index"):
-            msa.append(DNA(''))
-
-        self.assertEqual(msa, TabularMSA([DNA(''), DNA('')], index=['a', 'b']))
-
-    def test_with_index_type_change(self):
-        msa = TabularMSA([DNA('A'), DNA('.')])
-
-        msa.append(DNA('C'), index='foo')
-
-        self.assertEqual(
-            msa,
-            TabularMSA([DNA('A'), DNA('.'), DNA('C')], index=[0, 1, 'foo']))
-
-    def test_with_index_and_minter(self):
-        msa = TabularMSA([])
-
-        with self.assertRaisesRegex(ValueError, "both.*minter.*index"):
-            msa.append(DNA(''), index='', minter=str)
-
-        self.assertEqual(msa, TabularMSA([]))
-
-    def test_multiple_appends_to_empty_msa_with_default_labels(self):
-        msa = TabularMSA([])
-
-        msa.append(RNA('U--'))
-        msa.append(RNA('AA.'))
-
-        self.assertEqual(msa, TabularMSA([RNA('U--'), RNA('AA.')]))
-
-    def test_multiple_appends_to_non_empty_msa_with_default_labels(self):
-        msa = TabularMSA([RNA('U--'), RNA('AA.')])
-
-        msa.append(RNA('ACG'))
-        msa.append(RNA('U-U'))
-
-        self.assertEqual(
-            msa,
-            TabularMSA([RNA('U--'), RNA('AA.'), RNA('ACG'), RNA('U-U')]))
-
-    def test_with_multiindex_index(self):
-        msa = TabularMSA([])
-
-        msa.append(DNA('AA'), index=('foo', 42))
-
-        self.assertIsInstance(msa.index, pd.MultiIndex)
-        assert_index_equal(msa.index, pd.Index([('foo', 42)]))
-
-    def test_with_multiindex_minter(self):
+    def test_multiindex_minter_empty_msa(self):
         def multiindex_minter(seq):
             return ('foo', 42)
 
@@ -1974,117 +1991,193 @@ class TestAppend(unittest.TestCase):
         self.assertIsInstance(msa.index, pd.MultiIndex)
         assert_index_equal(msa.index, pd.Index([('foo', 42)]))
 
+    def test_multiindex_minter_non_empty_msa(self):
+        def multiindex_minter(seq):
+            return ('baz', 44)
 
-class TestExtend(unittest.TestCase):
-    def test_empty_to_empty(self):
+        msa = TabularMSA([RNA('UU'), RNA('CA')],
+                         index=[('foo', 42), ('bar', 43)])
+
+        msa.append(RNA('AC'), minter=multiindex_minter)
+
+        self.assertIsInstance(msa.index, pd.MultiIndex)
+        assert_index_equal(msa.index,
+                           pd.Index([('foo', 42), ('bar', 43), ('baz', 44)]))
+
+    # Valid cases: `index`
+    def test_index_empty_msa(self):
         msa = TabularMSA([])
 
-        msa.extend([])
-
-        self.assertEqual(msa, TabularMSA([]))
-
-    def test_empty_to_non_empty(self):
-        msa = TabularMSA([DNA('AC')])
-
-        msa.extend([])
-
-        self.assertEqual(msa, TabularMSA([DNA('AC')]))
-
-    def test_single_sequence(self):
-        msa = TabularMSA([DNA('AC')])
-
-        msa.extend([DNA('-C')])
-
-        self.assertEqual(msa, TabularMSA([DNA('AC'), DNA('-C')]))
-
-    def test_multiple_sequences(self):
-        msa = TabularMSA([DNA('AC')])
-
-        msa.extend([DNA('-C'), DNA('AG')])
-
-        self.assertEqual(msa, TabularMSA([DNA('AC'), DNA('-C'), DNA('AG')]))
-
-    def test_from_iterable(self):
-        msa = TabularMSA([])
-
-        msa.extend(iter([DNA('ACGT'), DNA('TGCA')]))
-
-        self.assertEqual(msa, TabularMSA([DNA('ACGT'), DNA('TGCA')]))
-
-    def test_from_tabular_msa_default_labels(self):
-        msa = TabularMSA([DNA('AC'), DNA('TG')])
-
-        msa.extend(TabularMSA([DNA('GG'), DNA('CC'), DNA('AA')],
-                              index=['a', 'b', 'c']))
+        msa.append(DNA('ACGT'), index='a')
 
         self.assertEqual(
             msa,
-            TabularMSA([DNA('AC'), DNA('TG'), DNA('GG'), DNA('CC'),
-                        DNA('AA')]))
+            TabularMSA([DNA('ACGT')], index=['a']))
 
-    def test_from_tabular_msa_non_default_labels(self):
-        msa = TabularMSA([DNA('AC'), DNA('TG')], index=['a', 'b'])
+    def test_index_non_empty_msa(self):
+        msa = TabularMSA([DNA('AC'), DNA('GT')], index=['a', 'b'])
 
-        with self.assertRaisesRegex(ValueError, 'provide.*minter.*index'):
-            msa.extend(TabularMSA([DNA('GG'), DNA('CC')]))
+        msa.append(DNA('--'), index='foo')
 
         self.assertEqual(
             msa,
-            TabularMSA([DNA('AC'), DNA('TG')], index=['a', 'b']))
+            TabularMSA([DNA('AC'), DNA('GT'), DNA('--')],
+                       index=['a', 'b', 'foo']))
 
-    def test_from_tabular_msa_with_index(self):
-        msa1 = TabularMSA([DNA('AC'), DNA('TG')])
-        msa2 = TabularMSA([DNA('GG'), DNA('CC'), DNA('AA')])
-
-        msa1.extend(msa2, index=msa2.index)
-
-        self.assertEqual(
-            msa1,
-            TabularMSA([DNA('AC'), DNA('TG'), DNA('GG'), DNA('CC'),
-                        DNA('AA')], index=[0, 1, 0, 1, 2]))
-
-    def test_minter_and_index(self):
-        with self.assertRaisesRegex(ValueError, 'both.*minter.*index'):
-            TabularMSA([]).extend([DNA('ACGT')], minter=str, index=['foo'])
-
-    def test_no_minter_no_index_to_empty(self):
+    def test_multiindex_index_empty_msa(self):
         msa = TabularMSA([])
 
-        msa.extend([DNA('ACGT'), DNA('TGCA')])
+        msa.append(DNA('AA'), index=('foo', 42))
 
-        self.assertEqual(msa, TabularMSA([DNA('ACGT'), DNA('TGCA')]))
+        self.assertIsInstance(msa.index, pd.MultiIndex)
+        assert_index_equal(msa.index, pd.Index([('foo', 42)]))
 
-    def test_no_minter_no_index_to_non_empty(self):
-        msa = TabularMSA([DNA('ACGT')])
+    def test_multiindex_index_non_empty_msa(self):
+        msa = TabularMSA([RNA('A'), RNA('C')],
+                         index=[('foo', 42), ('bar', 43)])
 
-        msa.extend([DNA('TGCA'), DNA('--..')])
+        msa.append(RNA('U'), index=('baz', 44))
+
+        self.assertIsInstance(msa.index, pd.MultiIndex)
+        assert_index_equal(msa.index,
+                           pd.Index([('foo', 42), ('bar', 43), ('baz', 44)]))
+
+    # Valid cases: `reset_index`
+    def test_reset_index_empty_msa(self):
+        msa = TabularMSA([])
+
+        msa.append(DNA('ACGT'), reset_index=True)
+
+        self.assertEqual(msa, TabularMSA([DNA('ACGT')]))
+        assert_index_equal(msa.index, pd.RangeIndex(1))
+
+    def test_reset_index_default_index(self):
+        msa = TabularMSA([DNA('ACGT'), DNA('CCCC')])
+
+        msa.append(DNA('ACGT'), reset_index=True)
 
         self.assertEqual(msa,
-                         TabularMSA([DNA('ACGT'), DNA('TGCA'), DNA('--..')]))
+                         TabularMSA([DNA('ACGT'), DNA('CCCC'), DNA('ACGT')]))
+        assert_index_equal(msa.index, pd.RangeIndex(3))
 
-    def test_no_minter_no_index_msa_has_non_default_labels(self):
-        msa = TabularMSA([DNA('ACGT')], index=[1])
+    def test_reset_index_non_default_index(self):
+        msa = TabularMSA([DNA('ACGT'), DNA('CCCC')], index=['foo', 'bar'])
 
-        with self.assertRaisesRegex(ValueError, 'provide.*minter.*index'):
-            msa.extend([DNA('TGCA')])
+        msa.append(DNA('ACGT'), reset_index=True)
 
-        self.assertEqual(msa, TabularMSA([DNA('ACGT')], index=[1]))
+        self.assertEqual(msa,
+                         TabularMSA([DNA('ACGT'), DNA('CCCC'), DNA('ACGT')]))
+        assert_index_equal(msa.index, pd.RangeIndex(3))
+
+    # Valid cases (misc)
+    def test_index_type_change(self):
+        msa = TabularMSA([DNA('A'), DNA('.')])
+
+        msa.append(DNA('C'), index='foo')
+
+        self.assertEqual(
+            msa,
+            TabularMSA([DNA('A'), DNA('.'), DNA('C')], index=[0, 1, 'foo']))
+
+    def test_duplicate_index(self):
+        msa = TabularMSA([DNA('A'), DNA('.')], index=['foo', 'bar'])
+
+        msa.append(DNA('C'), index='foo')
+
+        self.assertEqual(
+            msa,
+            TabularMSA([DNA('A'), DNA('.'), DNA('C')],
+                       index=['foo', 'bar', 'foo']))
+
+    def test_empty_msa_with_positional_metadata_no_new_positions(self):
+        msa = TabularMSA([], positional_metadata={'foo': []})
+
+        msa.append(DNA(''), reset_index=True)
+
+        self.assertEqual(
+            msa,
+            TabularMSA([DNA('')], positional_metadata={'foo': []}))
+
+    def test_empty_msa_with_positional_metadata_add_new_positions(self):
+        # bug in 0.4.2
+        msa = TabularMSA([], positional_metadata={'foo': []})
+
+        msa.append(DNA('AA'), reset_index=True)
+
+        self.assertEqual(
+            msa,
+            TabularMSA([DNA('AA')]))
+
+
+class TestExtend(unittest.TestCase):
+    # Error cases
+    #
+    # Note: these tests check that the MSA isn't mutated when an error is
+    # raised. Where applicable, the "invalid" sequence is preceded by valid
+    # sequence(s) to test one possible (buggy) implementation of `extend`:
+    # looping over `sequences` and calling `append`. These tests ensure that
+    # valid sequences aren't appended to the MSA before the error is raised.
+    def test_invalid_minter_index_reset_index_parameter_combos(self):
+        msa = TabularMSA([])
+
+        param_combos = (
+            {},
+            {'minter': str, 'index': 'foo', 'reset_index': True},
+            {'minter': str, 'index': 'foo'},
+            {'minter': str, 'reset_index': True},
+            {'index': 'foo', 'reset_index': True}
+        )
+
+        for params in param_combos:
+            with self.assertRaisesRegex(ValueError,
+                                        "one of.*minter.*index.*reset_index"):
+                msa.extend([DNA('ACGT')], **params)
+
+            self.assertEqual(msa, TabularMSA([]))
+
+    def test_from_tabular_msa_index_param_still_required(self):
+        msa = TabularMSA([DNA('AC'), DNA('TG')])
+
+        with self.assertRaisesRegex(ValueError,
+                                    "one of.*minter.*index.*reset_index"):
+            msa.extend(TabularMSA([DNA('GG'), DNA('CC')]))
+
+        self.assertEqual(msa, TabularMSA([DNA('AC'), DNA('TG')]))
 
     def test_invalid_dtype(self):
         msa = TabularMSA([])
 
         with self.assertRaisesRegex(TypeError, 'GrammaredSequence.*Sequence'):
-            msa.extend([Sequence('')])
+            msa.extend([Sequence('')], reset_index=True)
 
         self.assertEqual(msa, TabularMSA([]))
 
+    def test_dtype_mismatch_rna(self):
+        msa = TabularMSA([DNA('ACGT'), DNA('TGCA')])
+
+        with self.assertRaisesRegex(TypeError, 'matching type.*RNA.*DNA'):
+            msa.extend([DNA('----'), RNA('UUUU')], reset_index=True)
+
+        self.assertEqual(msa, TabularMSA([DNA('ACGT'), DNA('TGCA')]))
+
+    def test_dtype_mismatch_float(self):
+        msa = TabularMSA([DNA('ACGT'), DNA('TGCA')])
+
+        with self.assertRaisesRegex(TypeError, 'matching type.*float.*DNA'):
+            msa.extend([DNA('GGGG'), 42.0], reset_index=True)
+
+        self.assertEqual(msa, TabularMSA([DNA('ACGT'), DNA('TGCA')]))
+
+    def test_length_mismatch(self):
+        msa = TabularMSA([DNA('ACGT'), DNA('TGCA')])
+
+        with self.assertRaisesRegex(
+                ValueError, 'must match the number of positions.*5 != 4'):
+            msa.extend([DNA('TTTT'), DNA('ACGTA')], reset_index=True)
+
+        self.assertEqual(msa, TabularMSA([DNA('ACGT'), DNA('TGCA')]))
+
     def test_invalid_minter(self):
-        # This test (and the following error case tests) check that the MSA
-        # isn't mutated when an error is raised. The "invalid" sequence is
-        # preceded by valid sequence(s) to test one possible (buggy)
-        # implementation of extend(): looping over sequences and calling
-        # append(). These tests ensure that "valid" sequences aren't appended
-        # to the MSA before the error is raised.
         msa = TabularMSA([DNA('ACGT')], index=['foo'])
 
         with self.assertRaises(KeyError):
@@ -2093,30 +2186,13 @@ class TestExtend(unittest.TestCase):
 
         self.assertEqual(msa, TabularMSA([DNA('ACGT')], index=['foo']))
 
-    def test_mismatched_dtype(self):
-        msa = TabularMSA([DNA('ACGT'), DNA('TGCA')])
+    def test_invalid_index(self):
+        msa = TabularMSA([DNA('ACGT')], index=['foo'])
 
-        with self.assertRaisesRegex(TypeError, 'matching type.*RNA.*DNA'):
-            msa.extend([DNA('----'), RNA('UUUU')])
+        with self.assertRaises(TypeError):
+            msa.extend([DNA('----')], index=42)
 
-        self.assertEqual(msa, TabularMSA([DNA('ACGT'), DNA('TGCA')]))
-
-    def test_wrong_dtype_float(self):
-        msa = TabularMSA([DNA('ACGT'), DNA('TGCA')])
-
-        with self.assertRaisesRegex(TypeError, 'matching type.*float.*DNA'):
-            msa.extend([DNA('GGGG'), 42.0])
-
-        self.assertEqual(msa, TabularMSA([DNA('ACGT'), DNA('TGCA')]))
-
-    def test_wrong_length(self):
-        msa = TabularMSA([DNA('ACGT'), DNA('TGCA')])
-
-        with self.assertRaisesRegex(
-                ValueError, 'must match the number of positions.*5 != 4'):
-            msa.extend([DNA('TTTT'), DNA('ACGTA')])
-
-        self.assertEqual(msa, TabularMSA([DNA('ACGT'), DNA('TGCA')]))
+        self.assertEqual(msa, TabularMSA([DNA('ACGT')], index=['foo']))
 
     def test_sequences_index_length_mismatch(self):
         msa = TabularMSA([])
@@ -2127,7 +2203,15 @@ class TestExtend(unittest.TestCase):
 
         self.assertEqual(msa, TabularMSA([]))
 
-    def test_with_minter_metadata_key(self):
+    # Valid cases: `minter`
+    def test_minter_empty_msa(self):
+        msa = TabularMSA([])
+
+        msa.extend([RNA('UU'), RNA('--')], minter=str)
+
+        self.assertEqual(msa, TabularMSA([RNA('UU'), RNA('--')], minter=str))
+
+    def test_minter_metadata_key(self):
         msa = TabularMSA([DNA('', metadata={'id': 'a'}),
                           DNA('', metadata={'id': 'b'})],
                          minter='id')
@@ -2143,7 +2227,7 @@ class TestExtend(unittest.TestCase):
                 DNA('', metadata={'id': 'c'}),
                 DNA('', metadata={'id': 'd'})], minter='id'))
 
-    def test_with_minter_callable(self):
+    def test_minter_callable(self):
         msa = TabularMSA([DNA('A', metadata={'id': 'a'}),
                           DNA('C', metadata={'id': 'b'})],
                          minter='id')
@@ -2158,56 +2242,7 @@ class TestExtend(unittest.TestCase):
                 DNA('G'),
                 DNA('T')], index=['a', 'b', 'G', 'T']))
 
-    def test_with_index(self):
-        msa = TabularMSA([DNA('AC'), DNA('GT')], index=['a', 'b'])
-
-        msa.extend([DNA('--'), DNA('..')], index=['foo', 'bar'])
-
-        self.assertEqual(
-            msa,
-            TabularMSA([DNA('AC'), DNA('GT'), DNA('--'), DNA('..')],
-                       index=['a', 'b', 'foo', 'bar']))
-
-    def test_with_index_type_change(self):
-        msa = TabularMSA([DNA('A'), DNA('.')])
-
-        msa.extend([DNA('C')], index=['foo'])
-
-        self.assertEqual(
-            msa,
-            TabularMSA([DNA('A'), DNA('.'), DNA('C')], index=[0, 1, 'foo']))
-
-    def test_multiple_extends_to_empty_msa_with_default_labels(self):
-        msa = TabularMSA([])
-
-        msa.extend([RNA('U-'), RNA('GG')])
-        msa.extend([RNA('AA')])
-
-        self.assertEqual(msa, TabularMSA([RNA('U-'), RNA('GG'), RNA('AA')]))
-
-    def test_multiple_extends_to_non_empty_msa_with_default_labels(self):
-        msa = TabularMSA([RNA('U--'), RNA('AA.')])
-
-        msa.extend([RNA('ACG'), RNA('GCA')])
-        msa.extend([RNA('U-U')])
-
-        self.assertEqual(
-            msa,
-            TabularMSA([RNA('U--'),
-                        RNA('AA.'),
-                        RNA('ACG'),
-                        RNA('GCA'),
-                        RNA('U-U')]))
-
-    def test_with_multiindex_index(self):
-        msa = TabularMSA([])
-
-        msa.extend([DNA('AA'), DNA('GG')], index=[('foo', 42), ('bar', 43)])
-
-        self.assertIsInstance(msa.index, pd.MultiIndex)
-        assert_index_equal(msa.index, pd.Index([('foo', 42), ('bar', 43)]))
-
-    def test_with_multiindex_minter(self):
+    def test_multiindex_minter_empty_msa(self):
         def multiindex_minter(seq):
             if str(seq) == 'AC':
                 return ('foo', 42)
@@ -2221,27 +2256,222 @@ class TestExtend(unittest.TestCase):
         self.assertIsInstance(msa.index, pd.MultiIndex)
         assert_index_equal(msa.index, pd.Index([('foo', 42), ('bar', 43)]))
 
-    def test_with_index_object(self):
+    def test_multiindex_minter_non_empty_msa(self):
+        def multiindex_minter(seq):
+            if str(seq) == 'C':
+                return ('baz', 44)
+            else:
+                return ('baz', 45)
+
+        msa = TabularMSA([DNA('A'), DNA('G')],
+                         index=[('foo', 42), ('bar', 43)])
+
+        msa.extend([DNA('C'), DNA('T')], minter=multiindex_minter)
+
+        self.assertIsInstance(msa.index, pd.MultiIndex)
+        assert_index_equal(
+            msa.index,
+            pd.Index([('foo', 42), ('bar', 43), ('baz', 44), ('baz', 45)]))
+
+    # Valid cases: `index`
+    def test_index_empty_msa(self):
         msa = TabularMSA([])
 
-        msa.extend([DNA('AA'), DNA('GG')],
-                   index=pd.Index(['foo', 'bar']))
+        msa.extend([RNA('UAC'), RNA('AAU')], index=['foo', 'bar'])
+
+        self.assertEqual(msa, TabularMSA([RNA('UAC'), RNA('AAU')],
+                                         index=['foo', 'bar']))
+
+    def test_index_non_empty_msa(self):
+        msa = TabularMSA([DNA('AC'), DNA('GT')], index=['a', 'b'])
+
+        msa.extend([DNA('--'), DNA('..')], index=['foo', 'bar'])
 
         self.assertEqual(
             msa,
-            TabularMSA([DNA('AA'),
-                        DNA('GG')], index=['foo', 'bar']))
+            TabularMSA([DNA('AC'), DNA('GT'), DNA('--'), DNA('..')],
+                       index=['a', 'b', 'foo', 'bar']))
 
-    def test_extending_on_empty_with_positional_metadata(self):
+    def test_multiindex_index_empty_msa(self):
+        msa = TabularMSA([])
+
+        msa.extend([DNA('AA'), DNA('GG')], index=[('foo', 42), ('bar', 43)])
+
+        self.assertIsInstance(msa.index, pd.MultiIndex)
+        assert_index_equal(msa.index, pd.Index([('foo', 42), ('bar', 43)]))
+
+    def test_multiindex_index_non_empty_msa(self):
+        msa = TabularMSA([DNA('.'), DNA('-')],
+                         index=[('foo', 42), ('bar', 43)])
+
+        msa.extend([DNA('A'), DNA('G')], index=[('baz', 44), ('baz', 45)])
+
+        self.assertIsInstance(msa.index, pd.MultiIndex)
+        assert_index_equal(
+            msa.index,
+            pd.Index([('foo', 42), ('bar', 43), ('baz', 44), ('baz', 45)]))
+
+    def test_index_object_empty_msa(self):
+        msa = TabularMSA([])
+
+        msa.extend([DNA('AA'), DNA('GG')], index=pd.RangeIndex(2))
+
+        self.assertEqual(msa, TabularMSA([DNA('AA'), DNA('GG')]))
+        assert_index_equal(msa.index, pd.RangeIndex(2))
+
+    def test_index_object_non_empty_msa(self):
+        msa = TabularMSA([DNA('CT'), DNA('GG')])
+
+        msa.extend([DNA('AA'), DNA('GG')], index=pd.RangeIndex(2))
+
+        self.assertEqual(
+            msa,
+            TabularMSA([DNA('CT'), DNA('GG'), DNA('AA'), DNA('GG')],
+                       index=[0, 1, 0, 1]))
+
+    # Valid cases: `reset_index`
+    def test_reset_index_empty_msa(self):
+        msa = TabularMSA([])
+
+        msa.extend([DNA('ACGT'), DNA('----')], reset_index=True)
+
+        self.assertEqual(msa, TabularMSA([DNA('ACGT'), DNA('----')]))
+        assert_index_equal(msa.index, pd.RangeIndex(2))
+
+    def test_reset_index_empty_msa_empty_iterable(self):
+        msa = TabularMSA([])
+
+        msa.extend([], reset_index=True)
+
+        self.assertEqual(msa, TabularMSA([]))
+        assert_index_equal(msa.index, pd.RangeIndex(0))
+
+    def test_reset_index_non_empty_msa_empty_iterable(self):
+        msa = TabularMSA([RNA('UU'), RNA('CC')], index=['a', 'b'])
+
+        msa.extend([], reset_index=True)
+
+        self.assertEqual(msa, TabularMSA([RNA('UU'), RNA('CC')]))
+        assert_index_equal(msa.index, pd.RangeIndex(2))
+
+    def test_reset_index_default_index(self):
+        msa = TabularMSA([DNA('A'), DNA('G')])
+
+        msa.extend([DNA('.'), DNA('-')], reset_index=True)
+
+        self.assertEqual(msa,
+                         TabularMSA([DNA('A'), DNA('G'), DNA('.'), DNA('-')]))
+        assert_index_equal(msa.index, pd.RangeIndex(4))
+
+    def test_reset_index_non_default_index(self):
+        msa = TabularMSA([DNA('A'), DNA('G')], index=['a', 'b'])
+
+        msa.extend([DNA('.'), DNA('-')], reset_index=True)
+
+        self.assertEqual(msa,
+                         TabularMSA([DNA('A'), DNA('G'), DNA('.'), DNA('-')]))
+        assert_index_equal(msa.index, pd.RangeIndex(4))
+
+    def test_reset_index_from_tabular_msa(self):
+        msa = TabularMSA([DNA('AC'), DNA('TG')], index=[42, 43])
+
+        msa.extend(TabularMSA([DNA('GG'), DNA('CC'), DNA('AA')],
+                              index=['a', 'b', 'c']), reset_index=True)
+
+        self.assertEqual(
+            msa,
+            TabularMSA([DNA('AC'), DNA('TG'), DNA('GG'), DNA('CC'),
+                        DNA('AA')]))
+        assert_index_equal(msa.index, pd.RangeIndex(5))
+
+    # Valid cases (misc)
+    def test_index_type_change(self):
+        msa = TabularMSA([DNA('A'), DNA('.')])
+
+        msa.extend([DNA('C')], index=['foo'])
+
+        self.assertEqual(
+            msa,
+            TabularMSA([DNA('A'), DNA('.'), DNA('C')], index=[0, 1, 'foo']))
+
+    def test_duplicate_index(self):
+        msa = TabularMSA([DNA('A'), DNA('.')], index=['foo', 'bar'])
+
+        msa.extend([DNA('C'), DNA('.')], index=['foo', 'baz'])
+
+        self.assertEqual(
+            msa,
+            TabularMSA([DNA('A'), DNA('.'), DNA('C'), DNA('.')],
+                       index=['foo', 'bar', 'foo', 'baz']))
+
+    def test_empty_msa_with_positional_metadata_no_new_positions(self):
+        msa = TabularMSA([], positional_metadata={'foo': []})
+
+        msa.extend([DNA(''), DNA('')], reset_index=True)
+
+        self.assertEqual(
+            msa,
+            TabularMSA([DNA(''), DNA('')], positional_metadata={'foo': []}))
+
+    def test_empty_msa_with_positional_metadata_add_new_positions(self):
         # bug in 0.4.2
         msa = TabularMSA([], positional_metadata={'foo': []})
 
-        msa.extend([DNA('AA'), DNA('GG')])
+        msa.extend([DNA('AA'), DNA('GG')], reset_index=True)
 
         self.assertEqual(
             msa,
             TabularMSA([DNA('AA'),
                         DNA('GG')]))
+
+    def test_empty_msa_empty_iterable(self):
+        msa = TabularMSA([])
+
+        msa.extend([], minter=str)
+
+        self.assertEqual(msa, TabularMSA([]))
+
+    def test_non_empty_msa_empty_iterable(self):
+        msa = TabularMSA([DNA('AC')], index=['foo'])
+
+        msa.extend([], index=[])
+
+        self.assertEqual(msa, TabularMSA([DNA('AC')], index=['foo']))
+
+    def test_single_sequence(self):
+        msa = TabularMSA([DNA('AC')])
+
+        msa.extend([DNA('-C')], minter=str)
+
+        self.assertEqual(msa,
+                         TabularMSA([DNA('AC'), DNA('-C')], index=[0, '-C']))
+
+    def test_multiple_sequences(self):
+        msa = TabularMSA([DNA('AC')])
+
+        msa.extend([DNA('-C'), DNA('AG')], minter=str)
+
+        self.assertEqual(msa,
+                         TabularMSA([DNA('AC'), DNA('-C'), DNA('AG')],
+                                    index=[0, '-C', 'AG']))
+
+    def test_from_iterable(self):
+        msa = TabularMSA([])
+
+        msa.extend(iter([DNA('ACGT'), DNA('TGCA')]), reset_index=True)
+
+        self.assertEqual(msa, TabularMSA([DNA('ACGT'), DNA('TGCA')]))
+
+    def test_from_tabular_msa_with_index(self):
+        msa1 = TabularMSA([DNA('AC'), DNA('TG')])
+        msa2 = TabularMSA([DNA('GG'), DNA('CC'), DNA('AA')])
+
+        msa1.extend(msa2, index=msa2.index)
+
+        self.assertEqual(
+            msa1,
+            TabularMSA([DNA('AC'), DNA('TG'), DNA('GG'), DNA('CC'),
+                        DNA('AA')], index=[0, 1, 0, 1, 2]))
 
 
 class TestJoin(unittest.TestCase):

--- a/skbio/alignment/tests/test_tabular_msa.py
+++ b/skbio/alignment/tests/test_tabular_msa.py
@@ -2069,6 +2069,14 @@ class TestAppend(unittest.TestCase):
                          TabularMSA([DNA('ACGT'), DNA('CCCC'), DNA('ACGT')]))
         assert_index_equal(msa.index, pd.RangeIndex(3))
 
+    def test_reset_index_bool_cast(self):
+        msa = TabularMSA([RNA('AC'), RNA('UU')], index=[42, 43])
+
+        msa.append(RNA('..'), reset_index='abc')
+
+        self.assertEqual(msa, TabularMSA([RNA('AC'), RNA('UU'), RNA('..')]))
+        assert_index_equal(msa.index, pd.RangeIndex(3))
+
     # Valid cases (misc)
     def test_index_type_change(self):
         msa = TabularMSA([DNA('A'), DNA('.')])
@@ -2383,6 +2391,14 @@ class TestExtend(unittest.TestCase):
             TabularMSA([DNA('AC'), DNA('TG'), DNA('GG'), DNA('CC'),
                         DNA('AA')]))
         assert_index_equal(msa.index, pd.RangeIndex(5))
+
+    def test_reset_index_bool_cast(self):
+        msa = TabularMSA([RNA('AC'), RNA('UU')], index=[42, 43])
+
+        msa.extend([RNA('..')], reset_index='abc')
+
+        self.assertEqual(msa, TabularMSA([RNA('AC'), RNA('UU'), RNA('..')]))
+        assert_index_equal(msa.index, pd.RangeIndex(3))
 
     # Valid cases (misc)
     def test_index_type_change(self):

--- a/skbio/alignment/tests/test_tabular_msa.py
+++ b/skbio/alignment/tests/test_tabular_msa.py
@@ -601,6 +601,16 @@ class TestTabularMSA(unittest.TestCase, ReallyEqualMixin):
         # original state is maintained
         assert_index_equal(msa.index, pd.Index(['ACGT', 'TGCA']))
 
+    def test_reassign_index_mapping_invalid_type(self):
+        msa = TabularMSA([DNA('ACGT'), DNA('TGCA')], minter=str)
+
+        with self.assertRaisesRegex(TypeError,
+                                    'mapping.*dict.*callable.*list'):
+            msa.reassign_index(mapping=['abc', 'def'])
+
+        # original state is maintained
+        assert_index_equal(msa.index, pd.Index(['ACGT', 'TGCA']))
+
     def test_reassign_index_with_mapping_dict_empty(self):
         seqs = [DNA("A"), DNA("C"), DNA("G")]
         msa = TabularMSA(seqs, index=[0.5, 1.5, 2.5])
@@ -630,9 +640,13 @@ class TestTabularMSA(unittest.TestCase, ReallyEqualMixin):
         seqs = [DNA("A"), DNA("C"), DNA("G")]
 
         msa = TabularMSA(seqs, index=[0, 1, 2])
-        msa.reassign_index(mapping=lambda e: str(e))
+        msa.reassign_index(mapping=str)
 
         self.assertEqual(msa, TabularMSA(seqs, index=['0', '1', '2']))
+
+        msa.reassign_index(mapping=lambda e: int(e) + 42)
+
+        self.assertEqual(msa, TabularMSA(seqs, index=[42, 43, 44]))
 
     def test_reassign_index_non_unique_existing_index(self):
         seqs = [DNA("A"), DNA("C"), DNA("G")]

--- a/skbio/io/format/blast6.py
+++ b/skbio/io/format/blast6.py
@@ -193,12 +193,12 @@ be used:
 ...                    default_columns=True)
 >>> df # doctest: +NORMALIZE_WHITESPACE
   qseqid                           sseqid  pident  length  mismatch  gapopen \\
-0   moaC     gi|15800534|ref|NP_286546.1|  100.00     161         0        0
-1   moaC  gi|170768970|ref|ZP_02903423.1|   99.38     161         1        0
+0   moaC     gi|15800534|ref|NP_286546.1|  100.00   161.0       0.0      0.0
+1   moaC  gi|170768970|ref|ZP_02903423.1|   99.38   161.0       1.0      0.0
 <BLANKLINE>
-   qstart  qend  sstart  send         evalue  bitscore
-0       1   161       1   161  3.000000e-114       330
-1       1   161       1   161  9.000000e-114       329
+   qstart   qend  sstart   send         evalue  bitscore
+0     1.0  161.0     1.0  161.0  3.000000e-114     330.0
+1     1.0  161.0     1.0  161.0  9.000000e-114     329.0
 
 Suppose we have a ``blast+6`` file with user-supplied (non-default) columns:
 
@@ -218,9 +218,9 @@ in the file:
 ...                    columns=['qseqid', 'pident', 'mismatch', 'length',
 ...                             'gapopen', 'qend', 'bitscore', 'sstart'])
 >>> df # doctest: +NORMALIZE_WHITESPACE
-  qseqid  pident  mismatch  length  gapopen  qend  bitscore  sstart
-0   moaC  100.00         0     161        0   161       330       1
-1   moaC   99.38         1     161        0   161       329       1
+  qseqid  pident  mismatch  length  gapopen   qend  bitscore  sstart
+0   moaC  100.00       0.0   161.0      0.0  161.0     330.0     1.0
+1   moaC   99.38       1.0   161.0      0.0  161.0     329.0     1.0
 
 References
 ----------

--- a/skbio/io/format/blast7.py
+++ b/skbio/io/format/blast7.py
@@ -206,11 +206,11 @@ Read the file into a ``pd.DataFrame``:
 
 >>> df = skbio.io.read(fh, into=pd.DataFrame)
 >>> df # doctest: +NORMALIZE_WHITESPACE
-       qacc      sacc        evalue  qstart   qend  sstart   send
-0  AE000111  AE000111  0.000000e+00       1  10596       1  10596
-1  AE000111  AE000174  8.000000e-30    5565   5671    6928   6821
-2  AE000111  AE000171  3.000000e-24    5587   5671    2214   2130
-3  AE000111  AE000425  6.000000e-26    5587   5671    8552   8468
+       qacc      sacc        evalue  qstart     qend  sstart     send
+0  AE000111  AE000111  0.000000e+00     1.0  10596.0     1.0  10596.0
+1  AE000111  AE000174  8.000000e-30  5565.0   5671.0  6928.0   6821.0
+2  AE000111  AE000171  3.000000e-24  5587.0   5671.0  2214.0   2130.0
+3  AE000111  AE000425  6.000000e-26  5587.0   5671.0  8552.0   8468.0
 
 Suppose we have a legacy BLAST 9 file:
 
@@ -238,14 +238,14 @@ Read the file into a ``pd.DataFrame``:
 >>> df = skbio.io.read(fh, into=pd.DataFrame)
 >>> df # doctest: +NORMALIZE_WHITESPACE
      qseqid          sseqid  pident  length  mismatch  gapopen  qstart  qend \\
-0  AF178033  EMORG:AF178033  100.00     811         0        0       1   811
-1  AF178033  EMORG:AF178032   94.57     811        44        0       1   811
-2  AF178033  EMORG:AF178031   94.82     811        42        0       1   811
+0  AF178033  EMORG:AF178033  100.00   811.0       0.0      0.0     1.0  811.0
+1  AF178033  EMORG:AF178032   94.57   811.0      44.0      0.0     1.0  811.0
+2  AF178033  EMORG:AF178031   94.82   811.0      42.0      0.0     1.0  811.0
 <BLANKLINE>
-   sstart  send  evalue  bitscore
-0       1   811       0    1566.6
-1       1   811       0    1217.7
-2       1   811       0    1233.5
+   sstart   send  evalue  bitscore
+0     1.0  811.0     0.0    1566.6
+1     1.0  811.0     0.0    1217.7
+2     1.0  811.0     0.0    1233.5
 
 References
 ==========

--- a/skbio/io/format/phylip.py
+++ b/skbio/io/format/phylip.py
@@ -191,7 +191,7 @@ default integer index labels:
 
 >>> msa.reassign_index()
 >>> msa.index
-Int64Index([0, 1, 2], dtype='int64')
+RangeIndex(start=0, stop=3, step=1)
 
 We can now write the ``TabularMSA`` in PHYLIP format:
 

--- a/skbio/metadata/_mixin.py
+++ b/skbio/metadata/_mixin.py
@@ -9,7 +9,6 @@
 import abc
 import copy
 
-import numpy as np
 import pandas as pd
 
 from skbio.util._decorator import stable, deprecated
@@ -176,8 +175,8 @@ class PositionalMetadataMixin(metaclass=abc.ABCMeta):
         Notes
         -----
         This property can be set and deleted. When setting new positional
-        metadata, a shallow copy is made and the index is set to the pandas
-        default integer index.
+        metadata, a shallow copy is made and the ``pd.DataFrame`` index is set
+        to ``pd.RangeIndex(start=0, stop=axis_len, step=1)``.
 
         Examples
         --------
@@ -268,14 +267,20 @@ class PositionalMetadataMixin(metaclass=abc.ABCMeta):
                 "positional metadata axis length (%d)."
                 % (num_rows, axis_len))
 
-        positional_metadata.reset_index(drop=True, inplace=True)
+        positional_metadata.index = self._get_positional_metadata_index()
         self._positional_metadata = positional_metadata
 
     @positional_metadata.deleter
     def positional_metadata(self):
         # Not using setter to avoid copy.
         self._positional_metadata = pd.DataFrame(
-            index=np.arange(self._positional_metadata_axis_len_()))
+                index=self._get_positional_metadata_index())
+
+    def _get_positional_metadata_index(self):
+        """Create a memory-efficient integer index for positional metadata."""
+        return pd.RangeIndex(start=0,
+                             stop=self._positional_metadata_axis_len_(),
+                             step=1)
 
     @abc.abstractmethod
     def __init__(self, positional_metadata=None):

--- a/skbio/sequence/_sequence.py
+++ b/skbio/sequence/_sequence.py
@@ -487,10 +487,10 @@ class Sequence(MetadataMixin, PositionalMetadataMixin, collections.Sequence,
         1   True  NaN
         2   True  NaN
         3  False  NaN
-        4  False    1
-        5  False    2
-        6   True    3
-        7  False    4
+        4  False  1.0
+        5  False  2.0
+        6   True  3.0
+        7  False  4.0
 
         """
         if how not in {'strict', 'inner', 'outer'}:

--- a/skbio/sequence/tests/test_sequence.py
+++ b/skbio/sequence/tests/test_sequence.py
@@ -198,7 +198,7 @@ class TestSequence(TestSequenceBase, ReallyEqualMixin):
         self.assertFalse(seq.metadata)
         self.assertEqual(seq.metadata, {})
         assert_data_frame_almost_equal(seq.positional_metadata,
-                                       pd.DataFrame(index=np.arange(11)))
+                                       pd.DataFrame(index=range(11)))
 
     def test_init_nondefault_parameters(self):
         seq = Sequence('.ABC123xyz-',
@@ -213,7 +213,7 @@ class TestSequence(TestSequenceBase, ReallyEqualMixin):
 
         assert_data_frame_almost_equal(
             seq.positional_metadata,
-            pd.DataFrame({'quality': range(11)}, index=np.arange(11)))
+            pd.DataFrame({'quality': range(11)}, index=range(11)))
 
     def test_init_empty_sequence(self):
         # Test constructing an empty sequence using each supported input type.
@@ -235,7 +235,7 @@ class TestSequence(TestSequenceBase, ReallyEqualMixin):
             self.assertEqual(seq.metadata, {})
 
             assert_data_frame_almost_equal(seq.positional_metadata,
-                                           pd.DataFrame(index=np.arange(0)))
+                                           pd.DataFrame(index=range(0)))
 
     def test_init_single_character_sequence(self):
         for s in (b'A',
@@ -256,7 +256,7 @@ class TestSequence(TestSequenceBase, ReallyEqualMixin):
             self.assertEqual(seq.metadata, {})
 
             assert_data_frame_almost_equal(seq.positional_metadata,
-                                           pd.DataFrame(index=np.arange(1)))
+                                           pd.DataFrame(index=range(1)))
 
     def test_init_multiple_character_sequence(self):
         for s in (b'.ABC\t123  xyz-',
@@ -278,7 +278,7 @@ class TestSequence(TestSequenceBase, ReallyEqualMixin):
             self.assertEqual(seq.metadata, {})
 
             assert_data_frame_almost_equal(seq.positional_metadata,
-                                           pd.DataFrame(index=np.arange(14)))
+                                           pd.DataFrame(index=range(14)))
 
     def test_init_from_sequence_object(self):
         # We're testing this in its simplest form in other tests. This test

--- a/skbio/stats/distance/_base.py
+++ b/skbio/stats/distance/_base.py
@@ -428,10 +428,10 @@ class DissimilarityMatrix(SkbioObject):
         ...                      [2, 3, 0]], ids=['a', 'b', 'c'])
         >>> df = dm.to_data_frame()
         >>> df
-           a  b  c
-        a  0  1  2
-        b  1  0  3
-        c  2  3  0
+             a    b    c
+        a  0.0  1.0  2.0
+        b  1.0  0.0  3.0
+        c  2.0  3.0  0.0
 
         """
         return pd.DataFrame(data=self.data, index=self.ids, columns=self.ids)

--- a/skbio/stats/tests/test_gradient.py
+++ b/skbio/stats/tests/test_gradient.py
@@ -254,10 +254,14 @@ class GradientTests(BaseTests):
         w_vector = pd.Series(np.array([1, 2, 3, 4, 5, 6, 7, 8]),
                              ['s1', 's2', 's3', 's4',
                               's5', 's6', 's7', 's8']).astype(np.float64)
-        exp = pd.DataFrame.from_dict({'s1': np.array([1]), 's2': np.array([2]),
-                                      's3': np.array([3]), 's4': np.array([4]),
-                                      's5': np.array([5]), 's6': np.array([6]),
-                                      's7': np.array([7]), 's8': np.array([8])
+        exp = pd.DataFrame.from_dict({'s1': np.array([1.0]),
+                                      's2': np.array([2.0]),
+                                      's3': np.array([3.0]),
+                                      's4': np.array([4.0]),
+                                      's5': np.array([5.0]),
+                                      's6': np.array([6.0]),
+                                      's7': np.array([7.0]),
+                                      's8': np.array([8.0])
                                       },
                                      orient='index')
         obs = _weight_by_vector(trajectory, w_vector)
@@ -272,9 +276,11 @@ class GradientTests(BaseTests):
         trajectory.sort_values(by=0, inplace=True)
         w_vector = pd.Series(np.array([25, 30, 35, 40, 45]),
                              ['s2', 's3', 's4', 's5', 's6']).astype(np.float64)
-        exp = pd.DataFrame.from_dict({'s2': np.array([2]), 's3': np.array([3]),
-                                      's4': np.array([4]), 's5': np.array([5]),
-                                      's6': np.array([6])}, orient='index')
+        exp = pd.DataFrame.from_dict({'s2': np.array([2.0]),
+                                      's3': np.array([3.0]),
+                                      's4': np.array([4.0]),
+                                      's5': np.array([5.0]),
+                                      's6': np.array([6.0])}, orient='index')
         obs = _weight_by_vector(trajectory, w_vector)
         assert_data_frame_almost_equal(obs.sort_index(), exp.sort_index())
 


### PR DESCRIPTION
Fixes #1308. scikit-bio now depends on pandas >= 0.18.0.

Added support for `pandas.RangeIndex`, lowering the memory footprint of default integer index objects. `Sequence.positional_metadata` and `TabularMSA.positional_metadata` now use `pd.RangeIndex` as the positional metadata index. `TabularMSA` now uses `pd.RangeIndex` as the default index.  Usage of `pd.RangeIndex` over the previous `pd.Int64Index` [should be transparent](http://pandas.pydata.org/pandas-docs/version/0.18.0/whatsnew.html#range-index), so these changes should be non-breaking to users.

Added `reset_index=False` parameter to `TabularMSA.append` and `TabularMSA.extend` for resetting the MSA's index to the default index after appending/extending. `TabularMSA.append` and `TabularMSA.extend` now require one of `minter`, `index`, or `reset_index` to be provided when incorporating new sequences into an MSA. Previous behavior was to auto-increment the index labels if `minter` and `index` weren't provided and the MSA had a default integer index, otherwise error.

Fixed doctests to work with pandas 0.18.0 ("integers" stored in a float column now repr with a trailing `.0`).