### PR TITLE
Include subpackages in __init__.py #1309

### DIFF
--- a/skbio/__init__.py
+++ b/skbio/__init__.py
@@ -18,8 +18,8 @@ from skbio.alignment import local_pairwise_align_ssw, TabularMSA
 from skbio.tree import TreeNode, nj
 from skbio.io import read, write
 from skbio.stats.ordination import OrdinationResults
-import skbio.diversity
-import skbio.stats.evolve
+import skbio.diversity # noqa
+import skbio.stats.evolve # noqa
 
 __all__ = ['Sequence', 'DNA', 'RNA', 'Protein', 'GeneticCode',
            'DistanceMatrix', 'local_pairwise_align_ssw', 'TabularMSA',

--- a/skbio/__init__.py
+++ b/skbio/__init__.py
@@ -18,7 +18,8 @@ from skbio.alignment import local_pairwise_align_ssw, TabularMSA
 from skbio.tree import TreeNode, nj
 from skbio.io import read, write
 from skbio.stats.ordination import OrdinationResults
-
+import skbio.diversity
+import skbio.stats.evolve
 
 __all__ = ['Sequence', 'DNA', 'RNA', 'Protein', 'GeneticCode',
            'DistanceMatrix', 'local_pairwise_align_ssw', 'TabularMSA',

--- a/skbio/__init__.py
+++ b/skbio/__init__.py
@@ -18,8 +18,8 @@ from skbio.alignment import local_pairwise_align_ssw, TabularMSA
 from skbio.tree import TreeNode, nj
 from skbio.io import read, write
 from skbio.stats.ordination import OrdinationResults
-import skbio.diversity # noqa
-import skbio.stats.evolve # noqa
+import skbio.diversity  # noqa
+import skbio.stats.evolve  # noqa
 
 __all__ = ['Sequence', 'DNA', 'RNA', 'Protein', 'GeneticCode',
            'DistanceMatrix', 'local_pairwise_align_ssw', 'TabularMSA',


### PR DESCRIPTION
Fixes https://github.com/biocore/scikit-bio/issues/1309. the following example no longer fails with an `AttributeError`, all other sub-modules are already accessible:
```
import skbio
skbio.diversity
skbio.stats.evolve
```
Not sure if we want to add to `__all__`, since wildcard imports ( from skbio import * ) should be avoided (PEP8).