### PR TITLE
ENH: partial pairwise beta diversity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Expanded error message in `skbio.io.format.stockholm` reader when `constructor` is not passed, in order to provide better explanation to user. ([#1327](https://github.com/biocore/scikit-bio/issues/1327))
 * Added `skbio.sequence.distance.kmer_distance` for computing the kmer distance between two sequences. ([#913](https://github.com/biocore/scikit-bio/issues/913))
 * Added `skbio.sequence.Sequence.replace` for assigning a character to positions in a `Sequence`. ([#1222](https://github.com/biocore/scikit-bio/issues/1222))
+* Added support for partial pairwise calculations in `skbio.diversity.beta_diversity`. ([#1221](https://github.com/biocore/scikit-bio/issues/1221), [#1337](https://github.com/biocore/scikit-bio/pull/1337))
 
 ### Backward-incompatible changes [stable]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,10 @@
 * Added `skbio.sequence.Sequence.replace` for assigning a character to positions in a `Sequence`. ([#1222](https://github.com/biocore/scikit-bio/issues/1222))
 * Added support for `pandas.RangeIndex`, lowering the memory footprint of default integer index objects. `Sequence.positional_metadata` and `TabularMSA.positional_metadata` now use `pd.RangeIndex` as the positional metadata index. `TabularMSA` now uses `pd.RangeIndex` as the default index. Usage of `pd.RangeIndex` over the previous `pd.Int64Index` [should be transparent](http://pandas.pydata.org/pandas-docs/version/0.18.0/whatsnew.html#range-index), so these changes should be non-breaking to users. scikit-bio now depends on pandas >= 0.18.0 ([#1308](https://github.com/biocore/scikit-bio/issues/1308))
 * Added `reset_index=False` parameter to `TabularMSA.append` and `TabularMSA.extend` for resetting the MSA's index to the default index after appending/extending.
-* Added support for partial pairwise calculations in `skbio.diversity.beta_diversity`. ([#1221](https://github.com/biocore/scikit-bio/issues/1221), [#1337](https://github.com/biocore/scikit-bio/pull/1337))
+* Added support for partial pairwise calculations in `skbio.diversity.beta_diversity` via new keyword argument `id_pairs`, which returns an `skbio.stats.distance.PairwiseDistances` object. Multiple `PairwiseDistances` objects can be merged into a full distance matrix with `DistanceMatrix.from_pairwise_distances` ([#1221](https://github.com/biocore/scikit-bio/issues/1221))
+* Added `skbio.stats.distance.PairwiseDistances` class for storing distances between pairs of IDs.
+* Added `DistanceMatrix.from_pairwise_distances` class method for constructing a full `DistanceMatrix` from multiple `PairwiseDistances` objects.
+* `DissimilarityMatrix` and `DistanceMatrix` now have a `repr` that is the same as their existing `str` representation.
 
 ### Backward-incompatible changes [stable]
 

--- a/skbio/diversity/__init__.py
+++ b/skbio/diversity/__init__.py
@@ -377,15 +377,15 @@ Create a matrix containing 6 samples (rows) and 7 OTUs (columns):
    >>> plt.close('all') # not necessary for normal use
    >>> fig = sample_md.boxplot(column='Faith PD', by='body_site')
 
-We can also compute Spearman correlations between all pairs of columns in this
-``DataFrame``. Since our alpha diversity metrics are the only two numeric
-columns (and thus the only columns for which Spearman correlation is relevant),
-this will give us a symmetric 2x2 correlation matrix.
+    We can also compute Spearman correlations between all pairs of columns in
+    this ``DataFrame``. Since our alpha diversity metrics are the only two
+    numeric columns (and thus the only columns for which Spearman correlation
+    is relevant), this will give us a symmetric 2x2 correlation matrix.
 
->>> sample_md.corr(method="spearman")
-               Observed OTUs  Faith PD
-Observed OTUs       1.000000  0.939336
-Faith PD            0.939336  1.000000
+    >>> sample_md.corr(method="spearman")
+                   Observed OTUs  Faith PD
+    Observed OTUs       1.000000  0.939336
+    Faith PD            0.939336  1.000000
 
 """
 

--- a/skbio/diversity/__init__.py
+++ b/skbio/diversity/__init__.py
@@ -377,15 +377,15 @@ Create a matrix containing 6 samples (rows) and 7 OTUs (columns):
    >>> plt.close('all') # not necessary for normal use
    >>> fig = sample_md.boxplot(column='Faith PD', by='body_site')
 
-    We can also compute Spearman correlations between all pairs of columns in
-    this ``DataFrame``. Since our alpha diversity metrics are the only two
-    numeric columns (and thus the only columns for which Spearman correlation
-    is relevant), this will give us a symmetric 2x2 correlation matrix.
+We can also compute Spearman correlations between all pairs of columns in this
+``DataFrame``. Since our alpha diversity metrics are the only two numeric
+columns (and thus the only columns for which Spearman correlation is relevant),
+this will give us a symmetric 2x2 correlation matrix.
 
-    >>> sample_md.corr(method="spearman")
-                   Observed OTUs  Faith PD
-    Observed OTUs       1.000000  0.939336
-    Faith PD            0.939336  1.000000
+>>> sample_md.corr(method="spearman")
+               Observed OTUs  Faith PD
+Observed OTUs       1.000000  0.939336
+Faith PD            0.939336  1.000000
 
 """
 

--- a/skbio/diversity/_driver.py
+++ b/skbio/diversity/_driver.py
@@ -194,11 +194,12 @@ def _partial_pw(ids, id_pairs, counts, metric, **kwargs):
         of OTUs in a given sample.
     ids : iterable of strs
         Identifiers for each sample in ``counts``.
-    id_pairs : iterable of tuple, optional An iterable of tuples of IDs to
-        compare (e.g., ``[('a', 'b'), ('a', 'c'), ...])``. If specified, the
-        set of IDs described must be a subset of ``ids``. ``id_pairs`` is a
-        mutually exclusive argument with ``pairwise_func``. ``metric`` must be
-        resolvable by scikit-bio (e.g., UniFrac methods), or must be callable.
+    id_pairs : iterable of tuple, optional
+        An iterable of tuples of IDs to compare (e.g., ``[('a', 'b'), ('a',
+        'c'), ...])``. If specified, the set of IDs described must be a subset
+        of ``ids``. ``id_pairs`` is a mutually exclusive argument with
+        ``pairwise_func``. ``metric`` must be resolvable by scikit-bio (e.g.,
+        UniFrac methods), or must be callable.
     kwargs : kwargs, optional
         Metric-specific parameters.
 
@@ -214,6 +215,11 @@ def _partial_pw(ids, id_pairs, counts, metric, **kwargs):
         If ``id_pairs`` are not a subset of ``ids``.
         If ``metric`` is not a callable.
         If duplicates are observed in ``id_pairs``.
+
+    See Also
+    --------
+    skbio.diversity.get_beta_diversity_metrics
+
     """
     if ids is None:
         raise ValueError("`ids` must be specified if `id_pairs` is specified")
@@ -275,11 +281,12 @@ def beta_diversity(metric, counts, ids=None, validate=True, pairwise_func=None,
         that can be provided are ``scipy.spatial.distance.pdist`` and
         ``sklearn.metrics.pairwise_distances``. By default,
         ``scipy.spatial.distance.pdist`` will be used.
-    id_pairs : iterable of tuple, optional An iterable of tuples of IDs to
-        compare (e.g., ``[('a', 'b'), ('a', 'c'), ...])``. If specified, the
-        set of IDs described must be a subset of ``ids``. ``id_pairs`` is a
-        mutually exclusive argument with ``pairwise_func``. ``metric`` must be
-        resolvable by scikit-bio (e.g., UniFrac methods), or must be callable.
+    id_pairs : iterable of tuple, optional
+        An iterable of tuples of IDs to compare (e.g., ``[('a', 'b'), ('a',
+        'c'), ...])``. If specified, the set of IDs described must be a subset
+        of ``ids``. ``id_pairs`` is a mutually exclusive argument with
+        ``pairwise_func``. ``metric`` must be resolvable by scikit-bio (e.g.,
+        UniFrac methods), or must be callable.
     kwargs : kwargs, optional
         Metric-specific parameters.
 

--- a/skbio/diversity/_driver.py
+++ b/skbio/diversity/_driver.py
@@ -238,7 +238,7 @@ def _partial_pw(ids, id_pairs, counts, metric, **kwargs):
     for u, v in id_pairs_indexed:
         dm[u, v] = metric(counts[u], counts[v], **kwargs)
 
-    return scipy.spatial.distance.squareform(dm + dm.T)
+    return dm + dm.T
 
 
 @experimental(as_of="0.4.0")

--- a/skbio/diversity/_driver.py
+++ b/skbio/diversity/_driver.py
@@ -205,7 +205,7 @@ def _partial_pw(ids, id_pairs, counts, metric, **kwargs):
     Returns
     -------
     np.array
-        A condensed form of the distance matrix.
+        A square, hollow, matrix of distances between ID pairs.
 
     Raises
     ------

--- a/skbio/diversity/_driver.py
+++ b/skbio/diversity/_driver.py
@@ -182,7 +182,7 @@ def alpha_diversity(metric, counts, ids=None, validate=True, **kwargs):
 
 @experimental(as_of="0.4.0")
 def beta_diversity(metric, counts, ids=None, validate=True, pairwise_func=None,
-                   **kwargs):
+                   id_pairs=None, **kwargs):
     """Compute distances between all pairs of samples
 
     Parameters
@@ -242,6 +242,20 @@ def beta_diversity(metric, counts, ids=None, validate=True, pairwise_func=None,
     """
     if validate:
         counts = _validate_counts_matrix(counts, ids=ids)
+
+    if id_pairs is not None:
+        if ids is None:
+            raise ValueError("`ids` must be specified if `id_pairs` is "
+                             "specified")
+        if pairwise_func is not None:
+            raise ValueError("`pairwise_func` is not compatible with "
+                             "`id_pairs`")
+
+        # flattening list benchmark here
+        # http://stackoverflow.com/a/952952
+        all_ids_in_pairs = {id_ for pair in id_pairs for id_ in pair}
+        if not all_ids_in_pairs.issubset(ids):
+            raise ValueError("`id_pairs` are not a subset of `ids`")
 
     if pairwise_func is None:
         pairwise_func = scipy.spatial.distance.pdist

--- a/skbio/diversity/_driver.py
+++ b/skbio/diversity/_driver.py
@@ -7,6 +7,7 @@
 # ----------------------------------------------------------------------------
 
 import functools
+import itertools
 
 import numpy as np
 import scipy.spatial.distance
@@ -212,18 +213,22 @@ def _partial_pw(ids, id_pairs, counts, metric, **kwargs):
         If ``ids`` are not specified.
         If ``id_pairs`` are not a subset of ``ids``.
         If ``metric`` is not a callable.
+        If duplicates are observed in ``id_pairs``.
     """
     if ids is None:
         raise ValueError("`ids` must be specified if `id_pairs` is specified")
 
-    # flattening list benchmark here
-    # http://stackoverflow.com/a/952952
-    all_ids_in_pairs = {id_ for pair in id_pairs for id_ in pair}
+    all_ids_in_pairs = set(itertools.chain.from_iterable(id_pairs))
     if not all_ids_in_pairs.issubset(ids):
         raise ValueError("`id_pairs` are not a subset of `ids`")
 
+    hashes = {i for i in id_pairs}.union({i[::-1] for i in id_pairs})
+    if len(hashes) != len(id_pairs) * 2:
+        raise ValueError("Duplicate ID pairs observed.")
+
     if isinstance(metric, str):
         # The mechanism for going from str to callable in scipy's pdist is
+        # not exposed
         raise ValueError("`metric` must be callable")
 
     dm = np.zeros((len(ids), len(ids)), dtype=float)

--- a/skbio/diversity/_driver.py
+++ b/skbio/diversity/_driver.py
@@ -182,7 +182,37 @@ def alpha_diversity(metric, counts, ids=None, validate=True, **kwargs):
 
 
 def _partial_pw(ids, id_pairs, counts, metric, **kwargs):
-    """Compute distances only between specified ID pairs"""
+    """Compute distances only between specified ID pairs
+
+    Parameters
+    ----------
+    metric : callable
+        The pairwise distance function to apply.
+    counts : 2D array_like of ints or floats
+        Matrix containing count/abundance data where each row contains counts
+        of OTUs in a given sample.
+    ids : iterable of strs
+        Identifiers for each sample in ``counts``.
+    id_pairs : iterable of tuple, optional An iterable of tuples of IDs to
+        compare (e.g., ``[('a', 'b'), ('a', 'c'), ...])``. If specified, the
+        set of IDs described must be a subset of ``ids``. ``id_pairs`` is a
+        mutually exclusive argument with ``pairwise_func``. ``metric`` must be
+        resolvable by scikit-bio (e.g., UniFrac methods), or must be callable.
+    kwargs : kwargs, optional
+        Metric-specific parameters.
+
+    Returns
+    -------
+    np.array
+        A condensed form of the distance matrix.
+
+    Raises
+    ------
+    ValueError
+        If ``ids`` are not specified.
+        If ``id_pairs`` are not a subset of ``ids``.
+        If ``metric`` is not a callable.
+    """
     if ids is None:
         raise ValueError("`ids` must be specified if `id_pairs` is specified")
 
@@ -240,6 +270,11 @@ def beta_diversity(metric, counts, ids=None, validate=True, pairwise_func=None,
         that can be provided are ``scipy.spatial.distance.pdist`` and
         ``sklearn.metrics.pairwise_distances``. By default,
         ``scipy.spatial.distance.pdist`` will be used.
+    id_pairs : iterable of tuple, optional An iterable of tuples of IDs to
+        compare (e.g., ``[('a', 'b'), ('a', 'c'), ...])``. If specified, the
+        set of IDs described must be a subset of ``ids``. ``id_pairs`` is a
+        mutually exclusive argument with ``pairwise_func``. ``metric`` must be
+        resolvable by scikit-bio (e.g., UniFrac methods), or must be callable.
     kwargs : kwargs, optional
         Metric-specific parameters.
 

--- a/skbio/diversity/tests/test_driver.py
+++ b/skbio/diversity/tests/test_driver.py
@@ -583,6 +583,22 @@ class BetaDiversityTests(TestCase):
                 if id1 != id2:
                     self.assertNotEqual(dm1[id1, id2], dm2[id1, id2])
 
+    def test_partial_pw_duplicate_pairs(self):
+        # confirm that partial pairwise execution fails if duplicate pairs are
+        # observed
+        error_msg = ("Duplicate ID pairs observed.")
+        with self.assertRaisesRegex(ValueError, error_msg):
+            beta_diversity('euclidean', self.table1, ids=self.sids1,
+                           id_pairs=[('A', 'B'), ('A', 'B')])
+
+    def test_partial_pw_duplicate_transpose_pairs(self):
+        # confirm that partial pairwise execution fails if a transpose
+        # duplicate is observed
+        error_msg = ("Duplicate ID pairs observed.")
+        with self.assertRaisesRegex(ValueError, error_msg):
+            beta_diversity('euclidean', self.table1, ids=self.sids1,
+                           id_pairs=[('A', 'B'), ('B', 'A')])
+
     def test_partial_pw_no_ids(self):
         # confirm that partial pairwise execution errors when ids are not
         # specified

--- a/skbio/diversity/tests/test_driver.py
+++ b/skbio/diversity/tests/test_driver.py
@@ -20,6 +20,7 @@ from skbio.diversity import (alpha_diversity, beta_diversity,
                              get_beta_diversity_metrics)
 from skbio.diversity.alpha import faith_pd, observed_otus
 from skbio.diversity.beta import unweighted_unifrac, weighted_unifrac
+from skbio.diversity._driver import _partial_pw
 from skbio.tree import DuplicateNodeError, MissingNodeError
 
 
@@ -529,6 +530,45 @@ class BetaDiversityTests(TestCase):
                 npt.assert_almost_equal(dm1[id1, id2],
                                         expected_dm[id1, id2], 6)
 
+    def test_unweighted_unifrac_partial(self):
+        # TODO: update npt.assert_almost_equal calls to use DistanceMatrix
+        # near-equality testing when that support is available
+        # expected values calculated by hand
+        dm = beta_diversity('unweighted_unifrac', self.table1, self.sids1,
+                            otu_ids=self.oids1, tree=self.tree1,
+                            id_pairs=[('B', 'C'), ])
+        self.assertEqual(dm.shape, (3, 3))
+        expected_data = [[0.0, 0.0, 0.0],
+                         [0.0, 0.0, 0.25],
+                         [0.0, 0.25, 0.0]]
+        expected_dm = DistanceMatrix(expected_data, ids=self.sids1)
+        for id1 in self.sids1:
+            for id2 in self.sids1:
+                npt.assert_almost_equal(dm[id1, id2],
+                                        expected_dm[id1, id2], 6)
+
+    def test_weighted_unifrac_partial_full(self):
+        # TODO: update npt.assert_almost_equal calls to use DistanceMatrix
+        # near-equality testing when that support is available
+        # expected values calculated by hand
+        dm1 = beta_diversity('weighted_unifrac', self.table1, self.sids1,
+                             otu_ids=self.oids1, tree=self.tree1)
+        dm2 = beta_diversity('weighted_unifrac', self.table1, self.sids1,
+                             otu_ids=self.oids1, tree=self.tree1,
+                             id_pairs=[('A', 'B'), ('A', 'C'), ('B', 'C')])
+
+        self.assertEqual(dm1.shape, (3, 3))
+        self.assertEqual(dm1, dm2)
+        expected_data = [
+            [0.0, 0.1750000, 0.12499999],
+            [0.1750000, 0.0, 0.3000000],
+            [0.12499999, 0.3000000, 0.0]]
+        expected_dm = DistanceMatrix(expected_data, ids=self.sids1)
+        for id1 in self.sids1:
+            for id2 in self.sids1:
+                npt.assert_almost_equal(dm1[id1, id2],
+                                        expected_dm[id1, id2], 6)
+
     def test_weighted_unifrac(self):
         # TODO: update npt.assert_almost_equal calls to use DistanceMatrix
         # near-equality testing when that support is available
@@ -583,30 +623,6 @@ class BetaDiversityTests(TestCase):
                 if id1 != id2:
                     self.assertNotEqual(dm1[id1, id2], dm2[id1, id2])
 
-    def test_partial_pw_duplicate_pairs(self):
-        # confirm that partial pairwise execution fails if duplicate pairs are
-        # observed
-        error_msg = ("Duplicate ID pairs observed.")
-        with self.assertRaisesRegex(ValueError, error_msg):
-            beta_diversity('euclidean', self.table1, ids=self.sids1,
-                           id_pairs=[('A', 'B'), ('A', 'B')])
-
-    def test_partial_pw_duplicate_transpose_pairs(self):
-        # confirm that partial pairwise execution fails if a transpose
-        # duplicate is observed
-        error_msg = ("Duplicate ID pairs observed.")
-        with self.assertRaisesRegex(ValueError, error_msg):
-            beta_diversity('euclidean', self.table1, ids=self.sids1,
-                           id_pairs=[('A', 'B'), ('B', 'A')])
-
-    def test_partial_pw_no_ids(self):
-        # confirm that partial pairwise execution errors when ids are not
-        # specified
-        error_msg = ("`ids` must be specified")
-        with self.assertRaisesRegex(ValueError, error_msg):
-            beta_diversity('euclidean', self.table1, ids=None,
-                           id_pairs=[('a', 'b'), ])
-
     def test_partial_pw_alt_func(self):
         # confirm that partial pairwise execution errors when a pairwise_func
         # is specified
@@ -614,36 +630,6 @@ class BetaDiversityTests(TestCase):
         with self.assertRaisesRegex(ValueError, error_msg):
             beta_diversity('euclidean', self.table1, ids=['a', 'b', 'c'],
                            id_pairs=[('a', 'b'), ], pairwise_func=lambda x: x)
-
-    def test_partial_pw_pairs_not_subset(self):
-        # confirm raise when pairs are not a subset of IDs
-        error_msg = ("`id_pairs` are not a subset of `ids`")
-        with self.assertRaisesRegex(ValueError, error_msg):
-            beta_diversity('euclidean', self.table1, ids=['a', 'b', 'c'],
-                           id_pairs=[('x', 'b'), ])
-
-    def test_partial_pw_matches_pw(self):
-        # confirm that pw execution through partial is identical
-        def euclidean(u, v, **kwargs):
-            return np.sqrt(((u - v)**2).sum())
-
-        actual_dm = beta_diversity(euclidean, self.table2, self.sids2,
-                                   id_pairs=[('A', 'B'),
-                                             ('B', 'F'),
-                                             ('D', 'E')])
-        expected_data = [
-            [0., 80.8455317, 0., 0., 0., 0.],
-            [80.8455317, 0., 0., 0., 0., 14.422205],
-            [0., 0., 0., 0., 0., 0.],
-            [0., 0., 0., 0., 78.7908624, 0.],
-            [0., 0., 0., 78.7908624, 0., 0.],
-            [0., 14.422205, 0., 0., 0., 0.]]
-
-        expected_dm = DistanceMatrix(expected_data, self.sids2)
-        for id1 in self.sids2:
-            for id2 in self.sids2:
-                npt.assert_almost_equal(actual_dm[id1, id2],
-                                        expected_dm[id1, id2], 6)
 
     def test_alt_pairwise_func(self):
         # confirm that pairwise_func is actually being used
@@ -696,6 +682,81 @@ class MetricGetters(TestCase):
         m = get_beta_diversity_metrics()
         n = sorted(list(m))
         self.assertEqual(m, n)
+
+
+class PartialPairwise(TestCase):
+    def setUp(self):
+        self.table1 = [[1, 5],
+                       [2, 3],
+                       [0, 1]]
+        self.sids1 = list('ABC')
+        self.tree1 = TreeNode.read(io.StringIO(
+            '((O1:0.25, O2:0.50):0.25, O3:0.75)root;'))
+        self.oids1 = ['O1', 'O2']
+
+        self.table2 = [[23, 64, 14, 0, 0, 3, 1],
+                       [0, 3, 35, 42, 0, 12, 1],
+                       [0, 5, 5, 0, 40, 40, 0],
+                       [44, 35, 9, 0, 1, 0, 0],
+                       [0, 2, 8, 0, 35, 45, 1],
+                       [0, 0, 25, 35, 0, 19, 0]]
+        self.table2 = np.array(self.table2)
+        self.sids2 = list('ABCDEF')
+
+    def test_duplicate_pairs(self):
+        # confirm that partial pairwise execution fails if duplicate pairs are
+        # observed
+        error_msg = ("Duplicate ID pairs observed.")
+        with self.assertRaisesRegex(ValueError, error_msg):
+            _partial_pw(self.sids1, [('A', 'B'), ('A', 'B')], self.table1,
+                        (lambda x, y: x + y))
+
+    def test_duplicate_transpose_pairs(self):
+        # confirm that partial pairwise execution fails if a transpose
+        # duplicate is observed
+        error_msg = ("Duplicate ID pairs observed.")
+        with self.assertRaisesRegex(ValueError, error_msg):
+            _partial_pw(self.sids1, [('A', 'B'), ('B', 'A')], self.table1,
+                        (lambda x, y: x + y))
+
+    def test_no_ids(self):
+        # confirm that partial pairwise execution errors when ids are not
+        # specified
+        error_msg = ("`ids` must be specified")
+        with self.assertRaisesRegex(ValueError, error_msg):
+            _partial_pw(None, [('a', 'b'), ], self.table1,
+                        (lambda x, y: x + y))
+
+    def test_pairs_not_subset(self):
+        # confirm raise when pairs are not a subset of IDs
+        error_msg = ("`id_pairs` are not a subset of `ids`")
+        with self.assertRaisesRegex(ValueError, error_msg):
+            _partial_pw(['a', 'b', 'c'], [('x', 'b'), ], self.table1,
+                        (lambda x, y: x + y))
+
+    def test_euclidean(self):
+        # confirm that pw execution through partial is identical
+        def euclidean(u, v, **kwargs):
+            return np.sqrt(((u - v)**2).sum())
+
+        id_pairs = [('A', 'B'), ('B', 'F'), ('D', 'E')]
+        actual_dm = _partial_pw(self.sids2, id_pairs, self.table2, euclidean)
+        actual_dm = DistanceMatrix(actual_dm, self.sids2)
+
+        expected_data = [
+            [0., 80.8455317, 0., 0., 0., 0.],
+            [80.8455317, 0., 0., 0., 0., 14.422205],
+            [0., 0., 0., 0., 0., 0.],
+            [0., 0., 0., 0., 78.7908624, 0.],
+            [0., 0., 0., 78.7908624, 0., 0.],
+            [0., 14.422205, 0., 0., 0., 0.]]
+
+        expected_dm = DistanceMatrix(expected_data, self.sids2)
+        for id1 in self.sids2:
+            for id2 in self.sids2:
+                npt.assert_almost_equal(actual_dm[id1, id2],
+                                        expected_dm[id1, id2], 6)
+
 
 if __name__ == "__main__":
     main()

--- a/skbio/diversity/tests/test_driver.py
+++ b/skbio/diversity/tests/test_driver.py
@@ -608,7 +608,10 @@ class BetaDiversityTests(TestCase):
 
     def test_partial_pw_matches_pw(self):
         # confirm that pw execution through partial is identical
-        actual_dm = beta_diversity('euclidean', self.table2, self.sids2,
+        def euclidean(u, v, **kwargs):
+            return np.sqrt(((u - v)**2).sum())
+
+        actual_dm = beta_diversity(euclidean, self.table2, self.sids2,
                                    id_pairs=[('A', 'B'),
                                              ('B', 'F'),
                                              ('D', 'E')])

--- a/skbio/metadata/_repr.py
+++ b/skbio/metadata/_repr.py
@@ -14,6 +14,12 @@ from abc import ABCMeta, abstractmethod
 from skbio._base import ElasticLines
 
 
+# TODO: this class name is a misnomer now that `.metadata` and
+# `.positional_metadata` attributes are optional on the repr-d object. Consider
+# refactoring to have a class that builds the metadata portion of the repr, and
+# another class that builds a "scikit-bio-like" repr with class name, headings,
+# stats, and data section (e.g., see repr for Sequence, TabularMSA, and
+# PairwiseDistances).
 class _MetadataReprBuilder(metaclass=ABCMeta):
     """Abstract base class for building  a repr for an object containing
     metadata and/or positional metadata.
@@ -54,7 +60,7 @@ class _MetadataReprBuilder(metaclass=ABCMeta):
         return self._lines.to_str()
 
     def _process_metadata(self):
-        if self._obj.metadata:
+        if hasattr(self._obj, 'metadata') and self._obj.metadata:
             self._lines.add_line('Metadata:')
             # Python 3 doesn't allow sorting of mixed types so we can't just
             # use sorted() on the metadata keys. Sort first by type then sort
@@ -112,7 +118,8 @@ class _MetadataReprBuilder(metaclass=ABCMeta):
         return self._wrap_text_with_indent(value_repr, key_fmt, extra_indent)
 
     def _process_positional_metadata(self):
-        if len(self._obj.positional_metadata.columns):
+        if hasattr(self._obj, 'positional_metadata') and \
+                len(self._obj.positional_metadata.columns):
             self._lines.add_line('Positional metadata:')
             for key in self._obj.positional_metadata.columns.values.tolist():
                 dtype = self._obj.positional_metadata[key].dtype

--- a/skbio/stats/distance/__init__.py
+++ b/skbio/stats/distance/__init__.py
@@ -44,6 +44,7 @@ Classes
 
    DissimilarityMatrix
    DistanceMatrix
+   PairwiseDistances
 
 Functions
 ^^^^^^^^^
@@ -192,13 +193,14 @@ from skbio.util import TestRunner
 from ._base import (DissimilarityMatrixError, DistanceMatrixError,
                     MissingIDError, DissimilarityMatrix, DistanceMatrix,
                     randdm)
+from ._pairwise_distances import PairwiseDistances
 from ._bioenv import bioenv
 from ._anosim import anosim
 from ._permanova import permanova
 from ._mantel import mantel, pwmantel
 
 __all__ = ['DissimilarityMatrixError', 'DistanceMatrixError', 'MissingIDError',
-           'DissimilarityMatrix', 'DistanceMatrix', 'randdm', 'anosim',
-           'permanova', 'bioenv', 'mantel', 'pwmantel']
+           'DissimilarityMatrix', 'DistanceMatrix', 'PairwiseDistances',
+           'randdm', 'anosim', 'permanova', 'bioenv', 'mantel', 'pwmantel']
 
 test = TestRunner(__file__).test

--- a/skbio/stats/distance/_pairwise_distances.py
+++ b/skbio/stats/distance/_pairwise_distances.py
@@ -1,0 +1,446 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2013--, scikit-bio development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+# ----------------------------------------------------------------------------
+
+import collections.abc
+
+import numpy as np
+
+from skbio.util._decorator import experimental
+from ._repr import PairwiseDistancesReprBuilder
+from ._util import is_id_pair
+
+
+class PairwiseDistances(collections.abc.Mapping):
+    """Store distances between pairs of IDs.
+
+    ``PairwiseDistances`` is an immutable, unordered, dict-like structure
+    (``collections.abc.Mapping``) mapping pairs of IDs to distances. The
+    distance between a pair of IDs ("between" distance) must be symmetric, such
+    that the distance between IDs A and B is the same as the distance between
+    IDs B and A. The distance between an ID and itself ("within" distance) must
+    be 0.0 (hollow). It is not necessary to specify "within" distances; they
+    are inferred from the input. Likewise, for "between" distances it is not
+    necessary to specify both ID pair orientations; only one of A vs. B or
+    B vs. A must be supplied, and it does not matter which ordering is used.
+
+    A ``PairwiseDistances`` object can be thought of as a ``DistanceMatrix``
+    where not all pairwise distances are defined.
+    ``DistanceMatrix.from_pairwise_distances`` can be used to construct a
+    ``DistanceMatrix`` from an iterable of ``PairwiseDistances`` objects.
+    ``skbio.diversity.beta_diversity`` can produce a ``PairwiseDistances``
+    object from a set of ID pairs.
+
+    Parameters
+    ----------
+    distances : dict
+        Dictionary mapping pairs of IDs to distances, where each ID pair is a
+        two-element tuple of IDs (strings) mapping to a single distance
+        (float).
+
+    See Also
+    --------
+    skbio.diversity.beta_diversity
+    skbio.stats.distance.DistanceMatrix.from_pairwise_distances
+
+    Examples
+    --------
+    Construct a ``PairwiseDistances`` object from pairs of IDs:
+
+    >>> from skbio.stats.distance import PairwiseDistances
+    >>> pwdist = PairwiseDistances({('A', 'B'): 0.5,
+    ...                             ('A', 'C'): 0.2,
+    ...                             ('D', 'D'): 0.0})
+    >>> pwdist
+    PairwiseDistances
+    --------------------------------------
+    Stats:
+        ID count: 4
+        "Between" distances count: 2
+        Total "between" distances count: 6
+        Percent complete: 33.33%
+    --------------------------------------
+    'A': 2 "between" distances
+    'B': 1 "between" distance
+    'C': 1 "between" distance
+    'D': 0 "between" distances
+
+    There are four IDs, `'A'`, `'B'`, `'C'`, and `'D'`. A full
+    ``DistanceMatrix`` requires six "between" distances, and this
+    ``PairwiseDistances`` object defines two of them (33.33% of the full
+    ``DistanceMatrix`` is present). The number of distances between each ID and
+    the others are also displayed; `'A'` has two "between" distances
+    (A vs. B, A vs. C) while `'B'` and `'C'` each only have a single "between"
+    distance (B vs. A and C vs. A, respectively). `'D'` does not have any
+    "between" distances defined.
+
+    To get the set of IDs defined on the ``PairwiseDistances`` object:
+
+    >>> pwdist.ids == frozenset({'A', 'B', 'C', 'D'})
+    True
+
+    ``PairwiseDistances`` is dict-like, so common dictionary operations may be
+    performed, such as checking whether an ID pair exists:
+
+    >>> ('A', 'C') in pwdist
+    True
+    >>> ('C', 'A') in pwdist
+    True
+    >>> ('B', 'B') in pwdist
+    True
+    >>> ('D', 'D') in pwdist
+    True
+    >>> ('D', 'A') in pwdist
+    False
+    >>> ('A', 'D') in pwdist
+    False
+
+    Note that even though C vs. A was not explicitly provided when constructing
+    ``pwdist`` above, both A vs. C and C vs. A are present and map to the same
+    distance:
+
+    >>> pwdist['A', 'C']
+    0.2
+    >>> pwdist['C', 'A']
+    0.2
+
+    "Within" distances can also be accessed (they are always 0.0):
+
+    >>> pwdist['B', 'B']
+    0.0
+    >>> pwdist['D', 'D']
+    0.0
+
+    Other dict-like operations are supported, such as length-checking and
+    iteration:
+
+    >>> len(pwdist)
+    6
+    >>> sorted(pwdist)
+    [('A', 'A'), ('A', 'B'), ('A', 'C'), ('B', 'B'), ('C', 'C'), ('D', 'D')]
+
+    Note that both the length of and iteration over ``pwdist`` includes both
+    "within" and "between" distances.
+
+    """
+
+    # Make object unhashable. May want to revisit this in the future if there
+    # is a need.
+    __hash__ = None
+
+    # Make object irreversible so that calling reversed(d) raises a TypeError
+    # on a Mapping type instead of producing an incorrect iterator. There's an
+    # open bug in Python and this is (currently) the recommended way of fixing
+    # it: https://bugs.python.org/issue25864
+    __reversed__ = None
+
+    @experimental(as_of="0.4.2-dev")
+    def __init__(self, distances):
+        if not isinstance(distances, dict):
+            raise TypeError("`distances` must be a dict, not type %r"
+                            % type(distances).__name__)
+
+        distances_ = {}
+        ids = set()
+        for id_pair, distance in distances.items():
+            if not is_id_pair(id_pair):
+                raise TypeError(
+                    "Each key in `distances` must be a tuple of exactly two "
+                    "strings, not %r" % (id_pair,))
+
+            if not isinstance(distance, float):
+                raise TypeError(
+                    "Each distance in `distances` must be a float, not type %r"
+                    % type(distance).__name__)
+
+            if np.isnan(distance):
+                raise ValueError("`distances` contains a distance that is NaN")
+
+            id1, id2 = id_pair
+            if id1 == id2:
+                if distance != 0.0:
+                    raise ValueError(
+                        "`distances` contains a nonzero distance between ID "
+                        "%r and itself: %r" % (id1, distance))
+            elif (id2, id1) in distances_:
+                if distance != distances_[(id2, id1)]:
+                    raise ValueError(
+                        "`distances` contains an asymmetric distance between "
+                        "IDs %r and %r: %r != %r" % (id1, id2, distance,
+                                                     distances_[(id2, id1)]))
+            else:
+                distances_[id_pair] = distance
+
+            ids.add(id1)
+            ids.add(id2)
+
+        self._distances = distances_
+        self._ids = frozenset(ids)
+
+    @property
+    @experimental(as_of="0.4.2-dev")
+    def ids(self):
+        """Set of IDs present in this ``PairwiseDistances``.
+
+        Returns
+        -------
+        frozenset
+            Set of IDs present in this ``PairwiseDistances``.
+
+        Notes
+        -----
+        This property is not writeable.
+
+        Examples
+        --------
+        >>> from skbio.stats.distance import PairwiseDistances
+        >>> pwdist = PairwiseDistances({('A', 'B'): 0.1, ('C', 'C'): 0.0})
+        >>> pwdist.ids == frozenset({'A', 'B', 'C'})
+        True
+
+        """
+        return self._ids
+
+    @experimental(as_of="0.4.2-dev")
+    def __bool__(self):
+        """Boolean indicating whether this ``PairwiseDistances`` is empty.
+
+        Returns
+        -------
+        bool
+            ``False`` if there are no "within" or "between" distances, ``True``
+            otherwise.
+
+        Examples
+        --------
+        >>> from skbio.stats.distance import PairwiseDistances
+        >>> pwdist = PairwiseDistances({('A', 'B'): 0.1, ('C', 'C'): 0.0})
+        >>> bool(pwdist)
+        True
+        >>> pwdist = PairwiseDistances({})
+        >>> bool(pwdist)
+        False
+
+        """
+        return len(self) > 0
+
+    @experimental(as_of="0.4.2-dev")
+    def __len__(self):
+        """Number of "within" and "between" pairwise distances.
+
+        Returns
+        -------
+        int
+            Number of "within" and "between" pairwise distances in this
+            ``PairwiseDistances``.
+
+        Examples
+        --------
+        >>> from skbio.stats.distance import PairwiseDistances
+        >>> pwdist = PairwiseDistances({('A', 'B'): 0.1, ('C', 'C'): 0.0})
+        >>> len(pwdist)
+        4
+
+        Note that there are three "within" distances and one "between"
+        distance.
+
+        """
+        return len(self._distances) + len(self.ids)
+
+    @experimental(as_of="0.4.2-dev")
+    def __iter__(self):
+        """Iterate over "within" and "between" ID pairs in no particular order.
+
+        Yields "within" (ID to same ID) and "between" (ID to different ID)
+        ID pairs. Does not yield redundant distances (e.g., only one of A vs.
+        B or B vs. A will be yielded; which ordering is yielded is not
+        guaranteed).
+
+        There is no guaranteed order to how ID pairs are yielded.
+
+        Yields
+        ------
+        tuple
+            Each "within" and "between" ID pair present in this
+            ``PairwiseDistances``.
+
+        Examples
+        --------
+        >>> from skbio.stats.distance import PairwiseDistances
+        >>> pwdist = PairwiseDistances({('A', 'B'): 0.1, ('C', 'C'): 0.0})
+        >>> for id_pair in pwdist:
+        ...     # do something with `id_pair`, such as `pwdist[id_pair]`
+        ...     pass
+
+        """
+        yield from self._distances
+        for id_ in self.ids:
+            yield id_, id_
+
+    @experimental(as_of="0.4.2-dev")
+    def __getitem__(self, id_pair):
+        """Retrieve the distance between a pair of IDs.
+
+        Supports retrieving both "within" and "between" distances.
+
+        Parameters
+        ----------
+        id_pair : tuple
+            Pair of IDs whose distance will be retrieved. Either ordering of
+            IDs is supported, such that A vs. B and B vs. A will return the
+            same distance.
+
+        Returns
+        -------
+        float
+            Distance between IDs in `id_pair`.
+
+        Raises
+        ------
+        TypeError
+            If `id_pair` isn't a tuple of exactly two strings.
+        KeyError
+            If the pair of IDs isn't present in this ``PairwiseDistances``.
+
+        Examples
+        --------
+        >>> from skbio.stats.distance import PairwiseDistances
+        >>> pwdist = PairwiseDistances({('A', 'B'): 0.1, ('C', 'C'): 0.0})
+        >>> pwdist['A', 'B']
+        0.1
+        >>> pwdist['B', 'A']
+        0.1
+        >>> pwdist['A', 'A']
+        0.0
+        >>> pwdist['B', 'B']
+        0.0
+        >>> pwdist['C', 'C']
+        0.0
+
+        """
+        if is_id_pair(id_pair):
+            if id_pair in self._distances:
+                return self._distances[id_pair]
+            elif (id_pair[1], id_pair[0]) in self._distances:
+                return self._distances[id_pair[1], id_pair[0]]
+            elif id_pair[0] == id_pair[1] and id_pair[0] in self.ids:
+                return 0.0
+            else:
+                raise KeyError(id_pair)
+        else:
+            raise TypeError(
+                "`id_pair` must be a tuple of exactly two strings, not %r"
+                % (id_pair,))
+
+    # A generic implementation of __eq__ is provided by collections.abc.Mapping
+    # but we need to provide a different implementation because "between"
+    # distances should compare equal in either orientation (A vs. B, B vs. A).
+    @experimental(as_of="0.4.2-dev")
+    def __eq__(self, other):
+        """Determine if this ``PairwiseDistances`` is equal to another.
+
+        ``PairwiseDistances`` objects are equal if they are the same length and
+        have the same "within" and "between" pairwise distances.
+
+        Parameters
+        ----------
+        other : PairwiseDistances
+            ``PairwiseDistances`` object to test for equality against.
+
+        Returns
+        -------
+        bool
+            Indicates whether this ``PairwiseDistances`` object is equal to
+            `other`.
+
+        See Also
+        --------
+        __ne__
+
+        Examples
+        --------
+        >>> from skbio.stats.distance import PairwiseDistances
+        >>> pwdist1 = PairwiseDistances({('A', 'B'): 0.1})
+        >>> pwdist2 = PairwiseDistances({('B', 'A'): 0.1})
+        >>> pwdist1 == pwdist2
+        True
+
+        Note that the ordering of ID pairs (A vs. B in ``pwdist1``, B vs. A in
+        ``pwdist2``) does not affect the equality of these objects.
+
+        >>> pwdist3 = PairwiseDistances({('B', 'A'): 0.1, ('C', 'C'): 0.0})
+        >>> pwdist2 == pwdist3
+        False
+
+        """
+        if not isinstance(other, PairwiseDistances):
+            return False
+
+        if len(self) != len(other):
+            return False
+
+        for id_pair in self:
+            if id_pair not in other:
+                return False
+            if self[id_pair] != other[id_pair]:
+                return False
+        return True
+
+    @experimental(as_of="0.4.2-dev")
+    def __ne__(self, other):
+        """Determine if this ``PairwiseDistances`` is not equal to another.
+
+        Parameters
+        ----------
+        other : PairwiseDistances
+            ``PairwiseDistances`` object to test for inequality against.
+
+        Returns
+        -------
+        bool
+            Indicates whether this ``PairwiseDistances`` object is not equal to
+            `other`.
+
+        See Also
+        --------
+        __eq__
+
+        """
+        return not (self == other)
+
+    @experimental(as_of="0.4.2-dev")
+    def __repr__(self):
+        """String summary of this ``PairwiseDistances``."""
+        pep8_line_length_limit = 79
+        length_taken_by_docstring_indent = 8
+        width = pep8_line_length_limit - length_taken_by_docstring_indent
+        return PairwiseDistancesReprBuilder(
+            obj=self,
+            width=width,
+            indent=4).build()
+
+    def _repr_stats(self):
+        id_count = len(self.ids)
+        between_count = len(self._distances)
+        total_between_count = int((id_count * (id_count - 1)) / 2)
+        if id_count > 1:
+            percent_complete = between_count / total_between_count
+        else:
+            # No "between" distances.
+            percent_complete = 1.0
+
+        return [
+            ("ID count", str(id_count)),
+            ('"Between" distances count', str(between_count)),
+            ('Total "between" distances count', str(total_between_count)),
+            ("Percent complete", '{:.2%}'.format(percent_complete))
+        ]
+
+    @experimental(as_of="0.4.2-dev")
+    def __str__(self):
+        """String summary of this ``PairwiseDistances``."""
+        return repr(self)

--- a/skbio/stats/distance/_repr.py
+++ b/skbio/stats/distance/_repr.py
@@ -1,0 +1,38 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2013--, scikit-bio development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+# ----------------------------------------------------------------------------
+
+from skbio.metadata._repr import _MetadataReprBuilder
+
+
+class PairwiseDistancesReprBuilder(_MetadataReprBuilder):
+    def _process_header(self):
+        cls_name = self._obj.__class__.__name__
+        self._lines.add_line(cls_name)
+        self._lines.add_separator()
+
+    def _process_data(self):
+        ids = sorted(self._obj.ids)
+        if len(ids) <= 5:
+            self._lines.add_lines(self._format_id_counts(ids))
+        else:
+            self._lines.add_lines(self._format_id_counts(ids[:2]))
+            self._lines.add_line('...')
+            self._lines.add_lines(self._format_id_counts(ids[-2:]))
+
+    def _format_id_counts(self, ids):
+        lines = []
+        for id1 in ids:
+            count = 0
+            for id2 in self._obj.ids:
+                if id1 == id2:
+                    continue
+                if (id1, id2) in self._obj:
+                    count += 1
+            lines.append('%r: %d "between" distance%s' %
+                         (id1, count, '' if count == 1 else 's'))
+        return lines

--- a/skbio/stats/distance/_util.py
+++ b/skbio/stats/distance/_util.py
@@ -1,0 +1,16 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2013--, scikit-bio development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+# ----------------------------------------------------------------------------
+
+
+def is_id_pair(index):
+    return (
+        isinstance(index, tuple) and
+        len(index) == 2 and
+        isinstance(index[0], str) and
+        isinstance(index[1], str)
+    )

--- a/skbio/stats/distance/tests/test_pairwise_distances.py
+++ b/skbio/stats/distance/tests/test_pairwise_distances.py
@@ -1,0 +1,832 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2013--, scikit-bio development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+# ----------------------------------------------------------------------------
+
+import collections.abc
+import types
+import unittest
+
+import numpy as np
+
+from skbio.stats.distance import PairwiseDistances
+from skbio.util._testing import ReallyEqualMixin
+
+
+class TestMappingType(unittest.TestCase):
+    def test_isinstance_empty(self):
+        d = PairwiseDistances({})
+
+        self.assertIsInstance(d, collections.abc.Mapping)
+
+    def test_isinstance_non_empty(self):
+        d = PairwiseDistances({('a', 'b'): 42.0, ('b', 'c'): 43.0})
+
+        self.assertIsInstance(d, collections.abc.Mapping)
+
+    def test_immutable_mapping(self):
+        d = PairwiseDistances({('a', 'b'): 42.0, ('b', 'c'): 43.0})
+
+        self.assertNotIsInstance(d, collections.abc.MutableMapping)
+        with self.assertRaises(TypeError):
+            d[('a', 'b')] = 42.5
+
+
+class TestConstructor(unittest.TestCase):
+    def test_invalid_input_type(self):
+        with self.assertRaisesRegex(TypeError, 'dict.*set'):
+            PairwiseDistances({42.0, 43.0, 44.0})
+
+    def test_invalid_dict_key_type(self):
+        with self.assertRaisesRegex(TypeError, "key.*tuple.*'a'"):
+            PairwiseDistances({'a': 42.0, ('b', 'c'): 43.0})
+
+        with self.assertRaisesRegex(TypeError, "key.*tuple.*('a', 'b', 'c')"):
+            PairwiseDistances({('a', 'b', 'c'): 42.0, ('b', 'c'): 43.0})
+
+    def test_invalid_distance_type(self):
+        with self.assertRaisesRegex(TypeError, 'distance.*float.*str'):
+            PairwiseDistances({('a', 'c'): 'abc', ('b', 'a'): 43.0})
+
+        with self.assertRaisesRegex(TypeError, 'distance.*float.*int'):
+            PairwiseDistances({('a', 'c'): 42, ('b', 'a'): 43.0})
+
+    def test_nan_distance(self):
+        with self.assertRaisesRegex(ValueError, 'distance.*NaN'):
+            PairwiseDistances({('a', 'c'): 42.0, ('b', 'a'): np.nan})
+
+    def test_non_hollow_distances(self):
+        with self.assertRaisesRegex(ValueError, "nonzero distance.*'a'.*42.0"):
+            PairwiseDistances({('a', 'a'): 42.0, ('b', 'a'): 43.0})
+
+    def test_asymmetric_distances(self):
+        with self.assertRaises(ValueError) as cm:
+            PairwiseDistances({('a', 'b'): 42.0, ('b', 'a'): 43.0})
+
+        # Not using assertRaisesRegex because order of IDs isn't guaranteed.
+        error = str(cm.exception)
+        self.assertIn("asymmetric distance", error)
+        self.assertIn("'a'", error)
+        self.assertIn("'b'", error)
+        self.assertIn("42.0", error)
+        self.assertIn("43.0", error)
+
+    def test_empty(self):
+        d = PairwiseDistances({})
+
+        self.assertEqual(d.ids, set())
+        self.assertEqual(len(d), 0)
+
+    def test_single_within_distance(self):
+        d = PairwiseDistances({('abc', 'abc'): 0.0})
+
+        self.assertEqual(d.ids, {'abc'})
+        self.assertEqual(len(d), 1)
+        self.assertEqual(d['abc', 'abc'], 0.0)
+
+    def test_single_between_distance(self):
+        d = PairwiseDistances({('abc', 'x'): 0.9})
+
+        self.assertEqual(d.ids, {'abc', 'x'})
+        self.assertEqual(len(d), 3)
+        self.assertEqual(d['abc', 'abc'], 0.0)
+        self.assertEqual(d['x', 'x'], 0.0)
+        self.assertEqual(d['abc', 'x'], 0.9)
+
+    def test_multiple_distances(self):
+        d = PairwiseDistances({('a', 'b'): 1.0,
+                               ('a', 'c'): 42.5,
+                               ('c', 'd'): 0.0})
+
+        self.assertEqual(d.ids, {'a', 'b', 'c', 'd'})
+        self.assertEqual(len(d), 7)
+        self.assertEqual(d['a', 'a'], 0.0)
+        self.assertEqual(d['b', 'b'], 0.0)
+        self.assertEqual(d['c', 'c'], 0.0)
+        self.assertEqual(d['d', 'd'], 0.0)
+        self.assertEqual(d['a', 'b'], 1.0)
+        self.assertEqual(d['a', 'c'], 42.5)
+        self.assertEqual(d['c', 'd'], 0.0)
+
+    def test_redundant_symmetric_distances(self):
+        d = PairwiseDistances({('a', 'b'): 42.0, ('b', 'a'): 42.0})
+
+        self.assertEqual(d.ids, {'a', 'b'})
+        self.assertEqual(len(d), 3)
+        self.assertEqual(d['a', 'a'], 0.0)
+        self.assertEqual(d['b', 'b'], 0.0)
+        self.assertEqual(d['a', 'b'], 42.0)
+
+    def test_redundant_hollow_distances(self):
+        d = PairwiseDistances({('a', 'a'): 0.0,
+                               ('b', 'a'): 42.0,
+                               ('b', 'b'): 0.0})
+
+        self.assertEqual(d.ids, {'a', 'b'})
+        self.assertEqual(len(d), 3)
+        self.assertEqual(d['a', 'a'], 0.0)
+        self.assertEqual(d['b', 'b'], 0.0)
+        self.assertEqual(d['a', 'b'], 42.0)
+
+    def test_constructor_copies_distances(self):
+        distances = {('a', 'b'): 12.3, ('c', 'b'): 3.21}
+        d = PairwiseDistances(distances)
+
+        # Mutating `distances` dict after constructing PairwiseDistances
+        # shouldn't mutate PairwiseDistances.
+        distances['c', 'b'] = 100.0
+        distances['a', 'd'] = 42.0
+
+        self.assertEqual(d.ids, {'a', 'b', 'c'})
+        self.assertEqual(len(d), 5)
+        self.assertEqual(d['a', 'a'], 0.0)
+        self.assertEqual(d['b', 'b'], 0.0)
+        self.assertEqual(d['c', 'c'], 0.0)
+        self.assertEqual(d['a', 'b'], 12.3)
+        self.assertEqual(d['c', 'b'], 3.21)
+
+
+class TestIDs(unittest.TestCase):
+    def test_return_type(self):
+        d = PairwiseDistances({('a', 'b'): 1.2345})
+
+        self.assertIsInstance(d.ids, frozenset)
+
+    def test_read_only_property(self):
+        d = PairwiseDistances({('a', 'b'): 1.2345})
+
+        self.assertEqual(d.ids, {'a', 'b'})
+
+        with self.assertRaises(AttributeError):
+            d.ids = {'c', 'd'}
+
+        self.assertEqual(d.ids, {'a', 'b'})
+
+    def test_empty(self):
+        d = PairwiseDistances({})
+
+        self.assertEqual(d.ids, set())
+
+    def test_single_within_distance(self):
+        d = PairwiseDistances({('a', 'a'): 0.0})
+
+        self.assertEqual(d.ids, {'a'})
+
+    def test_single_between_distance(self):
+        d = PairwiseDistances({('a', 'b'): 42.0})
+
+        self.assertEqual(d.ids, {'a', 'b'})
+
+    def test_multiple_distances(self):
+        d = PairwiseDistances({('a', 'b'): 1.0,
+                               ('a', 'c'): 42.5,
+                               ('c', 'd'): 0.0,
+                               ('e', 'e'): 0.0})
+
+        self.assertEqual(d.ids, {'a', 'b', 'c', 'd', 'e'})
+
+
+class TestBool(unittest.TestCase):
+    def test_empty(self):
+        d = PairwiseDistances({})
+
+        self.assertFalse(bool(d))
+
+    def test_single_within_distance(self):
+        d = PairwiseDistances({('xyz', 'xyz'): 0.0})
+
+        self.assertTrue(bool(d))
+
+    def test_single_between_distance(self):
+        d = PairwiseDistances({('xyz', '123'): 0.5})
+
+        self.assertTrue(bool(d))
+
+    def test_multiple_distances(self):
+        d = PairwiseDistances({('a', 'b'): 1.0,
+                               ('a', 'c'): 42.5,
+                               ('c', 'd'): 0.0,
+                               ('e', 'e'): 0.0})
+
+        self.assertTrue(bool(d))
+
+
+class TestLen(unittest.TestCase):
+    def test_empty(self):
+        d = PairwiseDistances({})
+
+        self.assertEqual(len(d), 0)
+
+    def test_single_within_distance(self):
+        d = PairwiseDistances({('xyz', 'xyz'): 0.0})
+
+        self.assertEqual(len(d), 1)
+
+    def test_single_between_distance(self):
+        d = PairwiseDistances({('xyz', '123'): 0.5})
+
+        self.assertEqual(len(d), 3)
+
+    def test_multiple_redundant_distances(self):
+        d = PairwiseDistances({('a', 'b'): 1.0,
+                               ('a', 'c'): 42.5,
+                               ('a', 'a'): 0.0,
+                               ('c', 'a'): 42.5,
+                               ('c', 'd'): 0.0,
+                               ('d', 'c'): 0.0,
+                               ('e', 'e'): 0.0})
+
+        self.assertEqual(len(d), 8)
+
+
+class TestIter(unittest.TestCase):
+    def test_return_type(self):
+        d = PairwiseDistances({('a', 'c'): 1.0, ('a', 'd'): 2.0})
+
+        self.assertIsInstance(iter(d), types.GeneratorType)
+
+    def test_empty(self):
+        d = PairwiseDistances({})
+
+        id_pairs = list(iter(d))
+        self.assertEqual(id_pairs, [])
+
+    def test_single_within_distance(self):
+        d = PairwiseDistances({('xyz', 'xyz'): 0.0})
+
+        id_pairs = list(iter(d))
+
+        self.assertEqual(id_pairs, [('xyz', 'xyz')])
+
+    def test_single_between_distance(self):
+        d = PairwiseDistances({('xyz', '123'): 0.5})
+
+        id_pairs = list(iter(d))
+
+        self.assertEqual(len(id_pairs), 3)
+
+        id_pairs = set(id_pairs)
+
+        self.assertEqual(id_pairs, {('xyz', 'xyz'),
+                                    ('123', '123'),
+                                    ('xyz', '123')})
+
+    def test_multiple_redundant_distances(self):
+        d = PairwiseDistances({('a', 'b'): 1.0,
+                               ('a', 'c'): 42.5,
+                               ('a', 'a'): 0.0,
+                               ('c', 'a'): 42.5,
+                               ('c', 'd'): 0.0,
+                               ('e', 'e'): 0.0})
+
+        id_pairs = list(iter(d))
+
+        self.assertEqual(len(id_pairs), 8)
+
+        id_pairs = set(id_pairs)
+
+        exp = {
+            ('a', 'a'),
+            ('b', 'b'),
+            ('c', 'c'),
+            ('d', 'd'),
+            ('e', 'e'),
+            ('a', 'b'),
+            ('c', 'd'),
+        }
+
+        exp1 = exp | {('a', 'c')}
+        exp2 = exp | {('c', 'a')}
+
+        self.assertTrue((id_pairs == exp1) or (id_pairs == exp2))
+
+
+class TestReversed(unittest.TestCase):
+    def test_irreversible(self):
+        d = PairwiseDistances({('c', 'd'): 1.0, ('d', 'e'): 3.0})
+
+        with self.assertRaises(TypeError):
+            reversed(d)
+
+
+class TestHash(unittest.TestCase):
+    def test_unhashable(self):
+        d = PairwiseDistances({('c', 'd'): 1.0, ('d', 'e'): 3.0})
+
+        with self.assertRaises(TypeError):
+            hash(d)
+
+
+class TestGetItem(unittest.TestCase):
+    def test_non_id_pair(self):
+        d = PairwiseDistances({('a', 'b'): 1.0,
+                               ('a', 'c'): 42.5,
+                               ('c', 'd'): 0.0})
+
+        with self.assertRaisesRegex(TypeError, "id_pair.*tuple.*'a'"):
+            d['a']
+
+        with self.assertRaisesRegex(TypeError, 'id_pair.*tuple.*{.*}'):
+            d[{'a', 'b'}]
+
+        with self.assertRaisesRegex(TypeError,
+                                    "id_pair.*tuple.*('a', 'b', 'c')"):
+            d['a', 'b', 'c']
+
+    def test_non_existing_between_distance(self):
+        d = PairwiseDistances({('a', 'b'): 1.0,
+                               ('a', 'c'): 42.5,
+                               ('c', 'd'): 0.0})
+
+        with self.assertRaises(KeyError):
+            d['d', 'a']
+
+        with self.assertRaises(KeyError):
+            d['a', 'd']
+
+    def test_non_existing_within_distance(self):
+        d = PairwiseDistances({('a', 'b'): 1.0,
+                               ('a', 'c'): 42.5,
+                               ('c', 'd'): 0.0})
+
+        with self.assertRaises(KeyError):
+            d['e', 'e']
+
+    def test_empty(self):
+        d = PairwiseDistances({})
+
+        with self.assertRaises(KeyError):
+            d['', '']
+
+        with self.assertRaises(KeyError):
+            d['a', 'b']
+
+    def test_return_type_within_distance(self):
+        d = PairwiseDistances({('a', 'b'): 42.5})
+
+        self.assertIsInstance(d['a', 'a'], float)
+
+    def test_return_type_between_distance(self):
+        d = PairwiseDistances({('a', 'b'): 42.5})
+
+        self.assertIsInstance(d['a', 'b'], float)
+        self.assertIsInstance(d['b', 'a'], float)
+
+    def test_between_distances(self):
+        d = PairwiseDistances({('a', 'b'): 1.0,
+                               ('a', 'c'): 42.5,
+                               ('c', 'd'): 0.0})
+
+        self.assertEqual(d['a', 'b'], 1.0)
+        self.assertEqual(d['b', 'a'], 1.0)
+
+        self.assertEqual(d['a', 'c'], 42.5)
+        self.assertEqual(d['c', 'a'], 42.5)
+
+        self.assertEqual(d['c', 'd'], 0.0)
+        self.assertEqual(d['d', 'c'], 0.0)
+
+    def test_within_distances(self):
+        d = PairwiseDistances({('a', 'b'): 1.0,
+                               ('a', 'c'): 42.5,
+                               ('c', 'd'): 0.0})
+
+        self.assertEqual(d['a', 'a'], 0.0)
+        self.assertEqual(d['b', 'b'], 0.0)
+        self.assertEqual(d['c', 'c'], 0.0)
+        self.assertEqual(d['d', 'd'], 0.0)
+
+
+class TestEq(unittest.TestCase, ReallyEqualMixin):
+    def test_subclass(self):
+        class PairwiseDistancesSubclass(PairwiseDistances):
+            pass
+
+        d1 = PairwiseDistances({})
+        d2 = PairwiseDistancesSubclass({})
+
+        self.assertReallyEqual(d1, d2)
+
+    def test_empty(self):
+        d1 = PairwiseDistances({})
+        d2 = PairwiseDistances({})
+
+        self.assertReallyEqual(d1, d2)
+
+    def test_single_within_distance(self):
+        d1 = PairwiseDistances({('xyz', 'xyz'): 0.0})
+        d2 = PairwiseDistances({('xyz', 'xyz'): 0.0})
+
+        self.assertReallyEqual(d1, d2)
+
+    def test_single_between_distance(self):
+        d1 = PairwiseDistances({('xyz', '123'): 0.5})
+        d2 = PairwiseDistances({('xyz', '123'): 0.5})
+
+        self.assertReallyEqual(d1, d2)
+
+    def test_multiple_distances_partial(self):
+        d1 = PairwiseDistances({('a', 'b'): 0.5, ('a', 'c'): 42.0})
+        d2 = PairwiseDistances({('a', 'b'): 0.5, ('a', 'c'): 42.0})
+
+        self.assertReallyEqual(d1, d2)
+
+    def test_multiple_distances_full(self):
+        d1 = PairwiseDistances({('a', 'b'): 0.5,
+                                ('a', 'c'): 42.0,
+                                ('b', 'c'): 0.9})
+        d2 = PairwiseDistances({('a', 'b'): 0.5,
+                                ('a', 'c'): 42.0,
+                                ('b', 'c'): 0.9})
+
+        self.assertReallyEqual(d1, d2)
+
+    def test_isomorphic_id_pairs(self):
+        d1 = PairwiseDistances({('a', 'b'): 0.5,
+                                ('a', 'c'): 42.0,
+                                ('b', 'd'): 0.9})
+        d2 = PairwiseDistances({('b', 'a'): 0.5,
+                                ('c', 'a'): 42.0,
+                                ('d', 'b'): 0.9})
+
+        self.assertReallyEqual(d1, d2)
+
+    def test_redundant_isomorphic_distances(self):
+        d1 = PairwiseDistances({('a', 'b'): 0.5,
+                                ('a', 'c'): 42.0})
+        d2 = PairwiseDistances({('a', 'b'): 0.5,
+                                ('b', 'a'): 0.5,
+                                ('a', 'c'): 42.0,
+                                ('c', 'a'): 42.0,
+                                ('a', 'a'): 0.0,
+                                ('b', 'b'): 0.0,
+                                ('c', 'c'): 0.0})
+
+        self.assertReallyEqual(d1, d2)
+
+
+class TestNe(unittest.TestCase, ReallyEqualMixin):
+    def test_different_type(self):
+        d = PairwiseDistances({})
+
+        self.assertReallyNotEqual(d, {})
+
+    def test_different_length(self):
+        d1 = PairwiseDistances({})
+        d2 = PairwiseDistances({('a', 'a'): 0.0})
+
+        self.assertReallyNotEqual(d1, d2)
+
+    def test_different_ids(self):
+        d1 = PairwiseDistances({('a', 'a'): 0.0, ('b', 'b'): 0.0})
+        d2 = PairwiseDistances({('a', 'a'): 0.0, ('c', 'c'): 0.0})
+
+        self.assertReallyNotEqual(d1, d2)
+
+    def test_different_between_distances(self):
+        d1 = PairwiseDistances({('a', 'b'): 42.0, ('a', 'c'): 43.0})
+        d2 = PairwiseDistances({('a', 'b'): 42.0, ('a', 'c'): 44.0})
+
+        self.assertReallyNotEqual(d1, d2)
+
+    def test_different_between_id_pairs(self):
+        d1 = PairwiseDistances({('a', 'b'): 42.0, ('a', 'c'): 43.0})
+        d2 = PairwiseDistances({('a', 'b'): 42.0, ('b', 'c'): 1.0})
+
+        self.assertReallyNotEqual(d1, d2)
+
+
+# Tests for mixin methods provided by ABC and not overridden by
+# PairwiseDistances.
+
+class TestGet(unittest.TestCase):
+    def setUp(self):
+        self.d = PairwiseDistances({('A', 'B'): 42.0, ('A', 'C'): 43.0})
+
+    def test_non_id_pair(self):
+        with self.assertRaisesRegex(TypeError, "`id_pair`.*tuple.*'A'"):
+            self.d.get('A')
+
+    def test_existing_within_distance(self):
+        self.assertEqual(self.d.get(('C', 'C')), 0.0)
+
+    def test_non_existing_within_distance(self):
+        self.assertIsNone(self.d.get(('D', 'D')))
+
+    def test_existing_between_distance(self):
+        self.assertEqual(self.d.get(('A', 'C')), 43.0)
+        self.assertEqual(self.d.get(('C', 'A')), 43.0)
+
+    def test_non_existing_between_distance(self):
+        self.assertIsNone(self.d.get(('B', 'C')))
+        self.assertIsNone(self.d.get(('C', 'B')))
+
+    def test_non_existing_distance_non_default(self):
+        self.assertEqual(self.d.get(('B', 'C'), default='foo'), 'foo')
+        self.assertEqual(self.d.get(('C', 'B'), default='foo'), 'foo')
+
+
+class TestContains(unittest.TestCase):
+    def setUp(self):
+        self.d = PairwiseDistances({('A', 'B'): 42.0, ('A', 'C'): 43.0})
+
+    def test_non_id_pair(self):
+        with self.assertRaisesRegex(TypeError, "`id_pair`.*tuple.*'A'"):
+            'A' in self.d
+
+    def test_exists_within(self):
+        self.assertTrue(('A', 'A') in self.d)
+        self.assertTrue(('B', 'B') in self.d)
+        self.assertTrue(('C', 'C') in self.d)
+
+    def test_not_exists_within(self):
+        self.assertFalse(('D', 'D') in self.d)
+        self.assertFalse(('E', 'E') in self.d)
+
+    def test_exists_between(self):
+        self.assertTrue(('A', 'B') in self.d)
+        self.assertTrue(('B', 'A') in self.d)
+        self.assertTrue(('A', 'C') in self.d)
+        self.assertTrue(('C', 'A') in self.d)
+
+    def test_not_exists_between(self):
+        self.assertFalse(('B', 'C') in self.d)
+        self.assertFalse(('C', 'B') in self.d)
+        self.assertFalse(('X', 'Y') in self.d)
+
+
+class TestKeys(unittest.TestCase):
+    def test_empty(self):
+        d = PairwiseDistances({})
+
+        keys = d.keys()
+
+        self.assertIsInstance(keys, collections.abc.KeysView)
+        self.assertEqual(list(keys), [])
+
+    def test_non_empty(self):
+        d = PairwiseDistances({('A', 'B'): 42.0, ('A', 'C'): 43.0})
+
+        keys = d.keys()
+
+        self.assertIsInstance(keys, collections.abc.KeysView)
+        self.assertEqual(len(keys), 5)
+
+        keys = set(keys)
+        self.assertEqual(
+            keys, {('A', 'B'), ('A', 'C'), ('A', 'A'), ('B', 'B'), ('C', 'C')})
+
+
+class TestItems(unittest.TestCase):
+    def test_empty(self):
+        d = PairwiseDistances({})
+
+        items = d.items()
+
+        self.assertIsInstance(items, collections.abc.ItemsView)
+        self.assertEqual(list(items), [])
+
+    def test_non_empty(self):
+        d = PairwiseDistances({('A', 'B'): 42.0, ('A', 'C'): 43.0})
+
+        items = d.items()
+
+        self.assertIsInstance(items, collections.abc.ItemsView)
+        self.assertEqual(len(items), 5)
+
+        items = sorted(items)
+        self.assertEqual(items, [(('A', 'A'), 0.0),
+                                 (('A', 'B'), 42.0),
+                                 (('A', 'C'), 43.0),
+                                 (('B', 'B'), 0.0),
+                                 (('C', 'C'), 0.0)])
+
+
+class TestValues(unittest.TestCase):
+    def test_empty(self):
+        d = PairwiseDistances({})
+
+        values = d.values()
+
+        self.assertIsInstance(values, collections.abc.ValuesView)
+        self.assertEqual(list(values), [])
+
+    def test_non_empty(self):
+        d = PairwiseDistances({('A', 'B'): 42.0, ('A', 'C'): 43.0})
+
+        values = d.values()
+
+        self.assertIsInstance(values, collections.abc.ValuesView)
+        self.assertEqual(len(values), 5)
+
+        values = sorted(values)
+        self.assertEqual(values, [0.0, 0.0, 0.0, 42.0, 43.0])
+
+
+class TestReprAndStr(unittest.TestCase):
+    # Basic sanity checks -- more extensive testing of formatting and special
+    # cases is performed in PairwiseDistancesReprDoctests below. Here we only
+    # test that pieces of the repr are present. These tests also exercise
+    # coverage in case doctests stop counting towards coverage in the future.
+
+    def test_empty(self):
+        d = PairwiseDistances({})
+
+        obs = repr(d)
+
+        self.assertEqual(obs, str(d))
+        self.assertTrue(obs.startswith('PairwiseDistances'))
+        self.assertIn('ID count: 0', obs)
+        self.assertIn('"Between" distances count: 0', obs)
+
+    def test_single_within_distance(self):
+        d = PairwiseDistances({('A', 'A'): 0.0})
+
+        obs = repr(d)
+
+        self.assertEqual(obs, str(d))
+        self.assertTrue(obs.startswith('PairwiseDistances'))
+        self.assertIn('ID count: 1', obs)
+        self.assertIn('"Between" distances count: 0', obs)
+        self.assertIn("'A': 0", obs)
+
+    def test_single_between_distance(self):
+        d = PairwiseDistances({('A', 'B'): 0.5})
+
+        obs = repr(d)
+
+        self.assertEqual(obs, str(d))
+        self.assertTrue(obs.startswith('PairwiseDistances'))
+        self.assertIn('ID count: 2', obs)
+        self.assertIn('"Between" distances count: 1', obs)
+        self.assertIn("'A': 1", obs)
+        self.assertIn("'B': 1", obs)
+
+    def test_multiple_distances_truncated(self):
+        d = PairwiseDistances({('A', 'B'): 0.5,
+                               ('A', 'C'): 0.4,
+                               ('A', 'D'): 0.9,
+                               ('A', 'E'): 0.9,
+                               ('F', 'G'): 0.9,
+                               ('H', 'I'): 0.9})
+
+        obs = repr(d)
+
+        self.assertEqual(obs, str(d))
+        self.assertTrue(obs.startswith('PairwiseDistances'))
+        self.assertIn('ID count: 9', obs)
+        self.assertIn('"Between" distances count: 6', obs)
+        self.assertIn("'A': 4", obs)
+        self.assertIn("...", obs)
+        self.assertIn("'I': 1", obs)
+
+
+# NOTE: this must be a *separate* class for doctests only (no unit tests). nose
+# will not run the unit tests otherwise.
+#
+# These doctests exercise the correct formatting of PairwiseDistances's repr in
+# a variety of situations. They are more extensive than the unit tests above
+# (TestReprAndStr) but cannot be relied upon for coverage (the unit tests take
+# care of this).
+class PairwiseDistancesReprDoctests:
+    r"""
+    >>> from skbio.stats.distance import PairwiseDistances
+
+    Empty (minimal):
+
+    >>> PairwiseDistances({})
+    PairwiseDistances
+    --------------------------------------
+    Stats:
+        ID count: 0
+        "Between" distances count: 0
+        Total "between" distances count: 0
+        Percent complete: 100.00%
+    --------------------------------------
+
+    Single "within" distance:
+
+    >>> PairwiseDistances({('A', 'A'): 0.0})
+    PairwiseDistances
+    --------------------------------------
+    Stats:
+        ID count: 1
+        "Between" distances count: 0
+        Total "between" distances count: 0
+        Percent complete: 100.00%
+    --------------------------------------
+    'A': 0 "between" distances
+
+    Single "between" distance:
+
+    >>> PairwiseDistances({('A', 'B'): 0.5})
+    PairwiseDistances
+    --------------------------------------
+    Stats:
+        ID count: 2
+        "Between" distances count: 1
+        Total "between" distances count: 1
+        Percent complete: 100.00%
+    --------------------------------------
+    'A': 1 "between" distance
+    'B': 1 "between" distance
+
+    Multiple "within" distances (no "between" distances):
+
+    >>> PairwiseDistances({('ABC', 'ABC'): 0.0,
+    ...                    ('DEF', 'DEF'): 0.0,
+    ...                    ('GHI', 'GHI'): 0.0})
+    PairwiseDistances
+    --------------------------------------
+    Stats:
+        ID count: 3
+        "Between" distances count: 0
+        Total "between" distances count: 3
+        Percent complete: 0.00%
+    --------------------------------------
+    'ABC': 0 "between" distances
+    'DEF': 0 "between" distances
+    'GHI': 0 "between" distances
+
+    Multiple "between" distances (partial):
+
+    >>> PairwiseDistances({('A', 'B'): 0.5, ('A', 'C'): 0.4, ('D', 'D'): 0.0})
+    PairwiseDistances
+    --------------------------------------
+    Stats:
+        ID count: 4
+        "Between" distances count: 2
+        Total "between" distances count: 6
+        Percent complete: 33.33%
+    --------------------------------------
+    'A': 2 "between" distances
+    'B': 1 "between" distance
+    'C': 1 "between" distance
+    'D': 0 "between" distances
+
+    Multiple "between" distances (full):
+
+    >>> PairwiseDistances({('A', 'B'): 0.5, ('A', 'C'): 0.4, ('B', 'C'): 0.9})
+    PairwiseDistances
+    --------------------------------------
+    Stats:
+        ID count: 3
+        "Between" distances count: 3
+        Total "between" distances count: 3
+        Percent complete: 100.00%
+    --------------------------------------
+    'A': 2 "between" distances
+    'B': 2 "between" distances
+    'C': 2 "between" distances
+
+    Five IDs (max untruncated output):
+
+    >>> PairwiseDistances({('A', 'B'): 0.5,
+    ...                    ('B', 'C'): 0.4,
+    ...                    ('C', 'D'): 0.9,
+    ...                    ('D', 'E'): 0.9})
+    PairwiseDistances
+    ---------------------------------------
+    Stats:
+        ID count: 5
+        "Between" distances count: 4
+        Total "between" distances count: 10
+        Percent complete: 40.00%
+    ---------------------------------------
+    'A': 1 "between" distance
+    'B': 2 "between" distances
+    'C': 2 "between" distances
+    'D': 2 "between" distances
+    'E': 1 "between" distance
+
+    More than five IDs (truncated output):
+
+    >>> PairwiseDistances({('A', 'B'): 0.5,
+    ...                    ('A', 'C'): 0.4,
+    ...                    ('A', 'D'): 0.9,
+    ...                    ('A', 'E'): 0.9,
+    ...                    ('F', 'G'): 0.9,
+    ...                    ('H', 'I'): 0.9})
+    PairwiseDistances
+    ---------------------------------------
+    Stats:
+        ID count: 9
+        "Between" distances count: 6
+        Total "between" distances count: 36
+        Percent complete: 16.67%
+    ---------------------------------------
+    'A': 4 "between" distances
+    'B': 1 "between" distance
+    ...
+    'H': 1 "between" distance
+    'I': 1 "between" distance
+
+    """
+    pass
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/skbio/stats/distance/tests/test_util.py
+++ b/skbio/stats/distance/tests/test_util.py
@@ -1,0 +1,41 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2013--, scikit-bio development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+# ----------------------------------------------------------------------------
+
+import unittest
+
+from skbio.stats.distance._util import is_id_pair
+
+
+class TestIsIDPair(unittest.TestCase):
+    def test_positive(self):
+        self.assertTrue(is_id_pair(('', '')))
+        self.assertTrue(is_id_pair(('', '123')))
+        self.assertTrue(is_id_pair(('a', 'b')))
+        self.assertTrue(is_id_pair(('xyz', 'ab')))
+        self.assertTrue(is_id_pair(('xyz', 'xyz')))
+
+    def test_negative_wrong_container_type(self):
+        self.assertFalse(is_id_pair(['abc', 'xyz']))
+        self.assertFalse(is_id_pair({'abc', 'xyz'}))
+        self.assertFalse(is_id_pair('abc'))
+
+    def test_negative_wrong_element_type(self):
+        self.assertFalse(is_id_pair(('xyz', 123)))
+        self.assertFalse(is_id_pair((123, 'xyz')))
+        self.assertFalse(is_id_pair((123, 123)))
+        self.assertFalse(is_id_pair(('abc', 42.5)))
+        self.assertFalse(is_id_pair(('abc', ['xyz'])))
+
+    def test_negative_wrong_length(self):
+        self.assertFalse(is_id_pair(()))
+        self.assertFalse(is_id_pair(('a',)))
+        self.assertFalse(is_id_pair(('a', 'b', 'c')))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Contains commits from #1337.

Adds `skbio.stats.distance.PairwiseDistances` for storing distances between pairs of IDs.

Adds `DistanceMatrix.from_pairwise_distances` for constructing a full distance matrix from multiple `PairwiseDistances` objects.

`skbio.diversity.beta_diversity` returns a `PairwiseDistances` object when supplying `id_pairs` keyword argument.

Fixes #1221.

ping: @wasade @gregcaporaso @ebolyen @josenavas @ElDeveloper 