### PR TITLE
MAINT: explicitly make TabularMSA unhashable

### DIFF
--- a/skbio/alignment/_tabular_msa.py
+++ b/skbio/alignment/_tabular_msa.py
@@ -139,6 +139,7 @@ class TabularMSA(MetadataMixin, PositionalMetadataMixin, SkbioObject):
 
     """
     default_write_format = 'fasta'
+    __hash__ = None
 
     @property
     @experimental(as_of='0.4.1')

--- a/skbio/alignment/tests/test_tabular_msa.py
+++ b/skbio/alignment/tests/test_tabular_msa.py
@@ -6,6 +6,7 @@
 # The full license is in the file COPYING.txt, distributed with this software.
 # ----------------------------------------------------------------------------
 
+import collections
 import copy
 import unittest
 import functools
@@ -3620,6 +3621,15 @@ class TestIsSequenceAxis(unittest.TestCase):
 
     def test_negative_int(self):
         self.assertFalse(self.msa._is_sequence_axis(1))
+
+
+class TestHashable(unittest.TestCase):
+    def test_unhashable_type(self):
+        self.assertNotIsInstance(TabularMSA([]), collections.Hashable)
+
+    def test_unhashable_object(self):
+        with self.assertRaisesRegex(TypeError, 'unhashable'):
+            hash(TabularMSA([]))
 
 
 class TestRepr(unittest.TestCase):


### PR DESCRIPTION
TabularMSA was already unhashable because it defines an `__eq__` without `__hash__`. This commit makes an explicit statement that it is unhashable and includes some unit tests.