### PR TITLE
Partial pairwise calculation for beta diversity.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Expanded error message in `skbio.io.format.stockholm` reader when `constructor` is not passed, in order to provide better explanation to user. ([#1327](https://github.com/biocore/scikit-bio/issues/1327))
 * Added `skbio.sequence.distance.kmer_distance` for computing the kmer distance between two sequences. ([#913](https://github.com/biocore/scikit-bio/issues/913))
 * Added `skbio.sequence.Sequence.replace` for assigning a character to positions in a `Sequence`. ([#1222](https://github.com/biocore/scikit-bio/issues/1222))
+* Added support for partial pairwise calculations in `skbio.diversity.beta_diversity`. ([#1221](https://github.com/biocore/scikit-bio/issues/1221), [#1337](https://github.com/biocore/scikit-bio/pull/1337))
 
 ### Backward-incompatible changes [stable]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 * Added `skbio.sequence.Sequence.replace` for assigning a character to positions in a `Sequence`. ([#1222](https://github.com/biocore/scikit-bio/issues/1222))
 * Added support for `pandas.RangeIndex`, lowering the memory footprint of default integer index objects. `Sequence.positional_metadata` and `TabularMSA.positional_metadata` now use `pd.RangeIndex` as the positional metadata index. `TabularMSA` now uses `pd.RangeIndex` as the default index. Usage of `pd.RangeIndex` over the previous `pd.Int64Index` [should be transparent](http://pandas.pydata.org/pandas-docs/version/0.18.0/whatsnew.html#range-index), so these changes should be non-breaking to users. scikit-bio now depends on pandas >= 0.18.0 ([#1308](https://github.com/biocore/scikit-bio/issues/1308))
 * Added `reset_index=False` parameter to `TabularMSA.append` and `TabularMSA.extend` for resetting the MSA's index to the default index after appending/extending.
-* Added support for partial pairwise calculations in `skbio.diversity.beta_diversity`. ([#1221](https://github.com/biocore/scikit-bio/issues/1221), [#1337](https://github.com/biocore/scikit-bio/pull/1337))
+* Added support for partial pairwise calculations via `skbio.diversity.partial_beta_diversity`. ([#1221](https://github.com/biocore/scikit-bio/issues/1221), [#1337](https://github.com/biocore/scikit-bio/pull/1337))
 
 ### Backward-incompatible changes [stable]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 * Added `skbio.sequence.Sequence.replace` for assigning a character to positions in a `Sequence`. ([#1222](https://github.com/biocore/scikit-bio/issues/1222))
 * Added support for `pandas.RangeIndex`, lowering the memory footprint of default integer index objects. `Sequence.positional_metadata` and `TabularMSA.positional_metadata` now use `pd.RangeIndex` as the positional metadata index. `TabularMSA` now uses `pd.RangeIndex` as the default index. Usage of `pd.RangeIndex` over the previous `pd.Int64Index` [should be transparent](http://pandas.pydata.org/pandas-docs/version/0.18.0/whatsnew.html#range-index), so these changes should be non-breaking to users. scikit-bio now depends on pandas >= 0.18.0 ([#1308](https://github.com/biocore/scikit-bio/issues/1308))
 * Added `reset_index=False` parameter to `TabularMSA.append` and `TabularMSA.extend` for resetting the MSA's index to the default index after appending/extending.
-* Added support for partial pairwise calculations via `skbio.diversity.partial_beta_diversity`. ([#1221](https://github.com/biocore/scikit-bio/issues/1221), [#1337](https://github.com/biocore/scikit-bio/pull/1337))
+* Added support for partial pairwise calculations via `skbio.diversity.partial_beta_diversity`. ([#1221](https://github.com/biocore/scikit-bio/issues/1221), [#1337](https://github.com/biocore/scikit-bio/pull/1337)). This function is immediately deprecated as its return type will change in the future and should be used with caution in its present form (see the function's documentation for details).
 
 ### Backward-incompatible changes [stable]
 

--- a/skbio/diversity/__init__.py
+++ b/skbio/diversity/__init__.py
@@ -399,10 +399,10 @@ Create a matrix containing 6 samples (rows) and 7 OTUs (columns):
 
 from skbio.util import TestRunner
 
-from ._driver import (alpha_diversity, beta_diversity,
+from ._driver import (alpha_diversity, beta_diversity, partial_beta_diversity,
                       get_alpha_diversity_metrics, get_beta_diversity_metrics)
 
 __all__ = ["alpha_diversity", "beta_diversity", "get_alpha_diversity_metrics",
-           "get_beta_diversity_metrics"]
+           "get_beta_diversity_metrics", "partial_beta_diversity"]
 
 test = TestRunner(__file__).test

--- a/skbio/diversity/__init__.py
+++ b/skbio/diversity/__init__.py
@@ -377,15 +377,15 @@ Create a matrix containing 6 samples (rows) and 7 OTUs (columns):
    >>> plt.close('all') # not necessary for normal use
    >>> fig = sample_md.boxplot(column='Faith PD', by='body_site')
 
-We can also compute Spearman correlations between all pairs of columns in this
-``DataFrame``. Since our alpha diversity metrics are the only two numeric
-columns (and thus the only columns for which Spearman correlation is relevant),
-this will give us a symmetric 2x2 correlation matrix.
+    We can also compute Spearman correlations between all pairs of columns in
+    this ``DataFrame``. Since our alpha diversity metrics are the only two
+    numeric columns (and thus the only columns for which Spearman correlation
+    is relevant), this will give us a symmetric 2x2 correlation matrix.
 
->>> sample_md.corr(method="spearman")
-               Observed OTUs  Faith PD
-Observed OTUs       1.000000  0.939336
-Faith PD            0.939336  1.000000
+    >>> sample_md.corr(method="spearman")
+                   Observed OTUs  Faith PD
+    Observed OTUs       1.000000  0.939336
+    Faith PD            0.939336  1.000000
 
 """
 

--- a/skbio/diversity/__init__.py
+++ b/skbio/diversity/__init__.py
@@ -162,6 +162,7 @@ Functions
 
     alpha_diversity
     beta_diversity
+    partial_beta_diversity
     get_alpha_diversity_metrics
     get_beta_diversity_metrics
 
@@ -377,15 +378,15 @@ Create a matrix containing 6 samples (rows) and 7 OTUs (columns):
    >>> plt.close('all') # not necessary for normal use
    >>> fig = sample_md.boxplot(column='Faith PD', by='body_site')
 
-    We can also compute Spearman correlations between all pairs of columns in
-    this ``DataFrame``. Since our alpha diversity metrics are the only two
-    numeric columns (and thus the only columns for which Spearman correlation
-    is relevant), this will give us a symmetric 2x2 correlation matrix.
+We can also compute Spearman correlations between all pairs of columns in
+this ``DataFrame``. Since our alpha diversity metrics are the only two
+numeric columns (and thus the only columns for which Spearman correlation
+is relevant), this will give us a symmetric 2x2 correlation matrix.
 
-    >>> sample_md.corr(method="spearman")
-                   Observed OTUs  Faith PD
-    Observed OTUs       1.000000  0.939336
-    Faith PD            0.939336  1.000000
+>>> sample_md.corr(method="spearman")
+               Observed OTUs  Faith PD
+Observed OTUs       1.000000  0.939336
+Faith PD            0.939336  1.000000
 
 """
 

--- a/skbio/diversity/_driver.py
+++ b/skbio/diversity/_driver.py
@@ -194,11 +194,12 @@ def _partial_pw(ids, id_pairs, counts, metric, **kwargs):
         of OTUs in a given sample.
     ids : iterable of strs
         Identifiers for each sample in ``counts``.
-    id_pairs : iterable of tuple, optional An iterable of tuples of IDs to
-        compare (e.g., ``[('a', 'b'), ('a', 'c'), ...])``. If specified, the
-        set of IDs described must be a subset of ``ids``. ``id_pairs`` is a
-        mutually exclusive argument with ``pairwise_func``. ``metric`` must be
-        resolvable by scikit-bio (e.g., UniFrac methods), or must be callable.
+    id_pairs : iterable of tuple, optional
+        An iterable of tuples of IDs to compare (e.g., ``[('a', 'b'), ('a',
+        'c'), ...])``. If specified, the set of IDs described must be a subset
+        of ``ids``. ``id_pairs`` is a mutually exclusive argument with
+        ``pairwise_func``. ``metric`` must be resolvable by scikit-bio (e.g.,
+        UniFrac methods), or must be callable.
     kwargs : kwargs, optional
         Metric-specific parameters.
 
@@ -214,6 +215,11 @@ def _partial_pw(ids, id_pairs, counts, metric, **kwargs):
         If ``id_pairs`` are not a subset of ``ids``.
         If ``metric`` is not a callable.
         If duplicates are observed in ``id_pairs``.
+
+    See Also
+    --------
+    skbio.diversity.get_beta_diversity_metrics
+
     """
     if ids is None:
         raise ValueError("`ids` must be specified if `id_pairs` is specified")
@@ -275,11 +281,12 @@ def beta_diversity(metric, counts, ids=None, validate=True, pairwise_func=None,
         that can be provided are ``scipy.spatial.distance.pdist`` and
         ``sklearn.metrics.pairwise_distances``. By default,
         ``scipy.spatial.distance.pdist`` will be used.
-    id_pairs : iterable of tuple, optional An iterable of tuples of IDs to
-        compare (e.g., ``[('a', 'b'), ('a', 'c'), ...])``. If specified, the
-        set of IDs described must be a subset of ``ids``. ``id_pairs`` is a
-        mutually exclusive argument with ``pairwise_func``. ``metric`` must be
-        resolvable by scikit-bio (e.g., UniFrac methods), or must be callable.
+    id_pairs : iterable of tuple, optional
+        An iterable of tuples of IDs to compare (e.g., ``[('a', 'b'), ('a',
+        'c'), ...])``. If specified, the set of IDs described must be a subset
+        of ``ids``. ``id_pairs`` is a mutually exclusive argument with
+        ``pairwise_func``. ``metric`` must be resolvable by scikit-bio (e.g.,
+        UniFrac methods), or must be callable.
     kwargs : kwargs, optional
         Metric-specific parameters.
 

--- a/skbio/diversity/_driver.py
+++ b/skbio/diversity/_driver.py
@@ -238,7 +238,7 @@ def _partial_pw(ids, id_pairs, counts, metric, **kwargs):
     for u, v in id_pairs_indexed:
         dm[u, v] = metric(counts[u], counts[v], **kwargs)
 
-    return scipy.spatial.distance.squareform(dm + dm.T)
+    return dm + dm.T
 
 
 @experimental(as_of="0.4.0")

--- a/skbio/diversity/_driver.py
+++ b/skbio/diversity/_driver.py
@@ -205,7 +205,7 @@ def _partial_pw(ids, id_pairs, counts, metric, **kwargs):
     Returns
     -------
     np.array
-        A condensed form of the distance matrix.
+        A square, hollow, matrix of distances between ID pairs.
 
     Raises
     ------

--- a/skbio/diversity/_driver.py
+++ b/skbio/diversity/_driver.py
@@ -227,7 +227,6 @@ def partial_beta_diversity(metric, counts, ids=None, validate=None,
         If ``id_pairs`` are not a subset of ``ids``.
         If ``metric`` is not a callable.
         If duplicates are observed in ``id_pairs``.
-        If a metric is passed in that is a non-optimized UniFrac metric.
 
     See Also
     --------
@@ -239,6 +238,8 @@ def partial_beta_diversity(metric, counts, ids=None, validate=None,
         raise ValueError("`ids` must be specified")
 
     if id_pairs is None:
+        # determine all pairs of the upper triangle.
+        # alternatively, could just call beta_diversity?
         id_pairs = []
         for row, i in enumerate(ids):
             for j in ids[row+1:]:

--- a/skbio/diversity/_driver.py
+++ b/skbio/diversity/_driver.py
@@ -289,7 +289,7 @@ def partial_beta_diversity(metric, counts, ids=None, validate=None,
 
 @experimental(as_of="0.4.0")
 def beta_diversity(metric, counts, ids=None, validate=True, pairwise_func=None,
-                   id_pairs=None, **kwargs):
+                   **kwargs):
     """Compute distances between all pairs of samples
 
     Parameters
@@ -321,12 +321,6 @@ def beta_diversity(metric, counts, ids=None, validate=True, pairwise_func=None,
         that can be provided are ``scipy.spatial.distance.pdist`` and
         ``sklearn.metrics.pairwise_distances``. By default,
         ``scipy.spatial.distance.pdist`` will be used.
-    id_pairs : iterable of tuple, optional
-        An iterable of tuples of IDs to compare (e.g., ``[('a', 'b'), ('a',
-        'c'), ...])``. If specified, the set of IDs described must be a subset
-        of ``ids``. ``id_pairs`` is a mutually exclusive argument with
-        ``pairwise_func``. ``metric`` must be resolvable by scikit-bio (e.g.,
-        UniFrac methods), or must be callable.
     kwargs : kwargs, optional
         Metric-specific parameters.
 

--- a/skbio/diversity/_driver.py
+++ b/skbio/diversity/_driver.py
@@ -18,7 +18,7 @@ from skbio.diversity.alpha._faith_pd import _faith_pd, _setup_faith_pd
 from skbio.diversity.beta._unifrac import (
     _setup_multiple_unweighted_unifrac, _setup_multiple_weighted_unifrac,
     _normalize_weighted_unifrac_by_default)
-from skbio.util._decorator import experimental
+from skbio.util._decorator import experimental, deprecated
 from skbio.stats.distance import DistanceMatrix
 from skbio.diversity._util import (_validate_counts_matrix,
                                    _get_phylogenetic_kwargs)
@@ -182,13 +182,20 @@ def alpha_diversity(metric, counts, ids=None, validate=True, **kwargs):
     return pd.Series(results, index=ids)
 
 
-def _partial_pw(ids, id_pairs, counts, metric, **kwargs):
+@deprecated(as_of='0.4.2-dev', until='0.5.0',
+            reason=('The return type is unstable. Developer caution is '
+                    'advised. The resulting DistanceMatrix object may include '
+                    'zeros when distance has not been calculated, and '
+                    'therefore can be misleading.'))
+def partial_beta_diversity(metric, counts, ids=None, validate=None,
+                           id_pairs=None, **kwargs):
     """Compute distances only between specified ID pairs
 
     Parameters
     ----------
     metric : callable
-        The pairwise distance function to apply.
+        The pairwise distance function to apply. ``metric`` must be resolvable
+        by scikit-bio (e.g., UniFrac methods), or must be callable.
     counts : 2D array_like of ints or floats
         Matrix containing count/abundance data where each row contains counts
         of OTUs in a given sample.
@@ -197,16 +204,21 @@ def _partial_pw(ids, id_pairs, counts, metric, **kwargs):
     id_pairs : iterable of tuple, optional
         An iterable of tuples of IDs to compare (e.g., ``[('a', 'b'), ('a',
         'c'), ...])``. If specified, the set of IDs described must be a subset
-        of ``ids``. ``id_pairs`` is a mutually exclusive argument with
-        ``pairwise_func``. ``metric`` must be resolvable by scikit-bio (e.g.,
-        UniFrac methods), or must be callable.
+        of ``ids``.
+    validate : ignored
+        This kwarg is preserved to maintain consistency with the beta_diversity
+        signature.
     kwargs : kwargs, optional
         Metric-specific parameters.
 
     Returns
     -------
-    np.array
-        A square, hollow, matrix of distances between ID pairs.
+    skbio.DistanceMatrix
+        Distances between all pairs of samples (i.e., rows). The number of
+        rows and columns will be equal to the number of rows in ``counts``.
+
+        Warning: zeros in this matrix may represent a zero distance, or may
+        represent a pairwise distance that was not calculated.
 
     Raises
     ------
@@ -215,14 +227,22 @@ def _partial_pw(ids, id_pairs, counts, metric, **kwargs):
         If ``id_pairs`` are not a subset of ``ids``.
         If ``metric`` is not a callable.
         If duplicates are observed in ``id_pairs``.
+        If a metric is passed in that is a non-optimized UniFrac metric.
 
     See Also
     --------
+    skbio.beta_diversity
     skbio.diversity.get_beta_diversity_metrics
 
     """
     if ids is None:
-        raise ValueError("`ids` must be specified if `id_pairs` is specified")
+        raise ValueError("`ids` must be specified")
+
+    if id_pairs is None:
+        id_pairs = []
+        for row, i in enumerate(ids):
+            for j in ids[row+1:]:
+                id_pairs.append((i, j))
 
     all_ids_in_pairs = set(itertools.chain.from_iterable(id_pairs))
     if not all_ids_in_pairs.issubset(ids):
@@ -232,10 +252,29 @@ def _partial_pw(ids, id_pairs, counts, metric, **kwargs):
     if len(hashes) != len(id_pairs) * 2:
         raise ValueError("Duplicate ID pairs observed.")
 
-    if isinstance(metric, str):
-        # The mechanism for going from str to callable in scipy's pdist is
-        # not exposed
-        raise ValueError("`metric` must be callable")
+    if metric == 'unweighted_unifrac':
+        otu_ids, tree, kwargs = _get_phylogenetic_kwargs(counts, **kwargs)
+        metric, counts_by_node = _setup_multiple_unweighted_unifrac(
+                counts, otu_ids=otu_ids, tree=tree, validate=validate)
+        counts = counts_by_node
+    elif metric == 'weighted_unifrac':
+        # get the value for normalized. if it was not provided, it will fall
+        # back to the default value inside of _weighted_unifrac_pdist_f
+        normalized = kwargs.pop('normalized',
+                                _normalize_weighted_unifrac_by_default)
+        otu_ids, tree, kwargs = _get_phylogenetic_kwargs(counts, **kwargs)
+        metric, counts_by_node = _setup_multiple_weighted_unifrac(
+                counts, otu_ids=otu_ids, tree=tree, normalized=normalized,
+                validate=validate)
+        counts = counts_by_node
+    elif callable(metric):
+        metric = functools.partial(metric, **kwargs)
+        # remove all values from kwargs, since they have already been provided
+        # through the partial
+        kwargs = {}
+    else:
+        raise ValueError("partial_beta_diversity is only compatible with "
+                         "optimized unifrac methods and callable functions.")
 
     dm = np.zeros((len(ids), len(ids)), dtype=float)
     id_index = {id_: idx for idx, id_ in enumerate(ids)}
@@ -244,7 +283,7 @@ def _partial_pw(ids, id_pairs, counts, metric, **kwargs):
     for u, v in id_pairs_indexed:
         dm[u, v] = metric(counts[u], counts[v], **kwargs)
 
-    return dm + dm.T
+    return DistanceMatrix(dm + dm.T, ids)
 
 
 @experimental(as_of="0.4.0")
@@ -340,13 +379,6 @@ def beta_diversity(metric, counts, ids=None, validate=True, pairwise_func=None,
         # metric is a string that scikit-bio doesn't know about, for
         # example one of the SciPy metrics
         pass
-
-    if id_pairs is not None:
-        if pairwise_func is not None:
-            raise ValueError("`pairwise_func` is not compatible with "
-                             "`id_pairs`")
-
-        pairwise_func = functools.partial(_partial_pw, ids, id_pairs)
 
     if pairwise_func is None:
         pairwise_func = scipy.spatial.distance.pdist

--- a/skbio/diversity/_driver.py
+++ b/skbio/diversity/_driver.py
@@ -182,7 +182,7 @@ def alpha_diversity(metric, counts, ids=None, validate=True, **kwargs):
 
 @experimental(as_of="0.4.0")
 def beta_diversity(metric, counts, ids=None, validate=True, pairwise_func=None,
-                   **kwargs):
+                   id_pairs=None, **kwargs):
     """Compute distances between all pairs of samples
 
     Parameters
@@ -242,6 +242,20 @@ def beta_diversity(metric, counts, ids=None, validate=True, pairwise_func=None,
     """
     if validate:
         counts = _validate_counts_matrix(counts, ids=ids)
+
+    if id_pairs is not None:
+        if ids is None:
+            raise ValueError("`ids` must be specified if `id_pairs` is "
+                             "specified")
+        if pairwise_func is not None:
+            raise ValueError("`pairwise_func` is not compatible with "
+                             "`id_pairs`")
+
+        # flattening list benchmark here
+        # http://stackoverflow.com/a/952952
+        all_ids_in_pairs = {id_ for pair in id_pairs for id_ in pair}
+        if not all_ids_in_pairs.issubset(ids):
+            raise ValueError("`id_pairs` are not a subset of `ids`")
 
     if pairwise_func is None:
         pairwise_func = scipy.spatial.distance.pdist

--- a/skbio/diversity/_driver.py
+++ b/skbio/diversity/_driver.py
@@ -7,6 +7,7 @@
 # ----------------------------------------------------------------------------
 
 import functools
+import itertools
 
 import numpy as np
 import scipy.spatial.distance
@@ -212,18 +213,22 @@ def _partial_pw(ids, id_pairs, counts, metric, **kwargs):
         If ``ids`` are not specified.
         If ``id_pairs`` are not a subset of ``ids``.
         If ``metric`` is not a callable.
+        If duplicates are observed in ``id_pairs``.
     """
     if ids is None:
         raise ValueError("`ids` must be specified if `id_pairs` is specified")
 
-    # flattening list benchmark here
-    # http://stackoverflow.com/a/952952
-    all_ids_in_pairs = {id_ for pair in id_pairs for id_ in pair}
+    all_ids_in_pairs = set(itertools.chain.from_iterable(id_pairs))
     if not all_ids_in_pairs.issubset(ids):
         raise ValueError("`id_pairs` are not a subset of `ids`")
 
+    hashes = {i for i in id_pairs}.union({i[::-1] for i in id_pairs})
+    if len(hashes) != len(id_pairs) * 2:
+        raise ValueError("Duplicate ID pairs observed.")
+
     if isinstance(metric, str):
         # The mechanism for going from str to callable in scipy's pdist is
+        # not exposed
         raise ValueError("`metric` must be callable")
 
     dm = np.zeros((len(ids), len(ids)), dtype=float)

--- a/skbio/diversity/_driver.py
+++ b/skbio/diversity/_driver.py
@@ -202,7 +202,7 @@ def partial_beta_diversity(metric, counts, ids, id_pairs, validate=True,
         of OTUs in a given sample.
     ids : iterable of strs
         Identifiers for each sample in ``counts``.
-    id_pairs : iterable of tuple, optional
+    id_pairs : iterable of tuple
         An iterable of tuples of IDs to compare (e.g., ``[('a', 'b'), ('a',
         'c'), ...])``. If specified, the set of IDs described must be a subset
         of ``ids``.
@@ -235,9 +235,6 @@ def partial_beta_diversity(metric, counts, ids, id_pairs, validate=True,
     """
     if validate:
         counts = _validate_counts_matrix(counts, ids=ids)
-
-    if ids is None:
-        raise ValueError("`ids` must be specified")
 
     id_pairs = list(id_pairs)
     all_ids_in_pairs = set(itertools.chain.from_iterable(id_pairs))

--- a/skbio/diversity/_driver.py
+++ b/skbio/diversity/_driver.py
@@ -224,7 +224,7 @@ def partial_beta_diversity(metric, counts, ids, id_pairs, validate=True,
         If ``ids`` are not specified.
         If ``id_pairs`` are not a subset of ``ids``.
         If ``metric`` is not a callable or is unresolvable string by
-            scikit-bio.
+        scikit-bio.
         If duplicates are observed in ``id_pairs``.
 
     See Also

--- a/skbio/diversity/_driver.py
+++ b/skbio/diversity/_driver.py
@@ -182,7 +182,37 @@ def alpha_diversity(metric, counts, ids=None, validate=True, **kwargs):
 
 
 def _partial_pw(ids, id_pairs, counts, metric, **kwargs):
-    """Compute distances only between specified ID pairs"""
+    """Compute distances only between specified ID pairs
+
+    Parameters
+    ----------
+    metric : callable
+        The pairwise distance function to apply.
+    counts : 2D array_like of ints or floats
+        Matrix containing count/abundance data where each row contains counts
+        of OTUs in a given sample.
+    ids : iterable of strs
+        Identifiers for each sample in ``counts``.
+    id_pairs : iterable of tuple, optional An iterable of tuples of IDs to
+        compare (e.g., ``[('a', 'b'), ('a', 'c'), ...])``. If specified, the
+        set of IDs described must be a subset of ``ids``. ``id_pairs`` is a
+        mutually exclusive argument with ``pairwise_func``. ``metric`` must be
+        resolvable by scikit-bio (e.g., UniFrac methods), or must be callable.
+    kwargs : kwargs, optional
+        Metric-specific parameters.
+
+    Returns
+    -------
+    np.array
+        A condensed form of the distance matrix.
+
+    Raises
+    ------
+    ValueError
+        If ``ids`` are not specified.
+        If ``id_pairs`` are not a subset of ``ids``.
+        If ``metric`` is not a callable.
+    """
     if ids is None:
         raise ValueError("`ids` must be specified if `id_pairs` is specified")
 
@@ -240,6 +270,11 @@ def beta_diversity(metric, counts, ids=None, validate=True, pairwise_func=None,
         that can be provided are ``scipy.spatial.distance.pdist`` and
         ``sklearn.metrics.pairwise_distances``. By default,
         ``scipy.spatial.distance.pdist`` will be used.
+    id_pairs : iterable of tuple, optional An iterable of tuples of IDs to
+        compare (e.g., ``[('a', 'b'), ('a', 'c'), ...])``. If specified, the
+        set of IDs described must be a subset of ``ids``. ``id_pairs`` is a
+        mutually exclusive argument with ``pairwise_func``. ``metric`` must be
+        resolvable by scikit-bio (e.g., UniFrac methods), or must be callable.
     kwargs : kwargs, optional
         Metric-specific parameters.
 

--- a/skbio/diversity/tests/test_driver.py
+++ b/skbio/diversity/tests/test_driver.py
@@ -653,7 +653,6 @@ class TestPartialBetaDiversity(TestCase):
                        [44, 35, 9, 0, 1, 0, 0],
                        [0, 2, 8, 0, 35, 45, 1],
                        [0, 0, 25, 35, 0, 19, 0]]
-        self.table2 = np.array(self.table2)
         self.sids2 = list('ABCDEF')
 
     def test_id_pairs_as_iterable(self):
@@ -739,14 +738,6 @@ class TestPartialBetaDiversity(TestCase):
                                    self.sids1, id_pairs=[('A', 'B'),
                                                          ('A', 'B')])
 
-    def test_no_ids(self):
-        # confirm that partial pairwise execution errors when ids are not
-        # specified
-        error_msg = ("`ids` must be specified")
-        with self.assertRaisesRegex(ValueError, error_msg):
-            partial_beta_diversity((lambda x, y: x + y), self.table1,
-                                   None, id_pairs=[('A', 'B'), ('A', 'B')])
-
     def test_pairs_not_subset(self):
         # confirm raise when pairs are not a subset of IDs
         error_msg = ("`id_pairs` are not a subset of `ids`")
@@ -777,6 +768,13 @@ class TestPartialBetaDiversity(TestCase):
             for id2 in self.sids2:
                 npt.assert_almost_equal(actual_dm[id1, id2],
                                         expected_dm[id1, id2], 6)
+
+    def test_unusable_metric(self):
+        id_pairs = [('A', 'B'), ('B', 'F'), ('D', 'E')]
+        error_msg = "partial_beta_diversity is only compatible"
+        with self.assertRaisesRegex(ValueError, error_msg):
+            partial_beta_diversity('hamming', self.table2, self.sids2,
+                                   id_pairs=id_pairs)
 
 
 if __name__ == "__main__":

--- a/skbio/diversity/tests/test_driver.py
+++ b/skbio/diversity/tests/test_driver.py
@@ -583,6 +583,22 @@ class BetaDiversityTests(TestCase):
                 if id1 != id2:
                     self.assertNotEqual(dm1[id1, id2], dm2[id1, id2])
 
+    def test_partial_pw_duplicate_pairs(self):
+        # confirm that partial pairwise execution fails if duplicate pairs are
+        # observed
+        error_msg = ("Duplicate ID pairs observed.")
+        with self.assertRaisesRegex(ValueError, error_msg):
+            beta_diversity('euclidean', self.table1, ids=self.sids1,
+                           id_pairs=[('A', 'B'), ('A', 'B')])
+
+    def test_partial_pw_duplicate_transpose_pairs(self):
+        # confirm that partial pairwise execution fails if a transpose
+        # duplicate is observed
+        error_msg = ("Duplicate ID pairs observed.")
+        with self.assertRaisesRegex(ValueError, error_msg):
+            beta_diversity('euclidean', self.table1, ids=self.sids1,
+                           id_pairs=[('A', 'B'), ('B', 'A')])
+
     def test_partial_pw_no_ids(self):
         # confirm that partial pairwise execution errors when ids are not
         # specified

--- a/skbio/diversity/tests/test_driver.py
+++ b/skbio/diversity/tests/test_driver.py
@@ -530,48 +530,6 @@ class BetaDiversityTests(TestCase):
                 npt.assert_almost_equal(dm1[id1, id2],
                                         expected_dm[id1, id2], 6)
 
-    def test_unweighted_unifrac_partial(self):
-        # TODO: update npt.assert_almost_equal calls to use DistanceMatrix
-        # near-equality testing when that support is available
-        # expected values calculated by hand
-        dm = partial_beta_diversity('unweighted_unifrac', self.table1,
-                                    self.sids1, otu_ids=self.oids1,
-                                    tree=self.tree1, id_pairs=[('B', 'C'), ])
-        self.assertEqual(dm.shape, (3, 3))
-        expected_data = [[0.0, 0.0, 0.0],
-                         [0.0, 0.0, 0.25],
-                         [0.0, 0.25, 0.0]]
-        expected_dm = DistanceMatrix(expected_data, ids=self.sids1)
-        for id1 in self.sids1:
-            for id2 in self.sids1:
-                npt.assert_almost_equal(dm[id1, id2],
-                                        expected_dm[id1, id2], 6)
-
-    def test_weighted_unifrac_partial_full(self):
-        # TODO: update npt.assert_almost_equal calls to use DistanceMatrix
-        # near-equality testing when that support is available
-        # expected values calculated by hand
-        dm1 = partial_beta_diversity('weighted_unifrac', self.table1,
-                                     self.sids1, otu_ids=self.oids1,
-                                     tree=self.tree1)
-        dm2 = partial_beta_diversity('weighted_unifrac', self.table1,
-                                     self.sids1, otu_ids=self.oids1,
-                                     tree=self.tree1, id_pairs=[('A', 'B'),
-                                                                ('A', 'C'),
-                                                                ('B', 'C')])
-
-        self.assertEqual(dm1.shape, (3, 3))
-        self.assertEqual(dm1, dm2)
-        expected_data = [
-            [0.0, 0.1750000, 0.12499999],
-            [0.1750000, 0.0, 0.3000000],
-            [0.12499999, 0.3000000, 0.0]]
-        expected_dm = DistanceMatrix(expected_data, ids=self.sids1)
-        for id1 in self.sids1:
-            for id2 in self.sids1:
-                npt.assert_almost_equal(dm1[id1, id2],
-                                        expected_dm[id1, id2], 6)
-
     def test_weighted_unifrac(self):
         # TODO: update npt.assert_almost_equal calls to use DistanceMatrix
         # near-equality testing when that support is available
@@ -679,7 +637,7 @@ class MetricGetters(TestCase):
         self.assertEqual(m, n)
 
 
-class PartialPairwise(TestCase):
+class TestPartialBetaDiversity(TestCase):
     def setUp(self):
         self.table1 = [[1, 5],
                        [2, 3],
@@ -698,10 +656,75 @@ class PartialPairwise(TestCase):
         self.table2 = np.array(self.table2)
         self.sids2 = list('ABCDEF')
 
+    def test_id_pairs_as_iterable(self):
+        id_pairs = iter([('B', 'C'), ])
+        dm = partial_beta_diversity('unweighted_unifrac', self.table1,
+                                    self.sids1, otu_ids=self.oids1,
+                                    tree=self.tree1, id_pairs=id_pairs)
+        self.assertEqual(dm.shape, (3, 3))
+        expected_data = [[0.0, 0.0, 0.0],
+                         [0.0, 0.0, 0.25],
+                         [0.0, 0.25, 0.0]]
+        expected_dm = DistanceMatrix(expected_data, ids=self.sids1)
+        for id1 in self.sids1:
+            for id2 in self.sids1:
+                npt.assert_almost_equal(dm[id1, id2],
+                                        expected_dm[id1, id2], 6)
+
+        # pass in iter(foo)
+
+    def test_unweighted_unifrac_partial(self):
+        # TODO: update npt.assert_almost_equal calls to use DistanceMatrix
+        # near-equality testing when that support is available
+        # expected values calculated by hand
+        dm = partial_beta_diversity('unweighted_unifrac', self.table1,
+                                    self.sids1, otu_ids=self.oids1,
+                                    tree=self.tree1, id_pairs=[('B', 'C'), ])
+        self.assertEqual(dm.shape, (3, 3))
+        expected_data = [[0.0, 0.0, 0.0],
+                         [0.0, 0.0, 0.25],
+                         [0.0, 0.25, 0.0]]
+        expected_dm = DistanceMatrix(expected_data, ids=self.sids1)
+        for id1 in self.sids1:
+            for id2 in self.sids1:
+                npt.assert_almost_equal(dm[id1, id2],
+                                        expected_dm[id1, id2], 6)
+
+    def test_weighted_unifrac_partial_full(self):
+        # TODO: update npt.assert_almost_equal calls to use DistanceMatrix
+        # near-equality testing when that support is available
+        # expected values calculated by hand
+        dm1 = partial_beta_diversity('weighted_unifrac', self.table1,
+                                     self.sids1, otu_ids=self.oids1,
+                                     tree=self.tree1, id_pairs=[('A', 'B'),
+                                                                ('A', 'C'),
+                                                                ('B', 'C')])
+        dm2 = beta_diversity('weighted_unifrac', self.table1, self.sids1,
+                             otu_ids=self.oids1, tree=self.tree1)
+
+        self.assertEqual(dm1.shape, (3, 3))
+        self.assertEqual(dm1, dm2)
+        expected_data = [
+            [0.0, 0.1750000, 0.12499999],
+            [0.1750000, 0.0, 0.3000000],
+            [0.12499999, 0.3000000, 0.0]]
+        expected_dm = DistanceMatrix(expected_data, ids=self.sids1)
+        for id1 in self.sids1:
+            for id2 in self.sids1:
+                npt.assert_almost_equal(dm1[id1, id2],
+                                        expected_dm[id1, id2], 6)
+
+    def test_self_self_pair(self):
+        error_msg = ("A duplicate or a self-self pair was observed.")
+        with self.assertRaisesRegex(ValueError, error_msg):
+            partial_beta_diversity((lambda x, y: x + y), self.table1,
+                                   self.sids1, id_pairs=[('A', 'B'),
+                                                         ('A', 'A')])
+
     def test_duplicate_pairs(self):
         # confirm that partial pairwise execution fails if duplicate pairs are
         # observed
-        error_msg = ("Duplicate ID pairs observed.")
+        error_msg = ("A duplicate or a self-self pair was observed.")
         with self.assertRaisesRegex(ValueError, error_msg):
             partial_beta_diversity((lambda x, y: x + y), self.table1,
                                    self.sids1, id_pairs=[('A', 'B'),
@@ -710,7 +733,7 @@ class PartialPairwise(TestCase):
     def test_duplicate_transpose_pairs(self):
         # confirm that partial pairwise execution fails if a transpose
         # duplicate is observed
-        error_msg = ("Duplicate ID pairs observed.")
+        error_msg = ("A duplicate or a self-self pair was observed.")
         with self.assertRaisesRegex(ValueError, error_msg):
             partial_beta_diversity((lambda x, y: x + y), self.table1,
                                    self.sids1, id_pairs=[('A', 'B'),

--- a/skbio/diversity/tests/test_driver.py
+++ b/skbio/diversity/tests/test_driver.py
@@ -20,6 +20,7 @@ from skbio.diversity import (alpha_diversity, beta_diversity,
                              get_beta_diversity_metrics)
 from skbio.diversity.alpha import faith_pd, observed_otus
 from skbio.diversity.beta import unweighted_unifrac, weighted_unifrac
+from skbio.diversity._driver import _partial_pw
 from skbio.tree import DuplicateNodeError, MissingNodeError
 
 
@@ -529,6 +530,45 @@ class BetaDiversityTests(TestCase):
                 npt.assert_almost_equal(dm1[id1, id2],
                                         expected_dm[id1, id2], 6)
 
+    def test_unweighted_unifrac_partial(self):
+        # TODO: update npt.assert_almost_equal calls to use DistanceMatrix
+        # near-equality testing when that support is available
+        # expected values calculated by hand
+        dm = beta_diversity('unweighted_unifrac', self.table1, self.sids1,
+                            otu_ids=self.oids1, tree=self.tree1,
+                            id_pairs=[('B', 'C'), ])
+        self.assertEqual(dm.shape, (3, 3))
+        expected_data = [[0.0, 0.0, 0.0],
+                         [0.0, 0.0, 0.25],
+                         [0.0, 0.25, 0.0]]
+        expected_dm = DistanceMatrix(expected_data, ids=self.sids1)
+        for id1 in self.sids1:
+            for id2 in self.sids1:
+                npt.assert_almost_equal(dm[id1, id2],
+                                        expected_dm[id1, id2], 6)
+
+    def test_weighted_unifrac_partial_full(self):
+        # TODO: update npt.assert_almost_equal calls to use DistanceMatrix
+        # near-equality testing when that support is available
+        # expected values calculated by hand
+        dm1 = beta_diversity('weighted_unifrac', self.table1, self.sids1,
+                             otu_ids=self.oids1, tree=self.tree1)
+        dm2 = beta_diversity('weighted_unifrac', self.table1, self.sids1,
+                             otu_ids=self.oids1, tree=self.tree1,
+                             id_pairs=[('A', 'B'), ('A', 'C'), ('B', 'C')])
+
+        self.assertEqual(dm1.shape, (3, 3))
+        self.assertEqual(dm1, dm2)
+        expected_data = [
+            [0.0, 0.1750000, 0.12499999],
+            [0.1750000, 0.0, 0.3000000],
+            [0.12499999, 0.3000000, 0.0]]
+        expected_dm = DistanceMatrix(expected_data, ids=self.sids1)
+        for id1 in self.sids1:
+            for id2 in self.sids1:
+                npt.assert_almost_equal(dm1[id1, id2],
+                                        expected_dm[id1, id2], 6)
+
     def test_weighted_unifrac(self):
         # TODO: update npt.assert_almost_equal calls to use DistanceMatrix
         # near-equality testing when that support is available
@@ -583,30 +623,6 @@ class BetaDiversityTests(TestCase):
                 if id1 != id2:
                     self.assertNotEqual(dm1[id1, id2], dm2[id1, id2])
 
-    def test_partial_pw_duplicate_pairs(self):
-        # confirm that partial pairwise execution fails if duplicate pairs are
-        # observed
-        error_msg = ("Duplicate ID pairs observed.")
-        with self.assertRaisesRegex(ValueError, error_msg):
-            beta_diversity('euclidean', self.table1, ids=self.sids1,
-                           id_pairs=[('A', 'B'), ('A', 'B')])
-
-    def test_partial_pw_duplicate_transpose_pairs(self):
-        # confirm that partial pairwise execution fails if a transpose
-        # duplicate is observed
-        error_msg = ("Duplicate ID pairs observed.")
-        with self.assertRaisesRegex(ValueError, error_msg):
-            beta_diversity('euclidean', self.table1, ids=self.sids1,
-                           id_pairs=[('A', 'B'), ('B', 'A')])
-
-    def test_partial_pw_no_ids(self):
-        # confirm that partial pairwise execution errors when ids are not
-        # specified
-        error_msg = ("`ids` must be specified")
-        with self.assertRaisesRegex(ValueError, error_msg):
-            beta_diversity('euclidean', self.table1, ids=None,
-                           id_pairs=[('a', 'b'), ])
-
     def test_partial_pw_alt_func(self):
         # confirm that partial pairwise execution errors when a pairwise_func
         # is specified
@@ -614,36 +630,6 @@ class BetaDiversityTests(TestCase):
         with self.assertRaisesRegex(ValueError, error_msg):
             beta_diversity('euclidean', self.table1, ids=['a', 'b', 'c'],
                            id_pairs=[('a', 'b'), ], pairwise_func=lambda x: x)
-
-    def test_partial_pw_pairs_not_subset(self):
-        # confirm raise when pairs are not a subset of IDs
-        error_msg = ("`id_pairs` are not a subset of `ids`")
-        with self.assertRaisesRegex(ValueError, error_msg):
-            beta_diversity('euclidean', self.table1, ids=['a', 'b', 'c'],
-                           id_pairs=[('x', 'b'), ])
-
-    def test_partial_pw_matches_pw(self):
-        # confirm that pw execution through partial is identical
-        def euclidean(u, v, **kwargs):
-            return np.sqrt(((u - v)**2).sum())
-
-        actual_dm = beta_diversity(euclidean, self.table2, self.sids2,
-                                   id_pairs=[('A', 'B'),
-                                             ('B', 'F'),
-                                             ('D', 'E')])
-        expected_data = [
-            [0., 80.8455317, 0., 0., 0., 0.],
-            [80.8455317, 0., 0., 0., 0., 14.422205],
-            [0., 0., 0., 0., 0., 0.],
-            [0., 0., 0., 0., 78.7908624, 0.],
-            [0., 0., 0., 78.7908624, 0., 0.],
-            [0., 14.422205, 0., 0., 0., 0.]]
-
-        expected_dm = DistanceMatrix(expected_data, self.sids2)
-        for id1 in self.sids2:
-            for id2 in self.sids2:
-                npt.assert_almost_equal(actual_dm[id1, id2],
-                                        expected_dm[id1, id2], 6)
 
     def test_alt_pairwise_func(self):
         # confirm that pairwise_func is actually being used
@@ -696,6 +682,81 @@ class MetricGetters(TestCase):
         m = get_beta_diversity_metrics()
         n = sorted(list(m))
         self.assertEqual(m, n)
+
+
+class PartialPairwise(TestCase):
+    def setUp(self):
+        self.table1 = [[1, 5],
+                       [2, 3],
+                       [0, 1]]
+        self.sids1 = list('ABC')
+        self.tree1 = TreeNode.read(io.StringIO(
+            '((O1:0.25, O2:0.50):0.25, O3:0.75)root;'))
+        self.oids1 = ['O1', 'O2']
+
+        self.table2 = [[23, 64, 14, 0, 0, 3, 1],
+                       [0, 3, 35, 42, 0, 12, 1],
+                       [0, 5, 5, 0, 40, 40, 0],
+                       [44, 35, 9, 0, 1, 0, 0],
+                       [0, 2, 8, 0, 35, 45, 1],
+                       [0, 0, 25, 35, 0, 19, 0]]
+        self.table2 = np.array(self.table2)
+        self.sids2 = list('ABCDEF')
+
+    def test_duplicate_pairs(self):
+        # confirm that partial pairwise execution fails if duplicate pairs are
+        # observed
+        error_msg = ("Duplicate ID pairs observed.")
+        with self.assertRaisesRegex(ValueError, error_msg):
+            _partial_pw(self.sids1, [('A', 'B'), ('A', 'B')], self.table1,
+                        (lambda x, y: x + y))
+
+    def test_duplicate_transpose_pairs(self):
+        # confirm that partial pairwise execution fails if a transpose
+        # duplicate is observed
+        error_msg = ("Duplicate ID pairs observed.")
+        with self.assertRaisesRegex(ValueError, error_msg):
+            _partial_pw(self.sids1, [('A', 'B'), ('B', 'A')], self.table1,
+                        (lambda x, y: x + y))
+
+    def test_no_ids(self):
+        # confirm that partial pairwise execution errors when ids are not
+        # specified
+        error_msg = ("`ids` must be specified")
+        with self.assertRaisesRegex(ValueError, error_msg):
+            _partial_pw(None, [('a', 'b'), ], self.table1,
+                        (lambda x, y: x + y))
+
+    def test_pairs_not_subset(self):
+        # confirm raise when pairs are not a subset of IDs
+        error_msg = ("`id_pairs` are not a subset of `ids`")
+        with self.assertRaisesRegex(ValueError, error_msg):
+            _partial_pw(['a', 'b', 'c'], [('x', 'b'), ], self.table1,
+                        (lambda x, y: x + y))
+
+    def test_euclidean(self):
+        # confirm that pw execution through partial is identical
+        def euclidean(u, v, **kwargs):
+            return np.sqrt(((u - v)**2).sum())
+
+        id_pairs = [('A', 'B'), ('B', 'F'), ('D', 'E')]
+        actual_dm = _partial_pw(self.sids2, id_pairs, self.table2, euclidean)
+        actual_dm = DistanceMatrix(actual_dm, self.sids2)
+
+        expected_data = [
+            [0., 80.8455317, 0., 0., 0., 0.],
+            [80.8455317, 0., 0., 0., 0., 14.422205],
+            [0., 0., 0., 0., 0., 0.],
+            [0., 0., 0., 0., 78.7908624, 0.],
+            [0., 0., 0., 78.7908624, 0., 0.],
+            [0., 14.422205, 0., 0., 0., 0.]]
+
+        expected_dm = DistanceMatrix(expected_data, self.sids2)
+        for id1 in self.sids2:
+            for id2 in self.sids2:
+                npt.assert_almost_equal(actual_dm[id1, id2],
+                                        expected_dm[id1, id2], 6)
+
 
 if __name__ == "__main__":
     main()

--- a/skbio/diversity/tests/test_driver.py
+++ b/skbio/diversity/tests/test_driver.py
@@ -608,7 +608,10 @@ class BetaDiversityTests(TestCase):
 
     def test_partial_pw_matches_pw(self):
         # confirm that pw execution through partial is identical
-        actual_dm = beta_diversity('euclidean', self.table2, self.sids2,
+        def euclidean(u, v, **kwargs):
+            return np.sqrt(((u - v)**2).sum())
+
+        actual_dm = beta_diversity(euclidean, self.table2, self.sids2,
                                    id_pairs=[('A', 'B'),
                                              ('B', 'F'),
                                              ('D', 'E')])


### PR DESCRIPTION
Addresses #1221.

Specific questions:

* ~~Validation was pushed into `_partial_pw` to not clog `beta_diversity`, is this preferred?~~
* ~~The mechanism for resolving string forms of metrics (e.g., `"euclidean"`) is not [exposed](https://github.com/scipy/scipy/blob/v0.17.0/scipy/spatial/distance.py#L1249) in scipy's `pdist` making it difficult to support scipy-native metrics. Is this a blocker?~~ The method resolution in scipy makes a large number of internal assumptions, and likely requires a fairly substantial PR to scipy in order to even expose `euclidean`. As such, I'd prefer to merge this with support only for skbio metrics and passed in callables, as there is a near-term need for this functionality for UniFrac.  
* ~~The condensed form of the matrix is returned, but it isn't clear if this is absolutely necessary or not. Avoiding it would be nice.~~
* ~~Do we need to assert that duplicate ID pairs are not specified? As written, if both `('a', 'b')` and `('b', 'a')` are provided, it will result in a "doubling" of the distance due to the `dm + dm.T`. One option would be to carry forward `validate`.~~

~~I have not added in tests specifically for `_partial_pw` as resolution of the questions above may result in shuffling of the logic and tests. The tests added so far should exercise all branches, but this PR should not be considered complete until unit tests are added for `_partial_pw`.~~

To dos:

- [x] `_partial_pw` specific unit tests
- [ ] expand example documentation. Would a reviewer please advise on if and where an example should go? I looked at adding to `skbio.diversity.__init__`, but that is already comprehensive and I was concerned about breaking up the flow of the example. 
- [x] add mention in the ChangeLog

:neckbeard: 