### PR TITLE
Fix compiler error on Windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,8 @@ ext = '.pyx' if USE_CYTHON else '.c'
 # details. This acts as a workaround until the next Python 3 release -- thanks
 # Wolfgang Maier (wolma) for the workaround!
 ssw_extra_compile_args = ['-Wno-error=declaration-after-statement']
+if sys.platform == 'win32':
+    ssw_extra_compile_args = []
 
 # Users with i686 architectures have reported that adding this flag allows
 # SSW to be compiled. See https://github.com/biocore/scikit-bio/issues/409 and


### PR DESCRIPTION
I was able to build a bdist_wheel on Win10 64 and it didn't crash when trying to use the ssw extension (https://github.com/biocore/scikit-bio/issues/702#issuecomment-60054711).
```
Python 3.5.2 (v3.5.2:4def2a2901a5, Jun 25 2016, 22:18:55) [MSC v.1900 64 bit (AMD64)] on win32
Type "help", "copyright", "credits" or "license" for more information.
>>> import skbio
>>> from skbio.alignment._ssw_wrapper import StripedSmithWaterman as ssw
>>> x = ssw('AATTTNGNTTTANTTNGTA')
>>> x('AATTGNTNANTNGNTAATNGT')
{
    'optimal_alignment_score': 10,
    'suboptimal_alignment_score': 0,
    'query_begin': 9,
    'query_end': 18,
    'target_begin': 6,
    'target_end_optimal': 15,
    'target_end_suboptimal': 0,
    'cigar': '10M',
    'query_sequence': 'AATTTNGNTTTANTTNGTA',
    'target_sequence': 'AATTGNTNANTNGNTAATNGT'
}
```