### PR TITLE
Treenode prune bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Bug fixes
 
+* `skbio.tree.TreeNode.prune` was not handling a situation in which a parent was validly removed during pruning operations as may happen if the resulting subtree does not include the root.
+
 ### Deprecated functionality [stable]
 
 ### Deprecated functionality [stable]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Bug fixes
 
-* `skbio.tree.TreeNode.prune` was not handling a situation in which a parent was validly removed during pruning operations as may happen if the resulting subtree does not include the root.
+* `skbio.tree.TreeNode.prune` and implicitly `skbio.tree.TreeNode.shear` were not handling a situation in which a parent was validly removed during pruning operations as may happen if the resulting subtree does not include the root. Previously, an `AttributeError` would raise as `parent` would be `None` in this situation. 
 
 ### Deprecated functionality [stable]
 

--- a/skbio/tree/_tree.py
+++ b/skbio/tree/_tree.py
@@ -383,6 +383,21 @@ class TreeNode(SkbioObject):
             if len(node.children) == 1:
                 nodes_to_remove.append(node)
 
+        # clean up the single children nodes
+        for node in nodes_to_remove:
+            child = node.children[0]
+
+            if child.length is None or node.length is None:
+                child.length = child.length or node.length
+            else:
+                child.length += node.length
+
+            if node.parent is None:
+                continue
+
+            node.parent.append(child)
+            node.parent.remove(node)
+
         # if a single descendent from the root, the root adopts the childs
         # properties. we can't "delete" the root as that would be deleting
         # self.
@@ -394,18 +409,6 @@ class TreeNode(SkbioObject):
                     self.__dict__[key] = deepcopy(node_to_copy.__dict__[key])
             self.remove(node_to_copy)
             self.children.extend(node_to_copy.children)
-
-        # clean up the single children nodes
-        for node in nodes_to_remove:
-            child = node.children[0]
-
-            if child.length is None or node.length is None:
-                child.length = child.length or node.length
-            else:
-                child.length += node.length
-
-            node.parent.append(child)
-            node.parent.remove(node)
 
     @experimental(as_of="0.4.0")
     def shear(self, names):

--- a/skbio/tree/tests/test_tree.py
+++ b/skbio/tree/tests/test_tree.py
@@ -306,7 +306,7 @@ class TreeTests(TestCase):
     def test_shear_prune_parent_dropped(self):
         bugtree = "((a,b),((c,d),(e,f)));"
         to_keep = ['c', 'd']
-        exp = "(c,d);"
+        exp = "(c,d);\n"
         obs = str(TreeNode.read(io.StringIO(bugtree)).shear(to_keep))
         self.assertEqual(obs, exp)
 

--- a/skbio/tree/tests/test_tree.py
+++ b/skbio/tree/tests/test_tree.py
@@ -310,6 +310,14 @@ class TreeTests(TestCase):
         obs = str(TreeNode.read(io.StringIO(bugtree)).shear(to_keep))
         self.assertEqual(obs, exp)
 
+    def test_prune_nested_single_descendent(self):
+        bugtree = "(((a,b)));"
+        exp = "(a,b);\n"
+        t = TreeNode.read(io.StringIO(bugtree))
+        t.prune()
+        obs = str(t)
+        self.assertEqual(obs, exp)
+
     def test_prune_root_single_desc(self):
         t = TreeNode.read(["((a,b)c)extra;"])
         exp = "(a,b)c;\n"

--- a/skbio/tree/tests/test_tree.py
+++ b/skbio/tree/tests/test_tree.py
@@ -303,6 +303,13 @@ class TreeTests(TestCase):
         self.assertEqual(len(n.children), 2)
         self.assertNotIn(n, self.simple_t.children)
 
+    def test_shear_prune_parent_dropped(self):
+        bugtree = "((a,b),((c,d),(e,f)));"
+        to_keep = ['c', 'd']
+        exp = "(c,d);"
+        obs = str(TreeNode.read(io.StringIO(bugtree)).shear(to_keep))
+        self.assertEqual(obs, exp)
+
     def test_prune_root_single_desc(self):
         t = TreeNode.read(["((a,b)c)extra;"])
         exp = "(a,b)c;\n"


### PR DESCRIPTION
Found a bug when using `TreeNode.shear` where `TreeNode.prune` could not handle a resulting subtree in which the root was not included. `TreeNode.prune` is called implicitly by `shear`. 