### PR TITLE
BUG: fix performance regression by reinstating empty metadata optimizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,8 +34,6 @@ an empty generator.
 
 ### Deprecated functionality [stable]
 * Deprecated use of the term "non-degenerate", in favor of "definite". `GrammaredSequence.nondegenerate_chars`, `GrammaredSequence.nondegenerates`, and `GrammaredSequence.has_nondegenerates` have been renamed to `GrammaredSequence.definite_chars`, `GrammaredSequence.definites`, and `GrammaredSequence.has_definites`, respectively. The old names will be removed in scikit-bio 0.5.2. Relevant affected public classes include `GrammaredSequence`, `DNA`, `RNA`, and `Protein`.
-* Deprecated `Sequence.has_metadata` and `TabularMSA.has_metadata` methods, which will be removed in scikit-bio 0.5.2. Use `bool(obj.metadata)` to determine if the metadata dict is empty.
-* Deprecated `Sequence.has_positional_metadata` and `TabularMSA.has_positional_metadata` methods, which will be removed in scikit-bio 0.5.2. Use `len(obj.positional_metadata.columns)` to determine if positional metadata columns are present, or `obj.positional_metadata.empty` to determine if the positional metadata DataFrame is empty (empty index OR empty columns).
 
 ### Deprecated functionality [experimental]
 * Deprecated function `skbio.util.create_dir`. This function will be removed in scikit-bio 0.5.1. Please use the Python standard library

--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -61,4 +61,5 @@ class BenchmarkSuite:
         dna_seq.gc_content()
 
     def time_search_for_motif_in_gapped(self):
-        dna_seq.find_with_regex(motif_1_regex, ignore=dna_seq.gaps())
+        consume_iterator(
+            dna_seq.find_with_regex(motif_1_regex, ignore=dna_seq.gaps()))

--- a/skbio/_base.py
+++ b/skbio/_base.py
@@ -31,7 +31,7 @@ class SkbioObject(metaclass=abc.ABCMeta):
     """
     @abc.abstractmethod
     def __str__(self):
-        pass
+        raise NotImplementedError
 
 
 class OrdinationResults(SkbioObject):

--- a/skbio/alignment/_indexing.py
+++ b/skbio/alignment/_indexing.py
@@ -82,15 +82,15 @@ class _Indexing(metaclass=ABCMeta):
 
     @abstractmethod
     def is_scalar(self, indexable, axis):
-        pass
+        raise NotImplementedError
 
     @abstractmethod
     def _get_sequence(self, obj, indexable):
-        pass
+        raise NotImplementedError
 
     @abstractmethod
     def _slice_sequences(self, obj, indexable):
-        pass
+        raise NotImplementedError
 
     def _get_position(self, obj, indexable):
         return obj._get_position_(indexable)

--- a/skbio/io/format/stockholm.py
+++ b/skbio/io/format/stockholm.py
@@ -695,64 +695,69 @@ def _tabular_msa_to_stockholm(obj, fh):
     fh.write("# STOCKHOLM 1.0\n")
 
     # Writes GF data to file
-    for gf_feature, gf_feature_data in obj.metadata.items():
-        if gf_feature == 'NH' and isinstance(gf_feature_data, dict):
-            for tree_id, tree in obj.metadata[gf_feature].items():
-                fh.write("#=GF TN %s\n" % tree_id)
-                fh.write("#=GF NH %s\n" % tree)
-        elif gf_feature == 'RN':
-            if not isinstance(gf_feature_data, list):
-                raise StockholmFormatError("Expected 'RN' to contain a list "
-                                           "of reference dictionaries, got %r."
-                                           % gf_feature_data)
-            for ref_num, dictionary in enumerate(gf_feature_data, start=1):
-                if not isinstance(dictionary, dict):
-                    raise StockholmFormatError("Expected reference information"
-                                               " to be stored as a dictionary,"
-                                               " found reference %d stored as "
-                                               "%r."
-                                               % (ref_num,
-                                                  type(dictionary).__name__))
-                fh.write("#=GF RN [%d]\n" % ref_num)
-                for feature in dictionary:
-                    if feature not in _REFERENCE_TAGS:
-                        raise StockholmFormatError("Invalid reference tag %r "
-                                                   "found in reference dictio"
-                                                   "nary %d. Valid reference "
-                                                   "tags are: %s."
-                                                   % (feature, ref_num,
-                                                      ', '.join([
-                                                            tag for tag in
-                                                            _REFERENCE_TAGS])))
-                    fh.write("#=GF %s %s\n" % (feature,
-                                               dictionary[feature]))
-        else:
-            fh.write("#=GF %s %s\n" % (gf_feature, gf_feature_data))
+    if obj.has_metadata():
+        for gf_feature, gf_feature_data in obj.metadata.items():
+            if gf_feature == 'NH' and isinstance(gf_feature_data, dict):
+                for tree_id, tree in gf_feature_data.items():
+                    fh.write("#=GF TN %s\n" % tree_id)
+                    fh.write("#=GF NH %s\n" % tree)
+            elif gf_feature == 'RN':
+                if not isinstance(gf_feature_data, list):
+                    raise StockholmFormatError(
+                        "Expected 'RN' to contain a list of reference "
+                        "dictionaries, got %r." % gf_feature_data)
+
+                for ref_num, dictionary in enumerate(gf_feature_data, start=1):
+                    if not isinstance(dictionary, dict):
+                        raise StockholmFormatError(
+                            "Expected reference information to be stored as a "
+                            "dictionary, found reference %d stored as %r." %
+                            (ref_num, type(dictionary).__name__))
+
+                    fh.write("#=GF RN [%d]\n" % ref_num)
+                    for feature in dictionary:
+                        if feature not in _REFERENCE_TAGS:
+                            formatted_reference_tags = ', '.join(
+                                [tag for tag in _REFERENCE_TAGS])
+                            raise StockholmFormatError(
+                                "Invalid reference tag %r found in reference "
+                                "dictionary %d. Valid reference tags are: %s."
+                                % (feature, ref_num, formatted_reference_tags))
+
+                        fh.write("#=GF %s %s\n" % (feature,
+                                                   dictionary[feature]))
+            else:
+                fh.write("#=GF %s %s\n" % (gf_feature, gf_feature_data))
 
     unpadded_data = []
     # Writes GS data to file, retrieves GR data, and retrieves sequence data
     for seq, seq_name in zip(obj, obj.index):
         seq_name = str(seq_name)
-        for gs_feature, gs_feature_data in seq.metadata.items():
-            fh.write("#=GS %s %s %s\n" % (seq_name, gs_feature,
-                                          gs_feature_data))
+
+        if seq.has_metadata():
+            for gs_feature, gs_feature_data in seq.metadata.items():
+                fh.write("#=GS %s %s %s\n" % (seq_name, gs_feature,
+                                              gs_feature_data))
+
         unpadded_data.append((seq_name, str(seq)))
-        df = _format_positional_metadata(seq.positional_metadata,
-                                         'Sequence-specific positional '
-                                         'metadata (GR)')
-        for gr_feature in df.columns:
-            gr_feature_data = ''.join(df[gr_feature])
-            gr_string = "#=GR %s %s" % (seq_name, gr_feature)
-            unpadded_data.append((gr_string, gr_feature_data))
+        if seq.has_positional_metadata():
+            df = _format_positional_metadata(seq.positional_metadata,
+                                             'Sequence-specific positional '
+                                             'metadata (GR)')
+            for gr_feature in df.columns:
+                gr_feature_data = ''.join(df[gr_feature])
+                gr_string = "#=GR %s %s" % (seq_name, gr_feature)
+                unpadded_data.append((gr_string, gr_feature_data))
 
     # Retrieves GC data
-    df = _format_positional_metadata(obj.positional_metadata,
-                                     'Multiple sequence alignment '
-                                     'positional metadata (GC)')
-    for gc_feature in df.columns:
-        gc_feature_data = ''.join(df[gc_feature])
-        gc_string = "#=GC %s" % gc_feature
-        unpadded_data.append((gc_string, gc_feature_data))
+    if obj.has_positional_metadata():
+        df = _format_positional_metadata(obj.positional_metadata,
+                                         'Multiple sequence alignment '
+                                         'positional metadata (GC)')
+        for gc_feature in df.columns:
+            gc_feature_data = ''.join(df[gc_feature])
+            gc_string = "#=GC %s" % gc_feature
+            unpadded_data.append((gc_string, gc_feature_data))
 
     # Writes GR, GC, and raw data to file with padding
     _write_padded_data(unpadded_data, fh)

--- a/skbio/metadata/_mixin.py
+++ b/skbio/metadata/_mixin.py
@@ -11,7 +11,7 @@ import copy
 
 import pandas as pd
 
-from skbio.util._decorator import stable, deprecated
+from skbio.util._decorator import stable
 
 
 class MetadataMixin(metaclass=abc.ABCMeta):
@@ -60,24 +60,31 @@ class MetadataMixin(metaclass=abc.ABCMeta):
 
         Delete metadata:
 
+        >>> seq.has_metadata()
+        True
         >>> del seq.metadata
         >>> seq.metadata
         {}
+        >>> seq.has_metadata()
+        False
 
         """
+        if self._metadata is None:
+            # Not using setter to avoid copy.
+            self._metadata = {}
         return self._metadata
 
     @metadata.setter
     def metadata(self, metadata):
         if not isinstance(metadata, dict):
-            raise TypeError("metadata must be a dict")
+            raise TypeError("metadata must be a dict, not type %r" %
+                            type(metadata).__name__)
         # Shallow copy.
         self._metadata = metadata.copy()
 
     @metadata.deleter
     def metadata(self):
-        # Not using setter to avoid copy.
-        self._metadata = {}
+        self._metadata = None
 
     @abc.abstractmethod
     def __init__(self, metadata=None):
@@ -85,8 +92,10 @@ class MetadataMixin(metaclass=abc.ABCMeta):
 
     def _init_(self, metadata=None):
         if metadata is None:
-            del self.metadata
+            # Could use deleter but this is less overhead and needs to be fast.
+            self._metadata = None
         else:
+            # Use setter for validation and copy.
             self.metadata = metadata
 
     @abc.abstractmethod
@@ -94,7 +103,17 @@ class MetadataMixin(metaclass=abc.ABCMeta):
         pass
 
     def _eq_(self, other):
-        return self.metadata == other.metadata
+        # We're not simply comparing self.metadata to other.metadata in order
+        # to avoid creating "empty" metadata representations on the objects if
+        # they don't have metadata.
+        if self.has_metadata() and other.has_metadata():
+            return self.metadata == other.metadata
+        elif not (self.has_metadata() or other.has_metadata()):
+            # Both don't have metadata.
+            return True
+        else:
+            # One has metadata while the other does not.
+            return False
 
     @abc.abstractmethod
     def __ne__(self, other):
@@ -108,18 +127,22 @@ class MetadataMixin(metaclass=abc.ABCMeta):
         pass
 
     def _copy_(self):
-        return self.metadata.copy()
+        if self.has_metadata():
+            return self.metadata.copy()
+        else:
+            return None
 
     @abc.abstractmethod
     def __deepcopy__(self, memo):
         pass
 
     def _deepcopy_(self, memo):
-        return copy.deepcopy(self.metadata, memo)
+        if self.has_metadata():
+            return copy.deepcopy(self.metadata, memo)
+        else:
+            return None
 
-    @deprecated(as_of="0.4.2-dev", until="0.5.2",
-                reason="Use `bool(obj.metadata)` to determine if the metadata "
-                       "dict is empty.")
+    @stable(as_of="0.4.0")
     def has_metadata(self):
         """Determine if the object has metadata.
 
@@ -151,7 +174,7 @@ class MetadataMixin(metaclass=abc.ABCMeta):
         True
 
         """
-        return bool(self.metadata)
+        return self._metadata is not None and bool(self.metadata)
 
 
 class PositionalMetadataMixin(metaclass=abc.ABCMeta):
@@ -239,13 +262,21 @@ class PositionalMetadataMixin(metaclass=abc.ABCMeta):
 
         Delete positional metadata:
 
+        >>> seq.has_positional_metadata()
+        True
         >>> del seq.positional_metadata
         >>> seq.positional_metadata
         Empty DataFrame
         Columns: []
         Index: [0, 1, 2, 3]
+        >>> seq.has_positional_metadata()
+        False
 
         """
+        if self._positional_metadata is None:
+            # Not using setter to avoid copy.
+            self._positional_metadata = pd.DataFrame(
+                index=self._get_positional_metadata_index())
         return self._positional_metadata
 
     @positional_metadata.setter
@@ -272,9 +303,7 @@ class PositionalMetadataMixin(metaclass=abc.ABCMeta):
 
     @positional_metadata.deleter
     def positional_metadata(self):
-        # Not using setter to avoid copy.
-        self._positional_metadata = pd.DataFrame(
-                index=self._get_positional_metadata_index())
+        self._positional_metadata = None
 
     def _get_positional_metadata_index(self):
         """Create a memory-efficient integer index for positional metadata."""
@@ -288,8 +317,10 @@ class PositionalMetadataMixin(metaclass=abc.ABCMeta):
 
     def _init_(self, positional_metadata=None):
         if positional_metadata is None:
-            del self.positional_metadata
+            # Could use deleter but this is less overhead and needs to be fast.
+            self._positional_metadata = None
         else:
+            # Use setter for validation and copy.
             self.positional_metadata = positional_metadata
 
     @abc.abstractmethod
@@ -297,7 +328,20 @@ class PositionalMetadataMixin(metaclass=abc.ABCMeta):
         pass
 
     def _eq_(self, other):
-        return self.positional_metadata.equals(other.positional_metadata)
+        # We're not simply comparing self.positional_metadata to
+        # other.positional_metadata in order to avoid creating "empty"
+        # positional metadata representations on the objects if they don't have
+        # positional metadata.
+        if self.has_positional_metadata() and other.has_positional_metadata():
+            return self.positional_metadata.equals(other.positional_metadata)
+        elif not (self.has_positional_metadata() or
+                  other.has_positional_metadata()):
+            # Both don't have positional metadata.
+            return (self._positional_metadata_axis_len_() ==
+                    other._positional_metadata_axis_len_())
+        else:
+            # One has positional metadata while the other does not.
+            return False
 
     @abc.abstractmethod
     def __ne__(self, other):
@@ -311,22 +355,23 @@ class PositionalMetadataMixin(metaclass=abc.ABCMeta):
         pass
 
     def _copy_(self):
-        # deep=True makes a shallow copy of the underlying data buffer.
-        return self.positional_metadata.copy(deep=True)
+        if self.has_positional_metadata():
+            # deep=True makes a shallow copy of the underlying data buffer.
+            return self.positional_metadata.copy(deep=True)
+        else:
+            return None
 
     @abc.abstractmethod
     def __deepcopy__(self, memo):
         pass
 
     def _deepcopy_(self, memo):
-        return copy.deepcopy(self.positional_metadata, memo)
+        if self.has_positional_metadata():
+            return copy.deepcopy(self.positional_metadata, memo)
+        else:
+            return None
 
-    @deprecated(as_of="0.4.2-dev", until="0.5.2",
-                reason="Use `len(obj.positional_metadata.columns)` to "
-                       "determine if positional metadata columns are present, "
-                       "or `obj.positional_metadata.empty` to determine if "
-                       "the positional metadata DataFrame is empty (empty "
-                       "index OR empty columns).")
+    @stable(as_of="0.4.0")
     def has_positional_metadata(self):
         """Determine if the object has positional metadata.
 
@@ -359,4 +404,5 @@ class PositionalMetadataMixin(metaclass=abc.ABCMeta):
         True
 
         """
-        return len(self.positional_metadata.columns) > 0
+        return (self._positional_metadata is not None and
+                len(self.positional_metadata.columns) > 0)

--- a/skbio/metadata/_mixin.py
+++ b/skbio/metadata/_mixin.py
@@ -88,7 +88,7 @@ class MetadataMixin(metaclass=abc.ABCMeta):
 
     @abc.abstractmethod
     def __init__(self, metadata=None):
-        pass
+        raise NotImplementedError
 
     def _init_(self, metadata=None):
         if metadata is None:
@@ -100,7 +100,7 @@ class MetadataMixin(metaclass=abc.ABCMeta):
 
     @abc.abstractmethod
     def __eq__(self, other):
-        pass
+        raise NotImplementedError
 
     def _eq_(self, other):
         # We're not simply comparing self.metadata to other.metadata in order
@@ -117,14 +117,14 @@ class MetadataMixin(metaclass=abc.ABCMeta):
 
     @abc.abstractmethod
     def __ne__(self, other):
-        pass
+        raise NotImplementedError
 
     def _ne_(self, other):
         return not (self == other)
 
     @abc.abstractmethod
     def __copy__(self):
-        pass
+        raise NotImplementedError
 
     def _copy_(self):
         if self.has_metadata():
@@ -134,7 +134,7 @@ class MetadataMixin(metaclass=abc.ABCMeta):
 
     @abc.abstractmethod
     def __deepcopy__(self, memo):
-        pass
+        raise NotImplementedError
 
     def _deepcopy_(self, memo):
         if self.has_metadata():
@@ -188,7 +188,7 @@ class PositionalMetadataMixin(metaclass=abc.ABCMeta):
             Positional metadata axis length.
 
         """
-        pass
+        raise NotImplementedError
 
     @property
     @stable(as_of="0.4.0")
@@ -313,7 +313,7 @@ class PositionalMetadataMixin(metaclass=abc.ABCMeta):
 
     @abc.abstractmethod
     def __init__(self, positional_metadata=None):
-        pass
+        raise NotImplementedError
 
     def _init_(self, positional_metadata=None):
         if positional_metadata is None:
@@ -325,7 +325,7 @@ class PositionalMetadataMixin(metaclass=abc.ABCMeta):
 
     @abc.abstractmethod
     def __eq__(self, other):
-        pass
+        raise NotImplementedError
 
     def _eq_(self, other):
         # We're not simply comparing self.positional_metadata to
@@ -345,14 +345,14 @@ class PositionalMetadataMixin(metaclass=abc.ABCMeta):
 
     @abc.abstractmethod
     def __ne__(self, other):
-        pass
+        raise NotImplementedError
 
     def _ne_(self, other):
         return not (self == other)
 
     @abc.abstractmethod
     def __copy__(self):
-        pass
+        raise NotImplementedError
 
     def _copy_(self):
         if self.has_positional_metadata():
@@ -363,7 +363,7 @@ class PositionalMetadataMixin(metaclass=abc.ABCMeta):
 
     @abc.abstractmethod
     def __deepcopy__(self, memo):
-        pass
+        raise NotImplementedError
 
     def _deepcopy_(self, memo):
         if self.has_positional_metadata():

--- a/skbio/metadata/_repr.py
+++ b/skbio/metadata/_repr.py
@@ -35,10 +35,12 @@ class _MetadataReprBuilder(metaclass=ABCMeta):
     @abstractmethod
     def _process_header(self):
         """Used by `build` Template Method to build header for the repr"""
+        raise NotImplementedError
 
     @abstractmethod
     def _process_data(self):
         """Used by `build` Template Method to build data lines for the repr"""
+        raise NotImplementedError
 
     def build(self):
         """Template method for building the repr"""

--- a/skbio/metadata/_repr.py
+++ b/skbio/metadata/_repr.py
@@ -54,7 +54,7 @@ class _MetadataReprBuilder(metaclass=ABCMeta):
         return self._lines.to_str()
 
     def _process_metadata(self):
-        if self._obj.metadata:
+        if self._obj.has_metadata():
             self._lines.add_line('Metadata:')
             # Python 3 doesn't allow sorting of mixed types so we can't just
             # use sorted() on the metadata keys. Sort first by type then sort
@@ -112,7 +112,7 @@ class _MetadataReprBuilder(metaclass=ABCMeta):
         return self._wrap_text_with_indent(value_repr, key_fmt, extra_indent)
 
     def _process_positional_metadata(self):
-        if len(self._obj.positional_metadata.columns):
+        if self._obj.has_positional_metadata():
             self._lines.add_line('Positional metadata:')
             for key in self._obj.positional_metadata.columns.values.tolist():
                 dtype = self._obj.positional_metadata[key].dtype

--- a/skbio/sequence/_dna.py
+++ b/skbio/sequence/_dna.py
@@ -204,9 +204,17 @@ class DNA(GrammaredSequence, NucleotideMixin,
         """
         seq = self._string.replace(b'T', b'U')
 
+        metadata = None
+        if self.has_metadata():
+            metadata = self.metadata
+
+        positional_metadata = None
+        if self.has_positional_metadata():
+            positional_metadata = self.positional_metadata
+
         # turn off validation because `seq` is guaranteed to be valid
-        return skbio.RNA(seq, metadata=self.metadata,
-                         positional_metadata=self.positional_metadata,
+        return skbio.RNA(seq, metadata=metadata,
+                         positional_metadata=positional_metadata,
                          validate=False)
 
     @stable(as_of="0.4.0")

--- a/skbio/sequence/_genetic_code.py
+++ b/skbio/sequence/_genetic_code.py
@@ -582,8 +582,12 @@ class GeneticCode(SkbioObject):
             elif stop == 'require':
                 self._raise_require_error('stop', reading_frame)
 
+        metadata = None
+        if sequence.has_metadata():
+            metadata = sequence.metadata
+
         # turn off validation because `translated` is guaranteed to be valid
-        return Protein(translated, metadata=sequence.metadata, validate=False)
+        return Protein(translated, metadata=metadata, validate=False)
 
     def _validate_translate_inputs(self, sequence, reading_frame, start, stop):
         if not isinstance(sequence, RNA):

--- a/skbio/sequence/_grammared_sequence.py
+++ b/skbio/sequence/_grammared_sequence.py
@@ -246,7 +246,7 @@ class GrammaredSequence(Sequence, metaclass=GrammaredSequenceMeta):
             Characters defined as gaps.
 
         """
-        pass  # pragma: no cover
+        raise NotImplementedError
 
     @abstractproperty
     @classproperty
@@ -264,7 +264,7 @@ class GrammaredSequence(Sequence, metaclass=GrammaredSequenceMeta):
             Default gap character.
 
         """
-        pass  # pragma: no cover
+        raise NotImplementedError
 
     @classproperty
     @stable(as_of='0.4.0')
@@ -305,7 +305,7 @@ class GrammaredSequence(Sequence, metaclass=GrammaredSequenceMeta):
             Definite characters.
 
         """
-        pass  # pragma: no cover
+        raise NotImplementedError
 
     @abstractproperty
     @classproperty
@@ -320,7 +320,7 @@ class GrammaredSequence(Sequence, metaclass=GrammaredSequenceMeta):
             definite characters it represents.
 
         """
-        pass  # pragma: no cover
+        raise NotImplementedError
 
     @property
     def _motifs(self):

--- a/skbio/sequence/_grammared_sequence.py
+++ b/skbio/sequence/_grammared_sequence.py
@@ -683,11 +683,19 @@ class GrammaredSequence(Sequence, metaclass=GrammaredSequenceMeta):
             else:
                 expansions.append(degen_chars[char])
 
+        metadata = None
+        if self.has_metadata():
+            metadata = self.metadata
+
+        positional_metadata = None
+        if self.has_positional_metadata():
+            positional_metadata = self.positional_metadata
+
         for definite_seq in product(*expansions):
             yield self._constructor(
                 sequence=''.join(definite_seq),
-                metadata=self.metadata,
-                positional_metadata=self.positional_metadata)
+                metadata=metadata,
+                positional_metadata=positional_metadata)
 
     @stable(as_of='0.4.1')
     def to_regex(self):

--- a/skbio/sequence/_nucleotide_mixin.py
+++ b/skbio/sequence/_nucleotide_mixin.py
@@ -71,7 +71,7 @@ class NucleotideMixin(metaclass=ABCMeta):
         the complement of ``A`` is ambiguous. Thanks, nature...
 
         """
-        return set()  # pragma: no cover
+        raise NotImplementedError
 
     @stable(as_of='0.4.0')
     def complement(self, reverse=False):

--- a/skbio/sequence/_nucleotide_mixin.py
+++ b/skbio/sequence/_nucleotide_mixin.py
@@ -145,10 +145,19 @@ class NucleotideMixin(metaclass=ABCMeta):
 
         """
         result = self._complement_lookup[self._bytes]
+
+        metadata = None
+        if self.has_metadata():
+            metadata = self.metadata
+
+        positional_metadata = None
+        if self.has_positional_metadata():
+            positional_metadata = self.positional_metadata
+
         complement = self._constructor(
             sequence=result,
-            metadata=self.metadata,
-            positional_metadata=self.positional_metadata)
+            metadata=metadata,
+            positional_metadata=positional_metadata)
 
         if reverse:
             complement = complement[::-1]

--- a/skbio/sequence/_rna.py
+++ b/skbio/sequence/_rna.py
@@ -204,9 +204,17 @@ class RNA(GrammaredSequence, NucleotideMixin,
         """
         seq = self._string.replace(b'U', b'T')
 
+        metadata = None
+        if self.has_metadata():
+            metadata = self.metadata
+
+        positional_metadata = None
+        if self.has_positional_metadata():
+            positional_metadata = self.positional_metadata
+
         # turn off validation because `seq` is guaranteed to be valid
-        return skbio.DNA(seq, metadata=self.metadata,
-                         positional_metadata=self.positional_metadata,
+        return skbio.DNA(seq, metadata=metadata,
+                         positional_metadata=positional_metadata,
                          validate=False)
 
     @stable(as_of="0.4.0")

--- a/skbio/sequence/tests/test_sequence.py
+++ b/skbio/sequence/tests/test_sequence.py
@@ -1106,6 +1106,13 @@ class TestSequence(TestSequenceBase, ReallyEqualMixin):
         exp = DNA('-G-C-ACC--------GT--')
         self.assertEqual(obs, exp)
 
+    def test_replace_with_bytes(self):
+        seq = Sequence('ABC123')
+
+        obs = seq.replace([1, 3, 5], b'*')
+
+        self.assertEqual(obs, Sequence('A*C*2*'))
+
     def test_replace_invalid_char_for_type_error(self):
         seq = DNA('TAAACGGAACGCTACGTCTG')
         index = self._make_index('01000001101011001001')

--- a/skbio/sequence/tests/test_sequence.py
+++ b/skbio/sequence/tests/test_sequence.py
@@ -709,6 +709,14 @@ class TestSequence(TestSequenceBase, ReallyEqualMixin):
         self.assertEqual(seq[0:4, :-4:-1, 9], eseq)
         self.assertEqual(seq[0:4, :-4:-1, 9:10], eseq)
 
+    def test_getitem_with_tuple_of_mixed_no_metadata(self):
+        seq = Sequence("0123456789abcdef")
+        eseq = Sequence("0123fed9")
+        self.assertEqual(seq[0, 1, 2, 3, 15, 14, 13, 9], eseq)
+        self.assertEqual(seq[0, 1, 2, 3, :-4:-1, 9], eseq)
+        self.assertEqual(seq[0:4, :-4:-1, 9], eseq)
+        self.assertEqual(seq[0:4, :-4:-1, 9:10], eseq)
+
     def test_getitem_with_iterable_of_mixed_has_positional_metadata(self):
         s = "0123456789abcdef"
         length = len(s)


### PR DESCRIPTION
Fixes #1361 by reinstating the empty/missing metadata optimizations that were removed in #1321.

This is not a commit revert because upstream changes have happened since #1321, causing many merge conflicts. We also want to keep some of the changes in #1321 and discard others, so a manual revert was necessary.

The unit tests testing private state to ensure performance have not been reinstated, as this didn't scale (from a development/codebase perspective) and was fragile to implementation details. Now, private state unit tests exist only for the metadata mixin classes, where that private state is defined. Instead of writing private state unit tests for performance, users and developers are encouraged to submit ASV benchmarks if a method is determined to have suboptimal performance when handling missing/empty metadata.

Also improved coverage for abstract properties/methods (in a separate commit). Use `raise NotImplementedError` instead of defining abstract properties/methods with `pass`. Based on http://stackoverflow.com/a/9212387/3776794