### PR TITLE
CI: force matplotlib Agg backend

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ install:
   - source activate env_name
   - pip install -r ci/pip_requirements.txt
   - pip install . --no-deps
-  - 'echo "backend: Agg" > matplotlibrc'
+  - 'echo "backend: Agg" > ci/matplotlibrc'
 script:
   - WITH_COVERAGE=TRUE make test
   - if [ ${MAKE_DOC} ]; then make -C doc clean html; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,6 @@ install:
   - source activate env_name
   - pip install -r ci/pip_requirements.txt
   - pip install . --no-deps
-  - 'echo "backend: Agg" > ci/matplotlibrc'
 script:
   - WITH_COVERAGE=TRUE make test
   - if [ ${MAKE_DOC} ]; then make -C doc clean html; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ install:
   - source activate env_name
   - pip install -r ci/pip_requirements.txt
   - pip install . --no-deps
+  - 'echo "backend: Agg" > matplotlibrc'
 script:
   - WITH_COVERAGE=TRUE make test
   - if [ ${MAKE_DOC} ]; then make -C doc clean html; fi

--- a/ci/matplotlibrc
+++ b/ci/matplotlibrc
@@ -1,0 +1,1 @@
+backend: Agg


### PR DESCRIPTION
The newest versions of qt and pyqt installed with conda are incompatible with matplotlib. Force a non-Qt backend to get Travis builds passing again.