### PR TITLE
Fix an error on `pip install`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 ### Bug fixes
 
 * `skbio.tree.TreeNode.prune` and implicitly `skbio.tree.TreeNode.shear` were not handling a situation in which a parent was validly removed during pruning operations as may happen if the resulting subtree does not include the root. Previously, an `AttributeError` would raise as `parent` would be `None` in this situation. 
+* numpy linking was fixed for installation under El Capitan.
 
 ### Deprecated functionality [stable]
 

--- a/setup.py
+++ b/setup.py
@@ -73,13 +73,16 @@ if platform.machine() == 'i686':
 
 extensions = [
     Extension("skbio.stats.__subsample",
-              ["skbio/stats/__subsample" + ext]),
+              ["skbio/stats/__subsample" + ext],
+              include_dirs=[np.get_include()]),
     Extension("skbio.alignment._ssw_wrapper",
               ["skbio/alignment/_ssw_wrapper" + ext,
                "skbio/alignment/_lib/ssw.c"],
-              extra_compile_args=ssw_extra_compile_args),
+              extra_compile_args=ssw_extra_compile_args,
+              include_dirs=[np.get_include()]),
     Extension("skbio.diversity._phylogenetic",
-              ["skbio/diversity/_phylogenetic" + ext])
+              ["skbio/diversity/_phylogenetic" + ext],
+              include_dirs=[np.get_include()])
 ]
 
 if USE_CYTHON:


### PR DESCRIPTION
Closes #1407.

Based on a StackOverflow answer: http://stackoverflow.com/a/14657667/1951857

Sorry that I haven't followed all of the guidelines in `CONTRIBUTING.md`, but this is a pretty quick fix.

It's possible that this the error being fixed is Python3 specific.  This has not been fully tested.