### PR TITLE
Expands error message in `skbio.io.format.stockholm`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **IMPORTANT**: scikit-bio is no longer compatible with Python 2. scikit-bio is compatible with Python 3.4 and later.
 
 ### Features
+* Expanded error message in `skbio.io.format.stockholm` to provide better explanation to user. ([#1327](https://github.com/biocore/scikit-bio/issues/1327))
 * Added `skbio.sequence.distance.kmer_distance` for computing the kmer distance between two sequences. ([#913](https://github.com/biocore/scikit-bio/issues/913))
 * Added `skbio.sequence.Sequence.replace` for assigning a character to positions in a `Sequence`. ([#1222](https://github.com/biocore/scikit-bio/issues/1222))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 **IMPORTANT**: scikit-bio is no longer compatible with Python 2. scikit-bio is compatible with Python 3.4 and later.
 
 ### Features
-* Expanded error message in `skbio.io.format.stockholm` to provide better explanation to user. ([#1327](https://github.com/biocore/scikit-bio/issues/1327))
+* Expanded error message in `skbio.io.format.stockholm` reader when `constructor` is not passed, in order to provide better explanation to user. ([#1327](https://github.com/biocore/scikit-bio/issues/1327))
 * Added `skbio.sequence.distance.kmer_distance` for computing the kmer distance between two sequences. ([#913](https://github.com/biocore/scikit-bio/issues/913))
 * Added `skbio.sequence.Sequence.replace` for assigning a character to positions in a `Sequence`. ([#1222](https://github.com/biocore/scikit-bio/issues/1222))
 

--- a/skbio/io/format/stockholm.py
+++ b/skbio/io/format/stockholm.py
@@ -392,7 +392,10 @@ def _stockholm_sniffer(fh):
 def _stockholm_to_tabular_msa(fh, constructor=None):
     # Checks that user has passed required constructor parameter
     if constructor is None:
-        raise ValueError("Must provide `constructor` parameter.")
+        raise ValueError("Must provide `constructor` parameter indicating the "
+                         "type of sequences in the alignment. `constructor` "
+                         "must be a subclass of `GrammaredSequence` "
+                         "(e.g., `DNA`, `RNA`, `Protein`).")
     # Checks that contructor parameter is supported
     elif not issubclass(constructor, GrammaredSequence):
         raise TypeError("`constructor` must be a subclass of "

--- a/skbio/io/format/tests/test_stockholm.py
+++ b/skbio/io/format/tests/test_stockholm.py
@@ -375,13 +375,13 @@ class TestStockholmReader(unittest.TestCase):
 
     def test_no_constructor_error(self):
         fp = get_data_path('empty')
-        with self.assertRaisesRegex(ValueError, 'Must.*parameter.'):
+        with self.assertRaisesRegex(ValueError, 'Must provide.*parameter.'):
             _stockholm_to_tabular_msa(fp)
 
     def test_unsupported_constructor_error(self):
         fp = get_data_path('empty')
         with self.assertRaisesRegex(TypeError,
-                                    '`constructor`.*`GrammaredSequence`'):
+                                    '`constructor`.*`GrammaredSequence`.'):
             _stockholm_to_tabular_msa(fp, constructor=TabularMSA)
 
 

--- a/skbio/sequence/tests/test_grammared_sequence.py
+++ b/skbio/sequence/tests/test_grammared_sequence.py
@@ -14,7 +14,7 @@ import pandas as pd
 
 from skbio.sequence import GrammaredSequence
 from skbio.util import classproperty
-from skbio.util._testing import assert_data_frame_almost_equal
+from skbio.util import assert_data_frame_almost_equal
 
 
 class ExampleGrammaredSequence(GrammaredSequence):


### PR DESCRIPTION
Fixes #1327

Additionally fixes minor bug in tests with new error message. (The second test could be catching the new error message instead of its error message).
Also contains fix of `import` statement in `skbio.sequence.tests.test_grammared_sequence`