### PR TITLE
ENH: Add DissimiliarityMatrix.from_iterable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,15 @@
 ## Version 0.5.0-dev  (changes since 0.5.0 go here)
 
 ### Features
+* `DissimilarityMatrix` now has a new constructor method called `from_iterable`. ([#1343](https://github.com/biocore/scikit-bio/issues/1343)).
+* `DissimilarityMatrix` now allows non-hollow matrices. ([#1343](https://github.com/biocore/scikit-bio/issues/1343)).
+* `DistanceMatrix.from_iterable` now accepts a `validate=True` parameter. ([#1343](https://github.com/biocore/scikit-bio/issues/1343)).
 
 ### Backward-incompatible changes [stable]
 
 ### Backward-incompatible changes [experimental]
 * Modifying basis handling in `skbio.stats.composition.ilr_inv` prior to checking for orthogonality.  Now the basis is strictly assumed to be in the Aitchison simplex. 
+* `DistanceMatrix.from_iterable` default behavior is now to validate matrix by computing all pairwise distances. Pass `validate=False` to get the previous behavior (no validation, but faster execution).([#1343](https://github.com/biocore/scikit-bio/issues/1343)).
 
 ### Performance enhancements
 * `TreeNode.shear` was rewritten for approximately a 25% performance increase. ([#1399](https://github.com/biocore/scikit-bio/pull/1399))


### PR DESCRIPTION
Moves `from_iterable` definition from `DistanceMatrix` to `DissimilarityMatrix` (`DistanceMatrix` inherits from `DissimilarityMatrix`).

Copied existing `DistanceMatrix` `from_iterable` tests.

Fixes #1343.

Thanks!