### PR TITLE
ENH: Pairwise aligners propagate seq `metadata`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Added `tree_node_class=TreeNode` parameter to `skbio.tree.majority_rule` to support returning consensus trees of type `TreeNode` (the default) or a type that has the same interface as `TreeNode` (e.g. `TreeNode` subclasses) ([#1193](https://github.com/biocore/scikit-bio/pull/1193))
 * `TreeNode.from_linkage_matrix` and `TreeNode.from_taxonomy` now support constructing `TreeNode` subclasses. `TreeNode.bifurcate` now supports `TreeNode` subclasses ([#1193](https://github.com/biocore/scikit-bio/pull/1193))
 * The `ignore_metadata` keyword has been added to `TablueMSA.iter_positions` to improve performance when metadata is not necessary.
+* Pairwise aligners in `skbio.alignment` now propagate per-sequence `metadata` objects (this does not include `positional_metadata`).
 
 ### Backward-incompatible changes [stable]
 

--- a/skbio/alignment/_pairwise.py
+++ b/skbio/alignment/_pairwise.py
@@ -718,10 +718,18 @@ def local_pairwise_align_ssw(sequence1, sequence2, **kwargs):
             (alignment.target_begin, alignment.target_end_optimal)
         ]
 
+    metadata1 = metadata2 = None
+    if sequence1.has_metadata():
+        metadata1 = sequence1.metadata
+    if sequence2.has_metadata():
+        metadata2 = sequence2.metadata
+
     constructor = type(sequence1)
     msa = TabularMSA([
-        constructor(alignment.aligned_query_sequence),
-        constructor(alignment.aligned_target_sequence)
+        constructor(alignment.aligned_query_sequence, metadata=metadata1,
+                    validate=False),
+        constructor(alignment.aligned_target_sequence, metadata=metadata2,
+                    validate=False)
     ])
 
     return msa, alignment.optimal_alignment_score, start_end
@@ -1011,15 +1019,23 @@ def _traceback(traceback_matrix, score_matrix, aln1, aln2, start_row,
             raise ValueError(
                 "Invalid value in traceback matrix: %s" % current_value)
 
-    for i in range(aln1_sequence_count):
-        aligned_seq = ''.join(aligned_seqs1[i][::-1])
+    for i, (aligned_seq, original) in enumerate(zip(aligned_seqs1, aln1)):
+        aligned_seq = ''.join(aligned_seq)[::-1]
         constructor = aln1.dtype
-        aligned_seqs1[i] = constructor(aligned_seq)
+        metadata = None
+        if original.has_metadata():
+            metadata = original.metadata
+        aligned_seqs1[i] = constructor(aligned_seq, metadata=metadata,
+                                       validate=False)
 
-    for i in range(aln2_sequence_count):
-        aligned_seq = ''.join(aligned_seqs2[i][::-1])
+    for i, (aligned_seq, original) in enumerate(zip(aligned_seqs2, aln2)):
+        aligned_seq = ''.join(aligned_seq)[::-1]
         constructor = aln2.dtype
-        aligned_seqs2[i] = constructor(aligned_seq)
+        metadata = None
+        if original.has_metadata():
+            metadata = original.metadata
+        aligned_seqs2[i] = constructor(aligned_seq, metadata=metadata,
+                                       validate=False)
 
     return aligned_seqs1, aligned_seqs2, best_score, current_col, current_row
 

--- a/skbio/alignment/tests/test_pairwise.py
+++ b/skbio/alignment/tests/test_pairwise.py
@@ -220,8 +220,11 @@ class PairwiseAlignmentTests(TestCase):
             Protein("PAWHEAE", metadata={'id': "s2"}),
             gap_open_penalty=10., gap_extend_penalty=5.)
 
-        self.assertEqual(obs_msa, TabularMSA([Protein("HEAGAWGHEE-"),
-                                              Protein("---PAW-HEAE")]))
+        self.assertEqual(
+            obs_msa,
+            TabularMSA([Protein("HEAGAWGHEE-", metadata={'id': "s1"}),
+                        Protein("---PAW-HEAE", metadata={'id': "s2"})]))
+
         self.assertEqual(obs_score, 23.0)
         self.assertEqual(obs_start_end, [(0, 9), (0, 6)])
 
@@ -231,8 +234,11 @@ class PairwiseAlignmentTests(TestCase):
             Protein("PAWHEAE", metadata={'id': "s2"}),
             gap_open_penalty=10., gap_extend_penalty=5.)
 
-        self.assertEqual(obs_msa, TabularMSA([Protein("HEAGAWGHEE-"),
-                                              Protein("---PAW-HEAE")]))
+        self.assertEqual(
+            obs_msa,
+            TabularMSA([Protein("HEAGAWGHEE-", metadata={'id': "s1"}),
+                        Protein("---PAW-HEAE", metadata={'id': "s2"})]))
+
         self.assertEqual(obs_score, 23.0)
         self.assertEqual(obs_start_end, [(0, 9), (0, 6)])
 
@@ -244,9 +250,12 @@ class PairwiseAlignmentTests(TestCase):
             TabularMSA([Protein("PAWHEAE", metadata={'id': "s3"})]),
             gap_open_penalty=10., gap_extend_penalty=5.)
 
-        self.assertEqual(obs_msa, TabularMSA([Protein("HEAGAWGHEE-"),
-                                              Protein("HDAGAWGHDE-"),
-                                              Protein("---PAW-HEAE")]))
+        self.assertEqual(
+            obs_msa,
+            TabularMSA([Protein("HEAGAWGHEE-", metadata={'id': "s1"}),
+                        Protein("HDAGAWGHDE-", metadata={'id': "s2"}),
+                        Protein("---PAW-HEAE", metadata={'id': "s3"})]))
+
         self.assertEqual(obs_score, 21.0)
         self.assertEqual(obs_start_end, [(0, 9), (0, 6)])
 
@@ -329,8 +338,10 @@ class PairwiseAlignmentTests(TestCase):
             Protein("PAWHEAE", metadata={'id': "s2"}),
             gap_open_penalty=10., gap_extend_penalty=5.)
 
-        self.assertEqual(obs_msa, TabularMSA([Protein("AWGHE"),
-                                              Protein("AW-HE")]))
+        self.assertEqual(
+            obs_msa, TabularMSA([Protein("AWGHE", metadata={'id': "s1"}),
+                                 Protein("AW-HE", metadata={'id': "s2"})]))
+
         self.assertEqual(obs_score, 26.0)
         self.assertEqual(obs_start_end, [(4, 8), (1, 4)])
 
@@ -381,8 +392,11 @@ class PairwiseAlignmentTests(TestCase):
             gap_open_penalty=10., gap_extend_penalty=0.5, match_score=5,
             mismatch_score=-4)
 
-        self.assertEqual(obs_msa, TabularMSA([DNA("-GACCTTGACCAGGTACC"),
-                                              DNA("GAACTTTGAC---GTAAC")]))
+        self.assertEqual(
+            obs_msa,
+            TabularMSA([DNA("-GACCTTGACCAGGTACC", metadata={'id': "s1"}),
+                        DNA("GAACTTTGAC---GTAAC", metadata={'id': "s2"})]))
+
         self.assertEqual(obs_score, 32.0)
         self.assertEqual(obs_start_end, [(0, 16), (0, 14)])
 
@@ -394,9 +408,12 @@ class PairwiseAlignmentTests(TestCase):
             gap_open_penalty=10., gap_extend_penalty=0.5, match_score=5,
             mismatch_score=-4)
 
-        self.assertEqual(obs_msa, TabularMSA([DNA("-GACCTTGACCAGGTACC"),
-                                              DNA("-GACCATGACCAGGTACC"),
-                                              DNA("GAACTTTGAC---GTAAC")]))
+        self.assertEqual(
+            obs_msa,
+            TabularMSA([DNA("-GACCTTGACCAGGTACC", metadata={'id': "s1"}),
+                        DNA("-GACCATGACCAGGTACC", metadata={'id': "s2"}),
+                        DNA("GAACTTTGAC---GTAAC", metadata={'id': "s3"})]))
+
         self.assertEqual(obs_score, 27.5)
         self.assertEqual(obs_start_end, [(0, 16), (0, 14)])
 
@@ -441,8 +458,11 @@ class PairwiseAlignmentTests(TestCase):
             gap_open_penalty=10., gap_extend_penalty=5., match_score=5,
             mismatch_score=-4)
 
-        self.assertEqual(obs_msa, TabularMSA([DNA("ACCTTGAC"),
-                                              DNA("ACTTTGAC")]))
+        self.assertEqual(
+            obs_msa,
+            TabularMSA([DNA("ACCTTGAC", metadata={'id': "s1"}),
+                        DNA("ACTTTGAC", metadata={'id': "s2"})]))
+
         self.assertEqual(obs_score, 31.0)
         self.assertEqual(obs_start_end, [(1, 8), (2, 9)])
 
@@ -663,10 +683,11 @@ class PairwiseAlignmentTests(TestCase):
                    [2, 2, 2, 2]]
         tback_m = np.array(tback_m)
         # start at bottom-right
-        expected = ([DNA("ACG-")], [DNA("ACGT")], 1, 0, 0)
+        expected = ([DNA("ACG-", metadata={'id': 'foo'})],
+                    [DNA("ACGT", metadata={'id': 'bar'})], 1, 0, 0)
         actual = _traceback(tback_m, score_m,
-                            TabularMSA([DNA('ACG', metadata={'id': ''})]),
-                            TabularMSA([DNA('ACGT', metadata={'id': ''})]),
+                            TabularMSA([DNA('ACG', metadata={'id': 'foo'})]),
+                            TabularMSA([DNA('ACGT', metadata={'id': 'bar'})]),
                             4, 3)
         self.assertEqual(actual, expected)
 
@@ -684,10 +705,10 @@ class PairwiseAlignmentTests(TestCase):
                    [2, 2, 2, 2]]
         tback_m = np.array(tback_m)
         # start at bottom-right
-        expected = ([DNA("ACG-"),
-                     DNA("ACG-")],
-                    [DNA("ACGT"),
-                     DNA("ACGT")],
+        expected = ([DNA("ACG-", metadata={'id': 's1'}),
+                     DNA("ACG-", metadata={'id': 's2'})],
+                    [DNA("ACGT", metadata={'id': 's3'}),
+                     DNA("ACGT", metadata={'id': 's4'})],
                     1, 0, 0)
         actual = _traceback(tback_m, score_m,
                             TabularMSA([DNA('ACG', metadata={'id': 's1'}),
@@ -698,11 +719,11 @@ class PairwiseAlignmentTests(TestCase):
         self.assertEqual(actual, expected)
 
         # start at highest-score
-        expected = ([DNA("ACG")],
-                    [DNA("ACG")], 6, 0, 0)
+        expected = ([DNA("ACG", metadata={'id': 'foo'})],
+                    [DNA("ACG", metadata={'id': 'bar'})], 6, 0, 0)
         actual = _traceback(tback_m, score_m,
-                            TabularMSA([DNA('ACG', metadata={'id': ''})]),
-                            TabularMSA([DNA('ACGT', metadata={'id': ''})]),
+                            TabularMSA([DNA('ACG', metadata={'id': 'foo'})]),
+                            TabularMSA([DNA('ACGT', metadata={'id': 'bar'})]),
                             3, 3)
         self.assertEqual(actual, expected)
 
@@ -713,11 +734,11 @@ class PairwiseAlignmentTests(TestCase):
                    [2, 2, 2, 1],
                    [2, 2, 2, 2]]
         tback_m = np.array(tback_m)
-        expected = ([DNA("G")],
-                    [DNA("G")], 6, 2, 2)
+        expected = ([DNA("G", metadata={'id': 'a'})],
+                    [DNA("G", metadata={'id': 'a'})], 6, 2, 2)
         actual = _traceback(tback_m, score_m,
-                            TabularMSA([DNA('ACG', metadata={'id': ''})]),
-                            TabularMSA([DNA('ACGT', metadata={'id': ''})]),
+                            TabularMSA([DNA('ACG', metadata={'id': 'a'})]),
+                            TabularMSA([DNA('ACGT', metadata={'id': 'a'})]),
                             3, 3)
         self.assertEqual(actual, expected)
 


### PR DESCRIPTION
Docs in `skbio.alignment` were unaffected. 
Negligible performance change (actually improved because I added `validate=False` which more than offsets the cost of checking for metadata)