### PR TITLE
fixes issue with paired test

### DIFF
--- a/skbio/stats/power.py
+++ b/skbio/stats/power.py
@@ -1017,7 +1017,7 @@ def _identify_sample_groups(meta, cat, control_cats, order, strict_match):
         m_ids = meta.loc[ids].groupby(cat).groups
         # Checks if samples from the cat groups are represented in those
         # Samples
-        id_vecs = [m_ids[o].values for o in order if o in
+        id_vecs = [m_ids[o] for o in order if o in
                    m_ids]
         # If all groups are represented, the index and results are retained
         if len(id_vecs) == len(order):

--- a/skbio/stats/power.py
+++ b/skbio/stats/power.py
@@ -1017,10 +1017,10 @@ def _identify_sample_groups(meta, cat, control_cats, order, strict_match):
         m_ids = meta.loc[ids].groupby(cat).groups
         # Checks if samples from the cat groups are represented in those
         # Samples
-        ids_vec = id_vecs = [m_ids[o] for o in order if o in
-                             m_ids]
+        id_vecs = [m_ids[o].values for o in order if o in
+                   m_ids]
         # If all groups are represented, the index and results are retained
-        if len(ids_vec) == len(order):
+        if len(id_vecs) == len(order):
             min_vec = np.array([len(v) for v in id_vecs])
             loc_vec = np.arange(0, min_vec.min())
             meta_pairs[i1] = id_vecs

--- a/skbio/stats/tests/test_power.py
+++ b/skbio/stats/tests/test_power.py
@@ -477,9 +477,12 @@ class PowerAnalysisTest(TestCase):
 
     def test__identify_sample_groups_not_strict(self):
         # Defines the know values
-        known_pairs = {0: [['PP'], ['CD', 'NR']],
-                       1: [['MM', 'WM'], ['MH']],
-                       2: [['GW'], ['CB']]}
+        known_pairs = {1: [np.array(['PP'], dtype=object),
+                           np.array(['CD', 'NR'], dtype=object)],
+                       0: [np.array(['MM', 'WM'], dtype=object),
+                           np.array(['MH'], dtype=object)],
+                       2: [np.array(['GW'], dtype=object),
+                           np.array(['CB'], dtype=object)]}
         known_index = np.array([0, 1, 2])
         test_pairs, test_index = _identify_sample_groups(self.meta,
                                                          'INT',
@@ -487,8 +490,10 @@ class PowerAnalysisTest(TestCase):
                                                          order=['N', 'Y'],
                                                          strict_match=False)
         self.assertEqual(known_pairs.keys(), test_pairs.keys())
-        self.assertEqual(sorted(known_pairs.values()),
-                         sorted(test_pairs.values()))
+
+        for k in known_pairs:
+            for i in range(2):
+                npt.assert_array_equal(known_pairs[k][i], test_pairs[k][i])
         npt.assert_array_equal(known_index, test_index)
 
     def test__draw_paired_samples(self):


### PR DESCRIPTION
cleans up code (slightly)
corrects for pandas data typing and improves testing based on arrays
rather than lists

addresses #1436; this looks like a broken test following pandas compatibility

...I did have a bunch of test break associated with `skbio.io.format.tests.test_blast7.TestBlast7Reader`