### PR TITLE
fix a bug in _intersection.pyx

### DIFF
--- a/skbio/metadata/_intersection.c
+++ b/skbio/metadata/_intersection.c
@@ -494,7 +494,7 @@ struct __pyx_obj_5skbio_8metadata_13_intersection_IntervalTree;
 struct __pyx_opt_args_5skbio_8metadata_13_intersection_12IntervalNode_left;
 struct __pyx_opt_args_5skbio_8metadata_13_intersection_12IntervalNode_right;
 
-/* "skbio/metadata/_intersection.pyx":261
+/* "skbio/metadata/_intersection.pyx":263
  * 
  * 
  *     cpdef left(self, position, int n=1, int max_dist=2500):             # <<<<<<<<<<<<<<
@@ -507,7 +507,7 @@ struct __pyx_opt_args_5skbio_8metadata_13_intersection_12IntervalNode_left {
   int max_dist;
 };
 
-/* "skbio/metadata/_intersection.pyx":276
+/* "skbio/metadata/_intersection.pyx":278
  *         return r[:n]
  * 
  *     cpdef right(self, position, int n=1, int max_dist=2500):             # <<<<<<<<<<<<<<
@@ -543,7 +543,7 @@ struct __pyx_obj_5skbio_8metadata_13_intersection_IntervalNode {
 };
 
 
-/* "skbio/metadata/_intersection.pyx":303
+/* "skbio/metadata/_intersection.pyx":305
  * ## ---- Wrappers that retain the old interface -------------------------------
  * 
  * cdef class IntervalObj:             # <<<<<<<<<<<<<<
@@ -560,7 +560,7 @@ struct __pyx_obj_5skbio_8metadata_13_intersection_IntervalObj {
 };
 
 
-/* "skbio/metadata/_intersection.pyx":355
+/* "skbio/metadata/_intersection.pyx":357
  *             return self == other or self > other
  * 
  * cdef class IntervalTree:             # <<<<<<<<<<<<<<
@@ -2877,13 +2877,13 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_12IntervalNode_6inter
  *     find = intersect
  * 
  *     cdef void _intersect( IntervalNode self, int start, int end, list results):             # <<<<<<<<<<<<<<
- *         # Left subtree
- *         if self.cleft is not EmptyNode and self.cleft.maxend > start:
+ *         cdef int send, qend
+ * 
  */
 
 static void __pyx_f_5skbio_8metadata_13_intersection_12IntervalNode__intersect(struct __pyx_obj_5skbio_8metadata_13_intersection_IntervalNode *__pyx_v_self, int __pyx_v_start, int __pyx_v_end, PyObject *__pyx_v_results) {
-  long __pyx_v_send;
-  long __pyx_v_qend;
+  int __pyx_v_send;
+  int __pyx_v_qend;
   __Pyx_RefNannyDeclarations
   int __pyx_t_1;
   int __pyx_t_2;
@@ -2893,10 +2893,10 @@ static void __pyx_f_5skbio_8metadata_13_intersection_12IntervalNode__intersect(s
   int __pyx_t_6;
   __Pyx_RefNannySetupContext("_intersect", 0);
 
-  /* "skbio/metadata/_intersection.pyx":186
- *     cdef void _intersect( IntervalNode self, int start, int end, list results):
+  /* "skbio/metadata/_intersection.pyx":188
+ * 
  *         # Left subtree
- *         if self.cleft is not EmptyNode and self.cleft.maxend > start:             # <<<<<<<<<<<<<<
+ *         if self.cleft is not EmptyNode and self.cleft.maxend >= start:             # <<<<<<<<<<<<<<
  *             self.cleft._intersect( start, end, results )
  *         # This interval
  */
@@ -2907,32 +2907,73 @@ static void __pyx_f_5skbio_8metadata_13_intersection_12IntervalNode__intersect(s
     __pyx_t_1 = __pyx_t_3;
     goto __pyx_L4_bool_binop_done;
   }
-  __pyx_t_3 = ((__pyx_v_self->cleft->maxend > __pyx_v_start) != 0);
+  __pyx_t_3 = ((__pyx_v_self->cleft->maxend >= __pyx_v_start) != 0);
   __pyx_t_1 = __pyx_t_3;
   __pyx_L4_bool_binop_done:;
   if (__pyx_t_1) {
 
-    /* "skbio/metadata/_intersection.pyx":187
+    /* "skbio/metadata/_intersection.pyx":189
  *         # Left subtree
- *         if self.cleft is not EmptyNode and self.cleft.maxend > start:
+ *         if self.cleft is not EmptyNode and self.cleft.maxend >= start:
  *             self.cleft._intersect( start, end, results )             # <<<<<<<<<<<<<<
  *         # This interval
- *         if self.end == self.start:
+ *         if start == end:
  */
     ((struct __pyx_vtabstruct_5skbio_8metadata_13_intersection_IntervalNode *)__pyx_v_self->cleft->__pyx_vtab)->_intersect(__pyx_v_self->cleft, __pyx_v_start, __pyx_v_end, __pyx_v_results);
 
-    /* "skbio/metadata/_intersection.pyx":186
- *     cdef void _intersect( IntervalNode self, int start, int end, list results):
+    /* "skbio/metadata/_intersection.pyx":188
+ * 
  *         # Left subtree
- *         if self.cleft is not EmptyNode and self.cleft.maxend > start:             # <<<<<<<<<<<<<<
+ *         if self.cleft is not EmptyNode and self.cleft.maxend >= start:             # <<<<<<<<<<<<<<
  *             self.cleft._intersect( start, end, results )
  *         # This interval
  */
   }
 
-  /* "skbio/metadata/_intersection.pyx":189
+  /* "skbio/metadata/_intersection.pyx":191
  *             self.cleft._intersect( start, end, results )
  *         # This interval
+ *         if start == end:             # <<<<<<<<<<<<<<
+ *             qend = end
+ *         else:
+ */
+  __pyx_t_1 = ((__pyx_v_start == __pyx_v_end) != 0);
+  if (__pyx_t_1) {
+
+    /* "skbio/metadata/_intersection.pyx":192
+ *         # This interval
+ *         if start == end:
+ *             qend = end             # <<<<<<<<<<<<<<
+ *         else:
+ *             qend = end - 1
+ */
+    __pyx_v_qend = __pyx_v_end;
+
+    /* "skbio/metadata/_intersection.pyx":191
+ *             self.cleft._intersect( start, end, results )
+ *         # This interval
+ *         if start == end:             # <<<<<<<<<<<<<<
+ *             qend = end
+ *         else:
+ */
+    goto __pyx_L6;
+  }
+
+  /* "skbio/metadata/_intersection.pyx":194
+ *             qend = end
+ *         else:
+ *             qend = end - 1             # <<<<<<<<<<<<<<
+ *         if self.end == self.start:
+ *             send = self.end
+ */
+  /*else*/ {
+    __pyx_v_qend = (__pyx_v_end - 1);
+  }
+  __pyx_L6:;
+
+  /* "skbio/metadata/_intersection.pyx":195
+ *         else:
+ *             qend = end - 1
  *         if self.end == self.start:             # <<<<<<<<<<<<<<
  *             send = self.end
  *         else:
@@ -2940,8 +2981,8 @@ static void __pyx_f_5skbio_8metadata_13_intersection_12IntervalNode__intersect(s
   __pyx_t_1 = ((__pyx_v_self->end == __pyx_v_self->start) != 0);
   if (__pyx_t_1) {
 
-    /* "skbio/metadata/_intersection.pyx":190
- *         # This interval
+    /* "skbio/metadata/_intersection.pyx":196
+ *             qend = end - 1
  *         if self.end == self.start:
  *             send = self.end             # <<<<<<<<<<<<<<
  *         else:
@@ -2950,72 +2991,31 @@ static void __pyx_f_5skbio_8metadata_13_intersection_12IntervalNode__intersect(s
     __pyx_t_4 = __pyx_v_self->end;
     __pyx_v_send = __pyx_t_4;
 
-    /* "skbio/metadata/_intersection.pyx":189
- *             self.cleft._intersect( start, end, results )
- *         # This interval
- *         if self.end == self.start:             # <<<<<<<<<<<<<<
- *             send = self.end
- *         else:
- */
-    goto __pyx_L6;
-  }
-
-  /* "skbio/metadata/_intersection.pyx":192
- *             send = self.end
- *         else:
- *             send = self.end - 1             # <<<<<<<<<<<<<<
- *         if start == end:
- *             qend = end
- */
-  /*else*/ {
-    __pyx_v_send = (__pyx_v_self->end - 1);
-  }
-  __pyx_L6:;
-
-  /* "skbio/metadata/_intersection.pyx":193
- *         else:
- *             send = self.end - 1
- *         if start == end:             # <<<<<<<<<<<<<<
- *             qend = end
- *         else:
- */
-  __pyx_t_1 = ((__pyx_v_start == __pyx_v_end) != 0);
-  if (__pyx_t_1) {
-
-    /* "skbio/metadata/_intersection.pyx":194
- *             send = self.end - 1
- *         if start == end:
- *             qend = end             # <<<<<<<<<<<<<<
+    /* "skbio/metadata/_intersection.pyx":195
  *         else:
  *             qend = end - 1
- */
-    __pyx_v_qend = __pyx_v_end;
-
-    /* "skbio/metadata/_intersection.pyx":193
- *         else:
- *             send = self.end - 1
- *         if start == end:             # <<<<<<<<<<<<<<
- *             qend = end
+ *         if self.end == self.start:             # <<<<<<<<<<<<<<
+ *             send = self.end
  *         else:
  */
     goto __pyx_L7;
   }
 
-  /* "skbio/metadata/_intersection.pyx":196
- *             qend = end
+  /* "skbio/metadata/_intersection.pyx":198
+ *             send = self.end
  *         else:
- *             qend = end - 1             # <<<<<<<<<<<<<<
+ *             send = self.end - 1             # <<<<<<<<<<<<<<
  *         if ( send >= start ) and ( self.start <= qend ):
  *             results.append( self.interval )
  */
   /*else*/ {
-    __pyx_v_qend = (__pyx_v_end - 1);
+    __pyx_v_send = (__pyx_v_self->end - 1);
   }
   __pyx_L7:;
 
-  /* "skbio/metadata/_intersection.pyx":197
+  /* "skbio/metadata/_intersection.pyx":199
  *         else:
- *             qend = end - 1
+ *             send = self.end - 1
  *         if ( send >= start ) and ( self.start <= qend ):             # <<<<<<<<<<<<<<
  *             results.append( self.interval )
  *         # Right subtree
@@ -3031,35 +3031,35 @@ static void __pyx_f_5skbio_8metadata_13_intersection_12IntervalNode__intersect(s
   __pyx_L9_bool_binop_done:;
   if (__pyx_t_1) {
 
-    /* "skbio/metadata/_intersection.pyx":198
- *             qend = end - 1
+    /* "skbio/metadata/_intersection.pyx":200
+ *             send = self.end - 1
  *         if ( send >= start ) and ( self.start <= qend ):
  *             results.append( self.interval )             # <<<<<<<<<<<<<<
  *         # Right subtree
- *         if self.cright is not EmptyNode and self.start < end:
+ *         if self.cright is not EmptyNode and self.start <= qend:
  */
     if (unlikely(__pyx_v_results == Py_None)) {
       PyErr_Format(PyExc_AttributeError, "'NoneType' object has no attribute '%s'", "append");
-      __PYX_ERR(0, 198, __pyx_L1_error)
+      __PYX_ERR(0, 200, __pyx_L1_error)
     }
     __pyx_t_5 = __pyx_v_self->interval;
     __Pyx_INCREF(__pyx_t_5);
-    __pyx_t_6 = __Pyx_PyList_Append(__pyx_v_results, __pyx_t_5); if (unlikely(__pyx_t_6 == -1)) __PYX_ERR(0, 198, __pyx_L1_error)
+    __pyx_t_6 = __Pyx_PyList_Append(__pyx_v_results, __pyx_t_5); if (unlikely(__pyx_t_6 == -1)) __PYX_ERR(0, 200, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
 
-    /* "skbio/metadata/_intersection.pyx":197
+    /* "skbio/metadata/_intersection.pyx":199
  *         else:
- *             qend = end - 1
+ *             send = self.end - 1
  *         if ( send >= start ) and ( self.start <= qend ):             # <<<<<<<<<<<<<<
  *             results.append( self.interval )
  *         # Right subtree
  */
   }
 
-  /* "skbio/metadata/_intersection.pyx":200
+  /* "skbio/metadata/_intersection.pyx":202
  *             results.append( self.interval )
  *         # Right subtree
- *         if self.cright is not EmptyNode and self.start < end:             # <<<<<<<<<<<<<<
+ *         if self.cright is not EmptyNode and self.start <= qend:             # <<<<<<<<<<<<<<
  *             self.cright._intersect( start, end, results )
  * 
  */
@@ -3070,24 +3070,24 @@ static void __pyx_f_5skbio_8metadata_13_intersection_12IntervalNode__intersect(s
     __pyx_t_1 = __pyx_t_2;
     goto __pyx_L12_bool_binop_done;
   }
-  __pyx_t_2 = ((__pyx_v_self->start < __pyx_v_end) != 0);
+  __pyx_t_2 = ((__pyx_v_self->start <= __pyx_v_qend) != 0);
   __pyx_t_1 = __pyx_t_2;
   __pyx_L12_bool_binop_done:;
   if (__pyx_t_1) {
 
-    /* "skbio/metadata/_intersection.pyx":201
+    /* "skbio/metadata/_intersection.pyx":203
  *         # Right subtree
- *         if self.cright is not EmptyNode and self.start < end:
+ *         if self.cright is not EmptyNode and self.start <= qend:
  *             self.cright._intersect( start, end, results )             # <<<<<<<<<<<<<<
  * 
  *     cpdef void update(IntervalNode self, int start, int end,
  */
     ((struct __pyx_vtabstruct_5skbio_8metadata_13_intersection_IntervalNode *)__pyx_v_self->cright->__pyx_vtab)->_intersect(__pyx_v_self->cright, __pyx_v_start, __pyx_v_end, __pyx_v_results);
 
-    /* "skbio/metadata/_intersection.pyx":200
+    /* "skbio/metadata/_intersection.pyx":202
  *             results.append( self.interval )
  *         # Right subtree
- *         if self.cright is not EmptyNode and self.start < end:             # <<<<<<<<<<<<<<
+ *         if self.cright is not EmptyNode and self.start <= qend:             # <<<<<<<<<<<<<<
  *             self.cright._intersect( start, end, results )
  * 
  */
@@ -3097,8 +3097,8 @@ static void __pyx_f_5skbio_8metadata_13_intersection_12IntervalNode__intersect(s
  *     find = intersect
  * 
  *     cdef void _intersect( IntervalNode self, int start, int end, list results):             # <<<<<<<<<<<<<<
- *         # Left subtree
- *         if self.cleft is not EmptyNode and self.cleft.maxend > start:
+ *         cdef int send, qend
+ * 
  */
 
   /* function exit code */
@@ -3110,7 +3110,7 @@ static void __pyx_f_5skbio_8metadata_13_intersection_12IntervalNode__intersect(s
   __Pyx_RefNannyFinishContext();
 }
 
-/* "skbio/metadata/_intersection.pyx":203
+/* "skbio/metadata/_intersection.pyx":205
  *             self.cright._intersect( start, end, results )
  * 
  *     cpdef void update(IntervalNode self, int start, int end,             # <<<<<<<<<<<<<<
@@ -3137,12 +3137,12 @@ static void __pyx_f_5skbio_8metadata_13_intersection_12IntervalNode_update(struc
   if (unlikely(__pyx_skip_dispatch)) ;
   /* Check if overridden in Python */
   else if (unlikely(Py_TYPE(((PyObject *)__pyx_v_self))->tp_dictoffset != 0)) {
-    __pyx_t_1 = __Pyx_PyObject_GetAttrStr(((PyObject *)__pyx_v_self), __pyx_n_s_update); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 203, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_PyObject_GetAttrStr(((PyObject *)__pyx_v_self), __pyx_n_s_update); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 205, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
     if (!PyCFunction_Check(__pyx_t_1) || (PyCFunction_GET_FUNCTION(__pyx_t_1) != (PyCFunction)__pyx_pw_5skbio_8metadata_13_intersection_12IntervalNode_9update)) {
-      __pyx_t_3 = __Pyx_PyInt_From_int(__pyx_v_start); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 203, __pyx_L1_error)
+      __pyx_t_3 = __Pyx_PyInt_From_int(__pyx_v_start); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 205, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_3);
-      __pyx_t_4 = __Pyx_PyInt_From_int(__pyx_v_end); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 203, __pyx_L1_error)
+      __pyx_t_4 = __Pyx_PyInt_From_int(__pyx_v_end); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 205, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_4);
       __Pyx_INCREF(__pyx_t_1);
       __pyx_t_5 = __pyx_t_1; __pyx_t_6 = NULL;
@@ -3157,7 +3157,7 @@ static void __pyx_f_5skbio_8metadata_13_intersection_12IntervalNode_update(struc
           __pyx_t_7 = 1;
         }
       }
-      __pyx_t_8 = PyTuple_New(4+__pyx_t_7); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 203, __pyx_L1_error)
+      __pyx_t_8 = PyTuple_New(4+__pyx_t_7); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 205, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_8);
       if (__pyx_t_6) {
         __Pyx_GIVEREF(__pyx_t_6); PyTuple_SET_ITEM(__pyx_t_8, 0, __pyx_t_6); __pyx_t_6 = NULL;
@@ -3174,7 +3174,7 @@ static void __pyx_f_5skbio_8metadata_13_intersection_12IntervalNode_update(struc
       PyTuple_SET_ITEM(__pyx_t_8, 3+__pyx_t_7, __pyx_v_new_feature);
       __pyx_t_3 = 0;
       __pyx_t_4 = 0;
-      __pyx_t_2 = __Pyx_PyObject_Call(__pyx_t_5, __pyx_t_8, NULL); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 203, __pyx_L1_error)
+      __pyx_t_2 = __Pyx_PyObject_Call(__pyx_t_5, __pyx_t_8, NULL); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 205, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_2);
       __Pyx_DECREF(__pyx_t_8); __pyx_t_8 = 0;
       __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
@@ -3185,7 +3185,7 @@ static void __pyx_f_5skbio_8metadata_13_intersection_12IntervalNode_update(struc
     __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   }
 
-  /* "skbio/metadata/_intersection.pyx":211
+  /* "skbio/metadata/_intersection.pyx":213
  * 
  *         # Left subtree
  *         if self.cleft is not EmptyNode and self.cleft.maxend > start:             # <<<<<<<<<<<<<<
@@ -3204,7 +3204,7 @@ static void __pyx_f_5skbio_8metadata_13_intersection_12IntervalNode_update(struc
   __pyx_L4_bool_binop_done:;
   if (__pyx_t_9) {
 
-    /* "skbio/metadata/_intersection.pyx":212
+    /* "skbio/metadata/_intersection.pyx":214
  *         # Left subtree
  *         if self.cleft is not EmptyNode and self.cleft.maxend > start:
  *             self.cleft.update( start, end, old_feature, new_feature )             # <<<<<<<<<<<<<<
@@ -3213,7 +3213,7 @@ static void __pyx_f_5skbio_8metadata_13_intersection_12IntervalNode_update(struc
  */
     ((struct __pyx_vtabstruct_5skbio_8metadata_13_intersection_IntervalNode *)__pyx_v_self->cleft->__pyx_vtab)->update(__pyx_v_self->cleft, __pyx_v_start, __pyx_v_end, __pyx_v_old_feature, __pyx_v_new_feature, 0);
 
-    /* "skbio/metadata/_intersection.pyx":211
+    /* "skbio/metadata/_intersection.pyx":213
  * 
  *         # Left subtree
  *         if self.cleft is not EmptyNode and self.cleft.maxend > start:             # <<<<<<<<<<<<<<
@@ -3222,7 +3222,7 @@ static void __pyx_f_5skbio_8metadata_13_intersection_12IntervalNode_update(struc
  */
   }
 
-  /* "skbio/metadata/_intersection.pyx":214
+  /* "skbio/metadata/_intersection.pyx":216
  *             self.cleft.update( start, end, old_feature, new_feature )
  *         # This interval
  *         if ( self.end > start ) and ( self.start < end ):             # <<<<<<<<<<<<<<
@@ -3240,19 +3240,19 @@ static void __pyx_f_5skbio_8metadata_13_intersection_12IntervalNode_update(struc
   __pyx_L7_bool_binop_done:;
   if (__pyx_t_9) {
 
-    /* "skbio/metadata/_intersection.pyx":215
+    /* "skbio/metadata/_intersection.pyx":217
  *         # This interval
  *         if ( self.end > start ) and ( self.start < end ):
  *             if self.interval == old_feature:             # <<<<<<<<<<<<<<
  *                 self.interval = new_feature
  *         # Right subtree
  */
-    __pyx_t_1 = PyObject_RichCompare(__pyx_v_self->interval, __pyx_v_old_feature, Py_EQ); __Pyx_XGOTREF(__pyx_t_1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 215, __pyx_L1_error)
-    __pyx_t_9 = __Pyx_PyObject_IsTrue(__pyx_t_1); if (unlikely(__pyx_t_9 < 0)) __PYX_ERR(0, 215, __pyx_L1_error)
+    __pyx_t_1 = PyObject_RichCompare(__pyx_v_self->interval, __pyx_v_old_feature, Py_EQ); __Pyx_XGOTREF(__pyx_t_1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 217, __pyx_L1_error)
+    __pyx_t_9 = __Pyx_PyObject_IsTrue(__pyx_t_1); if (unlikely(__pyx_t_9 < 0)) __PYX_ERR(0, 217, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
     if (__pyx_t_9) {
 
-      /* "skbio/metadata/_intersection.pyx":216
+      /* "skbio/metadata/_intersection.pyx":218
  *         if ( self.end > start ) and ( self.start < end ):
  *             if self.interval == old_feature:
  *                 self.interval = new_feature             # <<<<<<<<<<<<<<
@@ -3265,7 +3265,7 @@ static void __pyx_f_5skbio_8metadata_13_intersection_12IntervalNode_update(struc
       __Pyx_DECREF(__pyx_v_self->interval);
       __pyx_v_self->interval = __pyx_v_new_feature;
 
-      /* "skbio/metadata/_intersection.pyx":215
+      /* "skbio/metadata/_intersection.pyx":217
  *         # This interval
  *         if ( self.end > start ) and ( self.start < end ):
  *             if self.interval == old_feature:             # <<<<<<<<<<<<<<
@@ -3274,7 +3274,7 @@ static void __pyx_f_5skbio_8metadata_13_intersection_12IntervalNode_update(struc
  */
     }
 
-    /* "skbio/metadata/_intersection.pyx":214
+    /* "skbio/metadata/_intersection.pyx":216
  *             self.cleft.update( start, end, old_feature, new_feature )
  *         # This interval
  *         if ( self.end > start ) and ( self.start < end ):             # <<<<<<<<<<<<<<
@@ -3283,7 +3283,7 @@ static void __pyx_f_5skbio_8metadata_13_intersection_12IntervalNode_update(struc
  */
   }
 
-  /* "skbio/metadata/_intersection.pyx":218
+  /* "skbio/metadata/_intersection.pyx":220
  *                 self.interval = new_feature
  *         # Right subtree
  *         if self.cright is not EmptyNode and self.start < end:             # <<<<<<<<<<<<<<
@@ -3302,7 +3302,7 @@ static void __pyx_f_5skbio_8metadata_13_intersection_12IntervalNode_update(struc
   __pyx_L11_bool_binop_done:;
   if (__pyx_t_9) {
 
-    /* "skbio/metadata/_intersection.pyx":219
+    /* "skbio/metadata/_intersection.pyx":221
  *         # Right subtree
  *         if self.cright is not EmptyNode and self.start < end:
  *             self.cright.update( start, end, old_feature, new_feature )             # <<<<<<<<<<<<<<
@@ -3311,7 +3311,7 @@ static void __pyx_f_5skbio_8metadata_13_intersection_12IntervalNode_update(struc
  */
     ((struct __pyx_vtabstruct_5skbio_8metadata_13_intersection_IntervalNode *)__pyx_v_self->cright->__pyx_vtab)->update(__pyx_v_self->cright, __pyx_v_start, __pyx_v_end, __pyx_v_old_feature, __pyx_v_new_feature, 0);
 
-    /* "skbio/metadata/_intersection.pyx":218
+    /* "skbio/metadata/_intersection.pyx":220
  *                 self.interval = new_feature
  *         # Right subtree
  *         if self.cright is not EmptyNode and self.start < end:             # <<<<<<<<<<<<<<
@@ -3320,7 +3320,7 @@ static void __pyx_f_5skbio_8metadata_13_intersection_12IntervalNode_update(struc
  */
   }
 
-  /* "skbio/metadata/_intersection.pyx":203
+  /* "skbio/metadata/_intersection.pyx":205
  *             self.cright._intersect( start, end, results )
  * 
  *     cpdef void update(IntervalNode self, int start, int end,             # <<<<<<<<<<<<<<
@@ -3376,21 +3376,21 @@ static PyObject *__pyx_pw_5skbio_8metadata_13_intersection_12IntervalNode_9updat
         case  1:
         if (likely((values[1] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_end)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("update", 1, 4, 4, 1); __PYX_ERR(0, 203, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("update", 1, 4, 4, 1); __PYX_ERR(0, 205, __pyx_L3_error)
         }
         case  2:
         if (likely((values[2] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_old_feature)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("update", 1, 4, 4, 2); __PYX_ERR(0, 203, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("update", 1, 4, 4, 2); __PYX_ERR(0, 205, __pyx_L3_error)
         }
         case  3:
         if (likely((values[3] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_new_feature)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("update", 1, 4, 4, 3); __PYX_ERR(0, 203, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("update", 1, 4, 4, 3); __PYX_ERR(0, 205, __pyx_L3_error)
         }
       }
       if (unlikely(kw_args > 0)) {
-        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "update") < 0)) __PYX_ERR(0, 203, __pyx_L3_error)
+        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "update") < 0)) __PYX_ERR(0, 205, __pyx_L3_error)
       }
     } else if (PyTuple_GET_SIZE(__pyx_args) != 4) {
       goto __pyx_L5_argtuple_error;
@@ -3400,14 +3400,14 @@ static PyObject *__pyx_pw_5skbio_8metadata_13_intersection_12IntervalNode_9updat
       values[2] = PyTuple_GET_ITEM(__pyx_args, 2);
       values[3] = PyTuple_GET_ITEM(__pyx_args, 3);
     }
-    __pyx_v_start = __Pyx_PyInt_As_int(values[0]); if (unlikely((__pyx_v_start == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 203, __pyx_L3_error)
-    __pyx_v_end = __Pyx_PyInt_As_int(values[1]); if (unlikely((__pyx_v_end == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 203, __pyx_L3_error)
+    __pyx_v_start = __Pyx_PyInt_As_int(values[0]); if (unlikely((__pyx_v_start == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 205, __pyx_L3_error)
+    __pyx_v_end = __Pyx_PyInt_As_int(values[1]); if (unlikely((__pyx_v_end == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 205, __pyx_L3_error)
     __pyx_v_old_feature = values[2];
     __pyx_v_new_feature = values[3];
   }
   goto __pyx_L4_argument_unpacking_done;
   __pyx_L5_argtuple_error:;
-  __Pyx_RaiseArgtupleInvalid("update", 1, 4, 4, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 203, __pyx_L3_error)
+  __Pyx_RaiseArgtupleInvalid("update", 1, 4, 4, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 205, __pyx_L3_error)
   __pyx_L3_error:;
   __Pyx_AddTraceback("skbio.metadata._intersection.IntervalNode.update", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __Pyx_RefNannyFinishContext();
@@ -3426,7 +3426,7 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_12IntervalNode_8updat
   PyObject *__pyx_t_1 = NULL;
   __Pyx_RefNannySetupContext("update", 0);
   __Pyx_XDECREF(__pyx_r);
-  __pyx_t_1 = __Pyx_void_to_None(__pyx_f_5skbio_8metadata_13_intersection_12IntervalNode_update(__pyx_v_self, __pyx_v_start, __pyx_v_end, __pyx_v_old_feature, __pyx_v_new_feature, 1)); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 203, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_void_to_None(__pyx_f_5skbio_8metadata_13_intersection_12IntervalNode_update(__pyx_v_self, __pyx_v_start, __pyx_v_end, __pyx_v_old_feature, __pyx_v_new_feature, 1)); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 205, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __pyx_r = __pyx_t_1;
   __pyx_t_1 = 0;
@@ -3443,7 +3443,7 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_12IntervalNode_8updat
   return __pyx_r;
 }
 
-/* "skbio/metadata/_intersection.pyx":221
+/* "skbio/metadata/_intersection.pyx":223
  *             self.cright.update( start, end, old_feature, new_feature )
  * 
  *     cdef void _seek_left(IntervalNode self, int position, list results, int n, int max_dist):             # <<<<<<<<<<<<<<
@@ -3460,7 +3460,7 @@ static void __pyx_f_5skbio_8metadata_13_intersection_12IntervalNode__seek_left(s
   int __pyx_t_5;
   __Pyx_RefNannySetupContext("_seek_left", 0);
 
-  /* "skbio/metadata/_intersection.pyx":223
+  /* "skbio/metadata/_intersection.pyx":225
  *     cdef void _seek_left(IntervalNode self, int position, list results, int n, int max_dist):
  *         # we know we can bail in these 2 cases.
  *         if self.maxend + max_dist < position:             # <<<<<<<<<<<<<<
@@ -3470,7 +3470,7 @@ static void __pyx_f_5skbio_8metadata_13_intersection_12IntervalNode__seek_left(s
   __pyx_t_1 = (((__pyx_v_self->maxend + __pyx_v_max_dist) < __pyx_v_position) != 0);
   if (__pyx_t_1) {
 
-    /* "skbio/metadata/_intersection.pyx":224
+    /* "skbio/metadata/_intersection.pyx":226
  *         # we know we can bail in these 2 cases.
  *         if self.maxend + max_dist < position:
  *             return             # <<<<<<<<<<<<<<
@@ -3479,7 +3479,7 @@ static void __pyx_f_5skbio_8metadata_13_intersection_12IntervalNode__seek_left(s
  */
     goto __pyx_L0;
 
-    /* "skbio/metadata/_intersection.pyx":223
+    /* "skbio/metadata/_intersection.pyx":225
  *     cdef void _seek_left(IntervalNode self, int position, list results, int n, int max_dist):
  *         # we know we can bail in these 2 cases.
  *         if self.maxend + max_dist < position:             # <<<<<<<<<<<<<<
@@ -3488,7 +3488,7 @@ static void __pyx_f_5skbio_8metadata_13_intersection_12IntervalNode__seek_left(s
  */
   }
 
-  /* "skbio/metadata/_intersection.pyx":225
+  /* "skbio/metadata/_intersection.pyx":227
  *         if self.maxend + max_dist < position:
  *             return
  *         if self.minstart > position:             # <<<<<<<<<<<<<<
@@ -3498,7 +3498,7 @@ static void __pyx_f_5skbio_8metadata_13_intersection_12IntervalNode__seek_left(s
   __pyx_t_1 = ((__pyx_v_self->minstart > __pyx_v_position) != 0);
   if (__pyx_t_1) {
 
-    /* "skbio/metadata/_intersection.pyx":226
+    /* "skbio/metadata/_intersection.pyx":228
  *             return
  *         if self.minstart > position:
  *             return             # <<<<<<<<<<<<<<
@@ -3507,7 +3507,7 @@ static void __pyx_f_5skbio_8metadata_13_intersection_12IntervalNode__seek_left(s
  */
     goto __pyx_L0;
 
-    /* "skbio/metadata/_intersection.pyx":225
+    /* "skbio/metadata/_intersection.pyx":227
  *         if self.maxend + max_dist < position:
  *             return
  *         if self.minstart > position:             # <<<<<<<<<<<<<<
@@ -3516,7 +3516,7 @@ static void __pyx_f_5skbio_8metadata_13_intersection_12IntervalNode__seek_left(s
  */
   }
 
-  /* "skbio/metadata/_intersection.pyx":230
+  /* "skbio/metadata/_intersection.pyx":232
  *         # the ordering of these 3 blocks makes it so the results are
  *         # ordered nearest to farest from the query position
  *         if self.cright is not EmptyNode:             # <<<<<<<<<<<<<<
@@ -3527,7 +3527,7 @@ static void __pyx_f_5skbio_8metadata_13_intersection_12IntervalNode__seek_left(s
   __pyx_t_2 = (__pyx_t_1 != 0);
   if (__pyx_t_2) {
 
-    /* "skbio/metadata/_intersection.pyx":231
+    /* "skbio/metadata/_intersection.pyx":233
  *         # ordered nearest to farest from the query position
  *         if self.cright is not EmptyNode:
  *             self.cright._seek_left(position, results, n, max_dist)             # <<<<<<<<<<<<<<
@@ -3536,7 +3536,7 @@ static void __pyx_f_5skbio_8metadata_13_intersection_12IntervalNode__seek_left(s
  */
     ((struct __pyx_vtabstruct_5skbio_8metadata_13_intersection_IntervalNode *)__pyx_v_self->cright->__pyx_vtab)->_seek_left(__pyx_v_self->cright, __pyx_v_position, __pyx_v_results, __pyx_v_n, __pyx_v_max_dist);
 
-    /* "skbio/metadata/_intersection.pyx":230
+    /* "skbio/metadata/_intersection.pyx":232
  *         # the ordering of these 3 blocks makes it so the results are
  *         # ordered nearest to farest from the query position
  *         if self.cright is not EmptyNode:             # <<<<<<<<<<<<<<
@@ -3545,7 +3545,7 @@ static void __pyx_f_5skbio_8metadata_13_intersection_12IntervalNode__seek_left(s
  */
   }
 
-  /* "skbio/metadata/_intersection.pyx":233
+  /* "skbio/metadata/_intersection.pyx":235
  *             self.cright._seek_left(position, results, n, max_dist)
  * 
  *         if -1 < position - self.end < max_dist:             # <<<<<<<<<<<<<<
@@ -3560,7 +3560,7 @@ static void __pyx_f_5skbio_8metadata_13_intersection_12IntervalNode__seek_left(s
   __pyx_t_1 = (__pyx_t_2 != 0);
   if (__pyx_t_1) {
 
-    /* "skbio/metadata/_intersection.pyx":234
+    /* "skbio/metadata/_intersection.pyx":236
  * 
  *         if -1 < position - self.end < max_dist:
  *             results.append(self.interval)             # <<<<<<<<<<<<<<
@@ -3569,14 +3569,14 @@ static void __pyx_f_5skbio_8metadata_13_intersection_12IntervalNode__seek_left(s
  */
     if (unlikely(__pyx_v_results == Py_None)) {
       PyErr_Format(PyExc_AttributeError, "'NoneType' object has no attribute '%s'", "append");
-      __PYX_ERR(0, 234, __pyx_L1_error)
+      __PYX_ERR(0, 236, __pyx_L1_error)
     }
     __pyx_t_4 = __pyx_v_self->interval;
     __Pyx_INCREF(__pyx_t_4);
-    __pyx_t_5 = __Pyx_PyList_Append(__pyx_v_results, __pyx_t_4); if (unlikely(__pyx_t_5 == -1)) __PYX_ERR(0, 234, __pyx_L1_error)
+    __pyx_t_5 = __Pyx_PyList_Append(__pyx_v_results, __pyx_t_4); if (unlikely(__pyx_t_5 == -1)) __PYX_ERR(0, 236, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
 
-    /* "skbio/metadata/_intersection.pyx":233
+    /* "skbio/metadata/_intersection.pyx":235
  *             self.cright._seek_left(position, results, n, max_dist)
  * 
  *         if -1 < position - self.end < max_dist:             # <<<<<<<<<<<<<<
@@ -3585,7 +3585,7 @@ static void __pyx_f_5skbio_8metadata_13_intersection_12IntervalNode__seek_left(s
  */
   }
 
-  /* "skbio/metadata/_intersection.pyx":237
+  /* "skbio/metadata/_intersection.pyx":239
  * 
  *         # TODO: can these conditionals be more stringent?
  *         if self.cleft is not EmptyNode:             # <<<<<<<<<<<<<<
@@ -3596,7 +3596,7 @@ static void __pyx_f_5skbio_8metadata_13_intersection_12IntervalNode__seek_left(s
   __pyx_t_2 = (__pyx_t_1 != 0);
   if (__pyx_t_2) {
 
-    /* "skbio/metadata/_intersection.pyx":238
+    /* "skbio/metadata/_intersection.pyx":240
  *         # TODO: can these conditionals be more stringent?
  *         if self.cleft is not EmptyNode:
  *                 self.cleft._seek_left(position, results, n, max_dist)             # <<<<<<<<<<<<<<
@@ -3605,7 +3605,7 @@ static void __pyx_f_5skbio_8metadata_13_intersection_12IntervalNode__seek_left(s
  */
     ((struct __pyx_vtabstruct_5skbio_8metadata_13_intersection_IntervalNode *)__pyx_v_self->cleft->__pyx_vtab)->_seek_left(__pyx_v_self->cleft, __pyx_v_position, __pyx_v_results, __pyx_v_n, __pyx_v_max_dist);
 
-    /* "skbio/metadata/_intersection.pyx":237
+    /* "skbio/metadata/_intersection.pyx":239
  * 
  *         # TODO: can these conditionals be more stringent?
  *         if self.cleft is not EmptyNode:             # <<<<<<<<<<<<<<
@@ -3614,7 +3614,7 @@ static void __pyx_f_5skbio_8metadata_13_intersection_12IntervalNode__seek_left(s
  */
   }
 
-  /* "skbio/metadata/_intersection.pyx":221
+  /* "skbio/metadata/_intersection.pyx":223
  *             self.cright.update( start, end, old_feature, new_feature )
  * 
  *     cdef void _seek_left(IntervalNode self, int position, list results, int n, int max_dist):             # <<<<<<<<<<<<<<
@@ -3631,7 +3631,7 @@ static void __pyx_f_5skbio_8metadata_13_intersection_12IntervalNode__seek_left(s
   __Pyx_RefNannyFinishContext();
 }
 
-/* "skbio/metadata/_intersection.pyx":242
+/* "skbio/metadata/_intersection.pyx":244
  * 
  * 
  *     cdef void _seek_right(IntervalNode self, int position, list results, int n, int max_dist):             # <<<<<<<<<<<<<<
@@ -3648,7 +3648,7 @@ static void __pyx_f_5skbio_8metadata_13_intersection_12IntervalNode__seek_right(
   int __pyx_t_5;
   __Pyx_RefNannySetupContext("_seek_right", 0);
 
-  /* "skbio/metadata/_intersection.pyx":244
+  /* "skbio/metadata/_intersection.pyx":246
  *     cdef void _seek_right(IntervalNode self, int position, list results, int n, int max_dist):
  *         # we know we can bail in these 2 cases.
  *         if self.maxend < position: return             # <<<<<<<<<<<<<<
@@ -3660,7 +3660,7 @@ static void __pyx_f_5skbio_8metadata_13_intersection_12IntervalNode__seek_right(
     goto __pyx_L0;
   }
 
-  /* "skbio/metadata/_intersection.pyx":245
+  /* "skbio/metadata/_intersection.pyx":247
  *         # we know we can bail in these 2 cases.
  *         if self.maxend < position: return
  *         if self.minstart - max_dist > position: return             # <<<<<<<<<<<<<<
@@ -3672,7 +3672,7 @@ static void __pyx_f_5skbio_8metadata_13_intersection_12IntervalNode__seek_right(
     goto __pyx_L0;
   }
 
-  /* "skbio/metadata/_intersection.pyx":251
+  /* "skbio/metadata/_intersection.pyx":253
  *         # the ordering of these 3 blocks makes it so the results are
  *         # ordered nearest to farest from the query position
  *         if self.cleft is not EmptyNode:             # <<<<<<<<<<<<<<
@@ -3683,7 +3683,7 @@ static void __pyx_f_5skbio_8metadata_13_intersection_12IntervalNode__seek_right(
   __pyx_t_2 = (__pyx_t_1 != 0);
   if (__pyx_t_2) {
 
-    /* "skbio/metadata/_intersection.pyx":252
+    /* "skbio/metadata/_intersection.pyx":254
  *         # ordered nearest to farest from the query position
  *         if self.cleft is not EmptyNode:
  *                 self.cleft._seek_right(position, results, n, max_dist)             # <<<<<<<<<<<<<<
@@ -3692,7 +3692,7 @@ static void __pyx_f_5skbio_8metadata_13_intersection_12IntervalNode__seek_right(
  */
     ((struct __pyx_vtabstruct_5skbio_8metadata_13_intersection_IntervalNode *)__pyx_v_self->cleft->__pyx_vtab)->_seek_right(__pyx_v_self->cleft, __pyx_v_position, __pyx_v_results, __pyx_v_n, __pyx_v_max_dist);
 
-    /* "skbio/metadata/_intersection.pyx":251
+    /* "skbio/metadata/_intersection.pyx":253
  *         # the ordering of these 3 blocks makes it so the results are
  *         # ordered nearest to farest from the query position
  *         if self.cleft is not EmptyNode:             # <<<<<<<<<<<<<<
@@ -3701,7 +3701,7 @@ static void __pyx_f_5skbio_8metadata_13_intersection_12IntervalNode__seek_right(
  */
   }
 
-  /* "skbio/metadata/_intersection.pyx":254
+  /* "skbio/metadata/_intersection.pyx":256
  *                 self.cleft._seek_right(position, results, n, max_dist)
  * 
  *         if -1 < self.start - position < max_dist:             # <<<<<<<<<<<<<<
@@ -3716,7 +3716,7 @@ static void __pyx_f_5skbio_8metadata_13_intersection_12IntervalNode__seek_right(
   __pyx_t_1 = (__pyx_t_2 != 0);
   if (__pyx_t_1) {
 
-    /* "skbio/metadata/_intersection.pyx":255
+    /* "skbio/metadata/_intersection.pyx":257
  * 
  *         if -1 < self.start - position < max_dist:
  *             results.append(self.interval)             # <<<<<<<<<<<<<<
@@ -3725,14 +3725,14 @@ static void __pyx_f_5skbio_8metadata_13_intersection_12IntervalNode__seek_right(
  */
     if (unlikely(__pyx_v_results == Py_None)) {
       PyErr_Format(PyExc_AttributeError, "'NoneType' object has no attribute '%s'", "append");
-      __PYX_ERR(0, 255, __pyx_L1_error)
+      __PYX_ERR(0, 257, __pyx_L1_error)
     }
     __pyx_t_4 = __pyx_v_self->interval;
     __Pyx_INCREF(__pyx_t_4);
-    __pyx_t_5 = __Pyx_PyList_Append(__pyx_v_results, __pyx_t_4); if (unlikely(__pyx_t_5 == -1)) __PYX_ERR(0, 255, __pyx_L1_error)
+    __pyx_t_5 = __Pyx_PyList_Append(__pyx_v_results, __pyx_t_4); if (unlikely(__pyx_t_5 == -1)) __PYX_ERR(0, 257, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
 
-    /* "skbio/metadata/_intersection.pyx":254
+    /* "skbio/metadata/_intersection.pyx":256
  *                 self.cleft._seek_right(position, results, n, max_dist)
  * 
  *         if -1 < self.start - position < max_dist:             # <<<<<<<<<<<<<<
@@ -3741,7 +3741,7 @@ static void __pyx_f_5skbio_8metadata_13_intersection_12IntervalNode__seek_right(
  */
   }
 
-  /* "skbio/metadata/_intersection.pyx":257
+  /* "skbio/metadata/_intersection.pyx":259
  *             results.append(self.interval)
  * 
  *         if self.cright is not EmptyNode:             # <<<<<<<<<<<<<<
@@ -3752,7 +3752,7 @@ static void __pyx_f_5skbio_8metadata_13_intersection_12IntervalNode__seek_right(
   __pyx_t_2 = (__pyx_t_1 != 0);
   if (__pyx_t_2) {
 
-    /* "skbio/metadata/_intersection.pyx":258
+    /* "skbio/metadata/_intersection.pyx":260
  * 
  *         if self.cright is not EmptyNode:
  *                 self.cright._seek_right(position, results, n, max_dist)             # <<<<<<<<<<<<<<
@@ -3761,7 +3761,7 @@ static void __pyx_f_5skbio_8metadata_13_intersection_12IntervalNode__seek_right(
  */
     ((struct __pyx_vtabstruct_5skbio_8metadata_13_intersection_IntervalNode *)__pyx_v_self->cright->__pyx_vtab)->_seek_right(__pyx_v_self->cright, __pyx_v_position, __pyx_v_results, __pyx_v_n, __pyx_v_max_dist);
 
-    /* "skbio/metadata/_intersection.pyx":257
+    /* "skbio/metadata/_intersection.pyx":259
  *             results.append(self.interval)
  * 
  *         if self.cright is not EmptyNode:             # <<<<<<<<<<<<<<
@@ -3770,7 +3770,7 @@ static void __pyx_f_5skbio_8metadata_13_intersection_12IntervalNode__seek_right(
  */
   }
 
-  /* "skbio/metadata/_intersection.pyx":242
+  /* "skbio/metadata/_intersection.pyx":244
  * 
  * 
  *     cdef void _seek_right(IntervalNode self, int position, list results, int n, int max_dist):             # <<<<<<<<<<<<<<
@@ -3787,7 +3787,7 @@ static void __pyx_f_5skbio_8metadata_13_intersection_12IntervalNode__seek_right(
   __Pyx_RefNannyFinishContext();
 }
 
-/* "skbio/metadata/_intersection.pyx":261
+/* "skbio/metadata/_intersection.pyx":263
  * 
  * 
  *     cpdef left(self, position, int n=1, int max_dist=2500):             # <<<<<<<<<<<<<<
@@ -3826,13 +3826,13 @@ static PyObject *__pyx_f_5skbio_8metadata_13_intersection_12IntervalNode_left(st
   if (unlikely(__pyx_skip_dispatch)) ;
   /* Check if overridden in Python */
   else if (unlikely(Py_TYPE(((PyObject *)__pyx_v_self))->tp_dictoffset != 0)) {
-    __pyx_t_1 = __Pyx_PyObject_GetAttrStr(((PyObject *)__pyx_v_self), __pyx_n_s_left); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 261, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_PyObject_GetAttrStr(((PyObject *)__pyx_v_self), __pyx_n_s_left); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 263, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
     if (!PyCFunction_Check(__pyx_t_1) || (PyCFunction_GET_FUNCTION(__pyx_t_1) != (PyCFunction)__pyx_pw_5skbio_8metadata_13_intersection_12IntervalNode_11left)) {
       __Pyx_XDECREF(__pyx_r);
-      __pyx_t_3 = __Pyx_PyInt_From_int(__pyx_v_n); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 261, __pyx_L1_error)
+      __pyx_t_3 = __Pyx_PyInt_From_int(__pyx_v_n); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 263, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_3);
-      __pyx_t_4 = __Pyx_PyInt_From_int(__pyx_v_max_dist); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 261, __pyx_L1_error)
+      __pyx_t_4 = __Pyx_PyInt_From_int(__pyx_v_max_dist); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 263, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_4);
       __Pyx_INCREF(__pyx_t_1);
       __pyx_t_5 = __pyx_t_1; __pyx_t_6 = NULL;
@@ -3847,7 +3847,7 @@ static PyObject *__pyx_f_5skbio_8metadata_13_intersection_12IntervalNode_left(st
           __pyx_t_7 = 1;
         }
       }
-      __pyx_t_8 = PyTuple_New(3+__pyx_t_7); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 261, __pyx_L1_error)
+      __pyx_t_8 = PyTuple_New(3+__pyx_t_7); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 263, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_8);
       if (__pyx_t_6) {
         __Pyx_GIVEREF(__pyx_t_6); PyTuple_SET_ITEM(__pyx_t_8, 0, __pyx_t_6); __pyx_t_6 = NULL;
@@ -3861,7 +3861,7 @@ static PyObject *__pyx_f_5skbio_8metadata_13_intersection_12IntervalNode_left(st
       PyTuple_SET_ITEM(__pyx_t_8, 2+__pyx_t_7, __pyx_t_4);
       __pyx_t_3 = 0;
       __pyx_t_4 = 0;
-      __pyx_t_2 = __Pyx_PyObject_Call(__pyx_t_5, __pyx_t_8, NULL); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 261, __pyx_L1_error)
+      __pyx_t_2 = __Pyx_PyObject_Call(__pyx_t_5, __pyx_t_8, NULL); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 263, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_2);
       __Pyx_DECREF(__pyx_t_8); __pyx_t_8 = 0;
       __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
@@ -3873,39 +3873,39 @@ static PyObject *__pyx_f_5skbio_8metadata_13_intersection_12IntervalNode_left(st
     __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   }
 
-  /* "skbio/metadata/_intersection.pyx":268
+  /* "skbio/metadata/_intersection.pyx":270
  *         max_dist: the maximum distance to look before giving up.
  *         """
  *         cdef list results = []             # <<<<<<<<<<<<<<
  *         # use start - 1 becuase .left() assumes strictly left-of
  *         self._seek_left( position - 1, results, n, max_dist )
  */
-  __pyx_t_1 = PyList_New(0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 268, __pyx_L1_error)
+  __pyx_t_1 = PyList_New(0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 270, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __pyx_v_results = ((PyObject*)__pyx_t_1);
   __pyx_t_1 = 0;
 
-  /* "skbio/metadata/_intersection.pyx":270
+  /* "skbio/metadata/_intersection.pyx":272
  *         cdef list results = []
  *         # use start - 1 becuase .left() assumes strictly left-of
  *         self._seek_left( position - 1, results, n, max_dist )             # <<<<<<<<<<<<<<
  *         if len(results) == n: return results
  *         r = results
  */
-  __pyx_t_1 = __Pyx_PyInt_SubtractObjC(__pyx_v_position, __pyx_int_1, 1, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 270, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyInt_SubtractObjC(__pyx_v_position, __pyx_int_1, 1, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 272, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_9 = __Pyx_PyInt_As_int(__pyx_t_1); if (unlikely((__pyx_t_9 == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 270, __pyx_L1_error)
+  __pyx_t_9 = __Pyx_PyInt_As_int(__pyx_t_1); if (unlikely((__pyx_t_9 == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 272, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   ((struct __pyx_vtabstruct_5skbio_8metadata_13_intersection_IntervalNode *)__pyx_v_self->__pyx_vtab)->_seek_left(__pyx_v_self, __pyx_t_9, __pyx_v_results, __pyx_v_n, __pyx_v_max_dist);
 
-  /* "skbio/metadata/_intersection.pyx":271
+  /* "skbio/metadata/_intersection.pyx":273
  *         # use start - 1 becuase .left() assumes strictly left-of
  *         self._seek_left( position - 1, results, n, max_dist )
  *         if len(results) == n: return results             # <<<<<<<<<<<<<<
  *         r = results
  *         r.sort(key=operator.attrgetter('end'), reverse=True)
  */
-  __pyx_t_7 = PyList_GET_SIZE(__pyx_v_results); if (unlikely(__pyx_t_7 == -1)) __PYX_ERR(0, 271, __pyx_L1_error)
+  __pyx_t_7 = PyList_GET_SIZE(__pyx_v_results); if (unlikely(__pyx_t_7 == -1)) __PYX_ERR(0, 273, __pyx_L1_error)
   __pyx_t_10 = ((__pyx_t_7 == __pyx_v_n) != 0);
   if (__pyx_t_10) {
     __Pyx_XDECREF(__pyx_r);
@@ -3914,7 +3914,7 @@ static PyObject *__pyx_f_5skbio_8metadata_13_intersection_12IntervalNode_left(st
     goto __pyx_L0;
   }
 
-  /* "skbio/metadata/_intersection.pyx":272
+  /* "skbio/metadata/_intersection.pyx":274
  *         self._seek_left( position - 1, results, n, max_dist )
  *         if len(results) == n: return results
  *         r = results             # <<<<<<<<<<<<<<
@@ -3924,35 +3924,35 @@ static PyObject *__pyx_f_5skbio_8metadata_13_intersection_12IntervalNode_left(st
   __Pyx_INCREF(__pyx_v_results);
   __pyx_v_r = __pyx_v_results;
 
-  /* "skbio/metadata/_intersection.pyx":273
+  /* "skbio/metadata/_intersection.pyx":275
  *         if len(results) == n: return results
  *         r = results
  *         r.sort(key=operator.attrgetter('end'), reverse=True)             # <<<<<<<<<<<<<<
  *         return r[:n]
  * 
  */
-  __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_v_r, __pyx_n_s_sort); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 273, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_v_r, __pyx_n_s_sort); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 275, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_2 = PyDict_New(); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 273, __pyx_L1_error)
+  __pyx_t_2 = PyDict_New(); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 275, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
-  __pyx_t_5 = __Pyx_GetModuleGlobalName(__pyx_n_s_operator); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 273, __pyx_L1_error)
+  __pyx_t_5 = __Pyx_GetModuleGlobalName(__pyx_n_s_operator); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 275, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_5);
-  __pyx_t_8 = __Pyx_PyObject_GetAttrStr(__pyx_t_5, __pyx_n_s_attrgetter); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 273, __pyx_L1_error)
+  __pyx_t_8 = __Pyx_PyObject_GetAttrStr(__pyx_t_5, __pyx_n_s_attrgetter); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 275, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_8);
   __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
-  __pyx_t_5 = __Pyx_PyObject_Call(__pyx_t_8, __pyx_tuple_, NULL); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 273, __pyx_L1_error)
+  __pyx_t_5 = __Pyx_PyObject_Call(__pyx_t_8, __pyx_tuple_, NULL); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 275, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_5);
   __Pyx_DECREF(__pyx_t_8); __pyx_t_8 = 0;
-  if (PyDict_SetItem(__pyx_t_2, __pyx_n_s_key, __pyx_t_5) < 0) __PYX_ERR(0, 273, __pyx_L1_error)
+  if (PyDict_SetItem(__pyx_t_2, __pyx_n_s_key, __pyx_t_5) < 0) __PYX_ERR(0, 275, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
-  if (PyDict_SetItem(__pyx_t_2, __pyx_n_s_reverse, Py_True) < 0) __PYX_ERR(0, 273, __pyx_L1_error)
-  __pyx_t_5 = __Pyx_PyObject_Call(__pyx_t_1, __pyx_empty_tuple, __pyx_t_2); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 273, __pyx_L1_error)
+  if (PyDict_SetItem(__pyx_t_2, __pyx_n_s_reverse, Py_True) < 0) __PYX_ERR(0, 275, __pyx_L1_error)
+  __pyx_t_5 = __Pyx_PyObject_Call(__pyx_t_1, __pyx_empty_tuple, __pyx_t_2); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 275, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_5);
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
   __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
 
-  /* "skbio/metadata/_intersection.pyx":274
+  /* "skbio/metadata/_intersection.pyx":276
  *         r = results
  *         r.sort(key=operator.attrgetter('end'), reverse=True)
  *         return r[:n]             # <<<<<<<<<<<<<<
@@ -3960,13 +3960,13 @@ static PyObject *__pyx_f_5skbio_8metadata_13_intersection_12IntervalNode_left(st
  *     cpdef right(self, position, int n=1, int max_dist=2500):
  */
   __Pyx_XDECREF(__pyx_r);
-  __pyx_t_5 = __Pyx_PyList_GetSlice(__pyx_v_r, 0, __pyx_v_n); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 274, __pyx_L1_error)
+  __pyx_t_5 = __Pyx_PyList_GetSlice(__pyx_v_r, 0, __pyx_v_n); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 276, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_5);
   __pyx_r = __pyx_t_5;
   __pyx_t_5 = 0;
   goto __pyx_L0;
 
-  /* "skbio/metadata/_intersection.pyx":261
+  /* "skbio/metadata/_intersection.pyx":263
  * 
  * 
  *     cpdef left(self, position, int n=1, int max_dist=2500):             # <<<<<<<<<<<<<<
@@ -4033,7 +4033,7 @@ static PyObject *__pyx_pw_5skbio_8metadata_13_intersection_12IntervalNode_11left
         }
       }
       if (unlikely(kw_args > 0)) {
-        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "left") < 0)) __PYX_ERR(0, 261, __pyx_L3_error)
+        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "left") < 0)) __PYX_ERR(0, 263, __pyx_L3_error)
       }
     } else {
       switch (PyTuple_GET_SIZE(__pyx_args)) {
@@ -4046,19 +4046,19 @@ static PyObject *__pyx_pw_5skbio_8metadata_13_intersection_12IntervalNode_11left
     }
     __pyx_v_position = values[0];
     if (values[1]) {
-      __pyx_v_n = __Pyx_PyInt_As_int(values[1]); if (unlikely((__pyx_v_n == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 261, __pyx_L3_error)
+      __pyx_v_n = __Pyx_PyInt_As_int(values[1]); if (unlikely((__pyx_v_n == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 263, __pyx_L3_error)
     } else {
       __pyx_v_n = ((int)1);
     }
     if (values[2]) {
-      __pyx_v_max_dist = __Pyx_PyInt_As_int(values[2]); if (unlikely((__pyx_v_max_dist == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 261, __pyx_L3_error)
+      __pyx_v_max_dist = __Pyx_PyInt_As_int(values[2]); if (unlikely((__pyx_v_max_dist == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 263, __pyx_L3_error)
     } else {
       __pyx_v_max_dist = ((int)0x9C4);
     }
   }
   goto __pyx_L4_argument_unpacking_done;
   __pyx_L5_argtuple_error:;
-  __Pyx_RaiseArgtupleInvalid("left", 0, 1, 3, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 261, __pyx_L3_error)
+  __Pyx_RaiseArgtupleInvalid("left", 0, 1, 3, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 263, __pyx_L3_error)
   __pyx_L3_error:;
   __Pyx_AddTraceback("skbio.metadata._intersection.IntervalNode.left", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __Pyx_RefNannyFinishContext();
@@ -4081,7 +4081,7 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_12IntervalNode_10left
   __pyx_t_2.__pyx_n = 2;
   __pyx_t_2.n = __pyx_v_n;
   __pyx_t_2.max_dist = __pyx_v_max_dist;
-  __pyx_t_1 = __pyx_vtabptr_5skbio_8metadata_13_intersection_IntervalNode->left(__pyx_v_self, __pyx_v_position, 1, &__pyx_t_2); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 261, __pyx_L1_error)
+  __pyx_t_1 = __pyx_vtabptr_5skbio_8metadata_13_intersection_IntervalNode->left(__pyx_v_self, __pyx_v_position, 1, &__pyx_t_2); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 263, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __pyx_r = __pyx_t_1;
   __pyx_t_1 = 0;
@@ -4098,7 +4098,7 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_12IntervalNode_10left
   return __pyx_r;
 }
 
-/* "skbio/metadata/_intersection.pyx":276
+/* "skbio/metadata/_intersection.pyx":278
  *         return r[:n]
  * 
  *     cpdef right(self, position, int n=1, int max_dist=2500):             # <<<<<<<<<<<<<<
@@ -4137,13 +4137,13 @@ static PyObject *__pyx_f_5skbio_8metadata_13_intersection_12IntervalNode_right(s
   if (unlikely(__pyx_skip_dispatch)) ;
   /* Check if overridden in Python */
   else if (unlikely(Py_TYPE(((PyObject *)__pyx_v_self))->tp_dictoffset != 0)) {
-    __pyx_t_1 = __Pyx_PyObject_GetAttrStr(((PyObject *)__pyx_v_self), __pyx_n_s_right); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 276, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_PyObject_GetAttrStr(((PyObject *)__pyx_v_self), __pyx_n_s_right); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 278, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
     if (!PyCFunction_Check(__pyx_t_1) || (PyCFunction_GET_FUNCTION(__pyx_t_1) != (PyCFunction)__pyx_pw_5skbio_8metadata_13_intersection_12IntervalNode_13right)) {
       __Pyx_XDECREF(__pyx_r);
-      __pyx_t_3 = __Pyx_PyInt_From_int(__pyx_v_n); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 276, __pyx_L1_error)
+      __pyx_t_3 = __Pyx_PyInt_From_int(__pyx_v_n); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 278, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_3);
-      __pyx_t_4 = __Pyx_PyInt_From_int(__pyx_v_max_dist); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 276, __pyx_L1_error)
+      __pyx_t_4 = __Pyx_PyInt_From_int(__pyx_v_max_dist); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 278, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_4);
       __Pyx_INCREF(__pyx_t_1);
       __pyx_t_5 = __pyx_t_1; __pyx_t_6 = NULL;
@@ -4158,7 +4158,7 @@ static PyObject *__pyx_f_5skbio_8metadata_13_intersection_12IntervalNode_right(s
           __pyx_t_7 = 1;
         }
       }
-      __pyx_t_8 = PyTuple_New(3+__pyx_t_7); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 276, __pyx_L1_error)
+      __pyx_t_8 = PyTuple_New(3+__pyx_t_7); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 278, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_8);
       if (__pyx_t_6) {
         __Pyx_GIVEREF(__pyx_t_6); PyTuple_SET_ITEM(__pyx_t_8, 0, __pyx_t_6); __pyx_t_6 = NULL;
@@ -4172,7 +4172,7 @@ static PyObject *__pyx_f_5skbio_8metadata_13_intersection_12IntervalNode_right(s
       PyTuple_SET_ITEM(__pyx_t_8, 2+__pyx_t_7, __pyx_t_4);
       __pyx_t_3 = 0;
       __pyx_t_4 = 0;
-      __pyx_t_2 = __Pyx_PyObject_Call(__pyx_t_5, __pyx_t_8, NULL); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 276, __pyx_L1_error)
+      __pyx_t_2 = __Pyx_PyObject_Call(__pyx_t_5, __pyx_t_8, NULL); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 278, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_2);
       __Pyx_DECREF(__pyx_t_8); __pyx_t_8 = 0;
       __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
@@ -4184,39 +4184,39 @@ static PyObject *__pyx_f_5skbio_8metadata_13_intersection_12IntervalNode_right(s
     __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   }
 
-  /* "skbio/metadata/_intersection.pyx":283
+  /* "skbio/metadata/_intersection.pyx":285
  *         max_dist: the maximum distance to look before giving up.
  *         """
  *         cdef list results = []             # <<<<<<<<<<<<<<
  *         # use end + 1 becuase .right() assumes strictly right-of
  *         self._seek_right(position + 1, results, n, max_dist)
  */
-  __pyx_t_1 = PyList_New(0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 283, __pyx_L1_error)
+  __pyx_t_1 = PyList_New(0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 285, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __pyx_v_results = ((PyObject*)__pyx_t_1);
   __pyx_t_1 = 0;
 
-  /* "skbio/metadata/_intersection.pyx":285
+  /* "skbio/metadata/_intersection.pyx":287
  *         cdef list results = []
  *         # use end + 1 becuase .right() assumes strictly right-of
  *         self._seek_right(position + 1, results, n, max_dist)             # <<<<<<<<<<<<<<
  *         if len(results) == n: return results
  *         r = results
  */
-  __pyx_t_1 = __Pyx_PyInt_AddObjC(__pyx_v_position, __pyx_int_1, 1, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 285, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyInt_AddObjC(__pyx_v_position, __pyx_int_1, 1, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 287, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_9 = __Pyx_PyInt_As_int(__pyx_t_1); if (unlikely((__pyx_t_9 == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 285, __pyx_L1_error)
+  __pyx_t_9 = __Pyx_PyInt_As_int(__pyx_t_1); if (unlikely((__pyx_t_9 == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 287, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   ((struct __pyx_vtabstruct_5skbio_8metadata_13_intersection_IntervalNode *)__pyx_v_self->__pyx_vtab)->_seek_right(__pyx_v_self, __pyx_t_9, __pyx_v_results, __pyx_v_n, __pyx_v_max_dist);
 
-  /* "skbio/metadata/_intersection.pyx":286
+  /* "skbio/metadata/_intersection.pyx":288
  *         # use end + 1 becuase .right() assumes strictly right-of
  *         self._seek_right(position + 1, results, n, max_dist)
  *         if len(results) == n: return results             # <<<<<<<<<<<<<<
  *         r = results
  *         r.sort(key=operator.attrgetter('start'))
  */
-  __pyx_t_7 = PyList_GET_SIZE(__pyx_v_results); if (unlikely(__pyx_t_7 == -1)) __PYX_ERR(0, 286, __pyx_L1_error)
+  __pyx_t_7 = PyList_GET_SIZE(__pyx_v_results); if (unlikely(__pyx_t_7 == -1)) __PYX_ERR(0, 288, __pyx_L1_error)
   __pyx_t_10 = ((__pyx_t_7 == __pyx_v_n) != 0);
   if (__pyx_t_10) {
     __Pyx_XDECREF(__pyx_r);
@@ -4225,7 +4225,7 @@ static PyObject *__pyx_f_5skbio_8metadata_13_intersection_12IntervalNode_right(s
     goto __pyx_L0;
   }
 
-  /* "skbio/metadata/_intersection.pyx":287
+  /* "skbio/metadata/_intersection.pyx":289
  *         self._seek_right(position + 1, results, n, max_dist)
  *         if len(results) == n: return results
  *         r = results             # <<<<<<<<<<<<<<
@@ -4235,34 +4235,34 @@ static PyObject *__pyx_f_5skbio_8metadata_13_intersection_12IntervalNode_right(s
   __Pyx_INCREF(__pyx_v_results);
   __pyx_v_r = __pyx_v_results;
 
-  /* "skbio/metadata/_intersection.pyx":288
+  /* "skbio/metadata/_intersection.pyx":290
  *         if len(results) == n: return results
  *         r = results
  *         r.sort(key=operator.attrgetter('start'))             # <<<<<<<<<<<<<<
  *         return r[:n]
  * 
  */
-  __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_v_r, __pyx_n_s_sort); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 288, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_v_r, __pyx_n_s_sort); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 290, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_2 = PyDict_New(); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 288, __pyx_L1_error)
+  __pyx_t_2 = PyDict_New(); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 290, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
-  __pyx_t_5 = __Pyx_GetModuleGlobalName(__pyx_n_s_operator); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 288, __pyx_L1_error)
+  __pyx_t_5 = __Pyx_GetModuleGlobalName(__pyx_n_s_operator); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 290, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_5);
-  __pyx_t_8 = __Pyx_PyObject_GetAttrStr(__pyx_t_5, __pyx_n_s_attrgetter); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 288, __pyx_L1_error)
+  __pyx_t_8 = __Pyx_PyObject_GetAttrStr(__pyx_t_5, __pyx_n_s_attrgetter); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 290, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_8);
   __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
-  __pyx_t_5 = __Pyx_PyObject_Call(__pyx_t_8, __pyx_tuple__2, NULL); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 288, __pyx_L1_error)
+  __pyx_t_5 = __Pyx_PyObject_Call(__pyx_t_8, __pyx_tuple__2, NULL); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 290, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_5);
   __Pyx_DECREF(__pyx_t_8); __pyx_t_8 = 0;
-  if (PyDict_SetItem(__pyx_t_2, __pyx_n_s_key, __pyx_t_5) < 0) __PYX_ERR(0, 288, __pyx_L1_error)
+  if (PyDict_SetItem(__pyx_t_2, __pyx_n_s_key, __pyx_t_5) < 0) __PYX_ERR(0, 290, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
-  __pyx_t_5 = __Pyx_PyObject_Call(__pyx_t_1, __pyx_empty_tuple, __pyx_t_2); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 288, __pyx_L1_error)
+  __pyx_t_5 = __Pyx_PyObject_Call(__pyx_t_1, __pyx_empty_tuple, __pyx_t_2); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 290, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_5);
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
   __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
 
-  /* "skbio/metadata/_intersection.pyx":289
+  /* "skbio/metadata/_intersection.pyx":291
  *         r = results
  *         r.sort(key=operator.attrgetter('start'))
  *         return r[:n]             # <<<<<<<<<<<<<<
@@ -4270,13 +4270,13 @@ static PyObject *__pyx_f_5skbio_8metadata_13_intersection_12IntervalNode_right(s
  *     def traverse(self, func):
  */
   __Pyx_XDECREF(__pyx_r);
-  __pyx_t_5 = __Pyx_PyList_GetSlice(__pyx_v_r, 0, __pyx_v_n); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 289, __pyx_L1_error)
+  __pyx_t_5 = __Pyx_PyList_GetSlice(__pyx_v_r, 0, __pyx_v_n); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 291, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_5);
   __pyx_r = __pyx_t_5;
   __pyx_t_5 = 0;
   goto __pyx_L0;
 
-  /* "skbio/metadata/_intersection.pyx":276
+  /* "skbio/metadata/_intersection.pyx":278
  *         return r[:n]
  * 
  *     cpdef right(self, position, int n=1, int max_dist=2500):             # <<<<<<<<<<<<<<
@@ -4343,7 +4343,7 @@ static PyObject *__pyx_pw_5skbio_8metadata_13_intersection_12IntervalNode_13righ
         }
       }
       if (unlikely(kw_args > 0)) {
-        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "right") < 0)) __PYX_ERR(0, 276, __pyx_L3_error)
+        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "right") < 0)) __PYX_ERR(0, 278, __pyx_L3_error)
       }
     } else {
       switch (PyTuple_GET_SIZE(__pyx_args)) {
@@ -4356,19 +4356,19 @@ static PyObject *__pyx_pw_5skbio_8metadata_13_intersection_12IntervalNode_13righ
     }
     __pyx_v_position = values[0];
     if (values[1]) {
-      __pyx_v_n = __Pyx_PyInt_As_int(values[1]); if (unlikely((__pyx_v_n == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 276, __pyx_L3_error)
+      __pyx_v_n = __Pyx_PyInt_As_int(values[1]); if (unlikely((__pyx_v_n == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 278, __pyx_L3_error)
     } else {
       __pyx_v_n = ((int)1);
     }
     if (values[2]) {
-      __pyx_v_max_dist = __Pyx_PyInt_As_int(values[2]); if (unlikely((__pyx_v_max_dist == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 276, __pyx_L3_error)
+      __pyx_v_max_dist = __Pyx_PyInt_As_int(values[2]); if (unlikely((__pyx_v_max_dist == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 278, __pyx_L3_error)
     } else {
       __pyx_v_max_dist = ((int)0x9C4);
     }
   }
   goto __pyx_L4_argument_unpacking_done;
   __pyx_L5_argtuple_error:;
-  __Pyx_RaiseArgtupleInvalid("right", 0, 1, 3, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 276, __pyx_L3_error)
+  __Pyx_RaiseArgtupleInvalid("right", 0, 1, 3, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 278, __pyx_L3_error)
   __pyx_L3_error:;
   __Pyx_AddTraceback("skbio.metadata._intersection.IntervalNode.right", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __Pyx_RefNannyFinishContext();
@@ -4391,7 +4391,7 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_12IntervalNode_12righ
   __pyx_t_2.__pyx_n = 2;
   __pyx_t_2.n = __pyx_v_n;
   __pyx_t_2.max_dist = __pyx_v_max_dist;
-  __pyx_t_1 = __pyx_vtabptr_5skbio_8metadata_13_intersection_IntervalNode->right(__pyx_v_self, __pyx_v_position, 1, &__pyx_t_2); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 276, __pyx_L1_error)
+  __pyx_t_1 = __pyx_vtabptr_5skbio_8metadata_13_intersection_IntervalNode->right(__pyx_v_self, __pyx_v_position, 1, &__pyx_t_2); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 278, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __pyx_r = __pyx_t_1;
   __pyx_t_1 = 0;
@@ -4408,7 +4408,7 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_12IntervalNode_12righ
   return __pyx_r;
 }
 
-/* "skbio/metadata/_intersection.pyx":291
+/* "skbio/metadata/_intersection.pyx":293
  *         return r[:n]
  * 
  *     def traverse(self, func):             # <<<<<<<<<<<<<<
@@ -4434,7 +4434,7 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_12IntervalNode_14trav
   __Pyx_RefNannyDeclarations
   __Pyx_RefNannySetupContext("traverse", 0);
 
-  /* "skbio/metadata/_intersection.pyx":292
+  /* "skbio/metadata/_intersection.pyx":294
  * 
  *     def traverse(self, func):
  *         self._traverse(func)             # <<<<<<<<<<<<<<
@@ -4443,7 +4443,7 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_12IntervalNode_14trav
  */
   ((struct __pyx_vtabstruct_5skbio_8metadata_13_intersection_IntervalNode *)__pyx_v_self->__pyx_vtab)->_traverse(__pyx_v_self, __pyx_v_func);
 
-  /* "skbio/metadata/_intersection.pyx":291
+  /* "skbio/metadata/_intersection.pyx":293
  *         return r[:n]
  * 
  *     def traverse(self, func):             # <<<<<<<<<<<<<<
@@ -4458,7 +4458,7 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_12IntervalNode_14trav
   return __pyx_r;
 }
 
-/* "skbio/metadata/_intersection.pyx":294
+/* "skbio/metadata/_intersection.pyx":296
  *         self._traverse(func)
  * 
  *     cdef void _traverse(IntervalNode self, object func):             # <<<<<<<<<<<<<<
@@ -4476,7 +4476,7 @@ static void __pyx_f_5skbio_8metadata_13_intersection_12IntervalNode__traverse(st
   PyObject *__pyx_t_6 = NULL;
   __Pyx_RefNannySetupContext("_traverse", 0);
 
-  /* "skbio/metadata/_intersection.pyx":295
+  /* "skbio/metadata/_intersection.pyx":297
  * 
  *     cdef void _traverse(IntervalNode self, object func):
  *         if self.cleft is not EmptyNode: self.cleft._traverse(func)             # <<<<<<<<<<<<<<
@@ -4489,7 +4489,7 @@ static void __pyx_f_5skbio_8metadata_13_intersection_12IntervalNode__traverse(st
     ((struct __pyx_vtabstruct_5skbio_8metadata_13_intersection_IntervalNode *)__pyx_v_self->cleft->__pyx_vtab)->_traverse(__pyx_v_self->cleft, __pyx_v_func);
   }
 
-  /* "skbio/metadata/_intersection.pyx":296
+  /* "skbio/metadata/_intersection.pyx":298
  *     cdef void _traverse(IntervalNode self, object func):
  *         if self.cleft is not EmptyNode: self.cleft._traverse(func)
  *         func(self)             # <<<<<<<<<<<<<<
@@ -4508,23 +4508,23 @@ static void __pyx_f_5skbio_8metadata_13_intersection_12IntervalNode__traverse(st
     }
   }
   if (!__pyx_t_5) {
-    __pyx_t_3 = __Pyx_PyObject_CallOneArg(__pyx_t_4, ((PyObject *)__pyx_v_self)); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 296, __pyx_L1_error)
+    __pyx_t_3 = __Pyx_PyObject_CallOneArg(__pyx_t_4, ((PyObject *)__pyx_v_self)); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 298, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
   } else {
-    __pyx_t_6 = PyTuple_New(1+1); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 296, __pyx_L1_error)
+    __pyx_t_6 = PyTuple_New(1+1); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 298, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_6);
     __Pyx_GIVEREF(__pyx_t_5); PyTuple_SET_ITEM(__pyx_t_6, 0, __pyx_t_5); __pyx_t_5 = NULL;
     __Pyx_INCREF(((PyObject *)__pyx_v_self));
     __Pyx_GIVEREF(((PyObject *)__pyx_v_self));
     PyTuple_SET_ITEM(__pyx_t_6, 0+1, ((PyObject *)__pyx_v_self));
-    __pyx_t_3 = __Pyx_PyObject_Call(__pyx_t_4, __pyx_t_6, NULL); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 296, __pyx_L1_error)
+    __pyx_t_3 = __Pyx_PyObject_Call(__pyx_t_4, __pyx_t_6, NULL); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 298, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
     __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
   }
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
 
-  /* "skbio/metadata/_intersection.pyx":297
+  /* "skbio/metadata/_intersection.pyx":299
  *         if self.cleft is not EmptyNode: self.cleft._traverse(func)
  *         func(self)
  *         if self.cright is not EmptyNode: self.cright._traverse(func)             # <<<<<<<<<<<<<<
@@ -4537,7 +4537,7 @@ static void __pyx_f_5skbio_8metadata_13_intersection_12IntervalNode__traverse(st
     ((struct __pyx_vtabstruct_5skbio_8metadata_13_intersection_IntervalNode *)__pyx_v_self->cright->__pyx_vtab)->_traverse(__pyx_v_self->cright, __pyx_v_func);
   }
 
-  /* "skbio/metadata/_intersection.pyx":294
+  /* "skbio/metadata/_intersection.pyx":296
  *         self._traverse(func)
  * 
  *     cdef void _traverse(IntervalNode self, object func):             # <<<<<<<<<<<<<<
@@ -4796,7 +4796,7 @@ static int __pyx_pf_5skbio_8metadata_13_intersection_12IntervalNode_3end_2__set_
   return __pyx_r;
 }
 
-/* "skbio/metadata/_intersection.pyx":320
+/* "skbio/metadata/_intersection.pyx":322
  *     cdef public object value, chrom, strand
  * 
  *     def __init__(self, int start, int end, object value=None, object chrom=None, object strand=None ):             # <<<<<<<<<<<<<<
@@ -4841,7 +4841,7 @@ static int __pyx_pw_5skbio_8metadata_13_intersection_11IntervalObj_1__init__(PyO
         case  1:
         if (likely((values[1] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_end)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("__init__", 0, 2, 5, 1); __PYX_ERR(0, 320, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("__init__", 0, 2, 5, 1); __PYX_ERR(0, 322, __pyx_L3_error)
         }
         case  2:
         if (kw_args > 0) {
@@ -4860,7 +4860,7 @@ static int __pyx_pw_5skbio_8metadata_13_intersection_11IntervalObj_1__init__(PyO
         }
       }
       if (unlikely(kw_args > 0)) {
-        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "__init__") < 0)) __PYX_ERR(0, 320, __pyx_L3_error)
+        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "__init__") < 0)) __PYX_ERR(0, 322, __pyx_L3_error)
       }
     } else {
       switch (PyTuple_GET_SIZE(__pyx_args)) {
@@ -4873,15 +4873,15 @@ static int __pyx_pw_5skbio_8metadata_13_intersection_11IntervalObj_1__init__(PyO
         default: goto __pyx_L5_argtuple_error;
       }
     }
-    __pyx_v_start = __Pyx_PyInt_As_int(values[0]); if (unlikely((__pyx_v_start == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 320, __pyx_L3_error)
-    __pyx_v_end = __Pyx_PyInt_As_int(values[1]); if (unlikely((__pyx_v_end == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 320, __pyx_L3_error)
+    __pyx_v_start = __Pyx_PyInt_As_int(values[0]); if (unlikely((__pyx_v_start == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 322, __pyx_L3_error)
+    __pyx_v_end = __Pyx_PyInt_As_int(values[1]); if (unlikely((__pyx_v_end == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 322, __pyx_L3_error)
     __pyx_v_value = values[2];
     __pyx_v_chrom = values[3];
     __pyx_v_strand = values[4];
   }
   goto __pyx_L4_argument_unpacking_done;
   __pyx_L5_argtuple_error:;
-  __Pyx_RaiseArgtupleInvalid("__init__", 0, 2, 5, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 320, __pyx_L3_error)
+  __Pyx_RaiseArgtupleInvalid("__init__", 0, 2, 5, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 322, __pyx_L3_error)
   __pyx_L3_error:;
   __Pyx_AddTraceback("skbio.metadata._intersection.IntervalObj.__init__", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __Pyx_RefNannyFinishContext();
@@ -4899,7 +4899,7 @@ static int __pyx_pf_5skbio_8metadata_13_intersection_11IntervalObj___init__(stru
   __Pyx_RefNannyDeclarations
   __Pyx_RefNannySetupContext("__init__", 0);
 
-  /* "skbio/metadata/_intersection.pyx":321
+  /* "skbio/metadata/_intersection.pyx":323
  * 
  *     def __init__(self, int start, int end, object value=None, object chrom=None, object strand=None ):
  *         assert start <= end, "start must be less than end"             # <<<<<<<<<<<<<<
@@ -4910,12 +4910,12 @@ static int __pyx_pf_5skbio_8metadata_13_intersection_11IntervalObj___init__(stru
   if (unlikely(!Py_OptimizeFlag)) {
     if (unlikely(!((__pyx_v_start <= __pyx_v_end) != 0))) {
       PyErr_SetObject(PyExc_AssertionError, __pyx_kp_s_start_must_be_less_than_end);
-      __PYX_ERR(0, 321, __pyx_L1_error)
+      __PYX_ERR(0, 323, __pyx_L1_error)
     }
   }
   #endif
 
-  /* "skbio/metadata/_intersection.pyx":322
+  /* "skbio/metadata/_intersection.pyx":324
  *     def __init__(self, int start, int end, object value=None, object chrom=None, object strand=None ):
  *         assert start <= end, "start must be less than end"
  *         self.start  = start             # <<<<<<<<<<<<<<
@@ -4924,7 +4924,7 @@ static int __pyx_pf_5skbio_8metadata_13_intersection_11IntervalObj___init__(stru
  */
   __pyx_v_self->start = __pyx_v_start;
 
-  /* "skbio/metadata/_intersection.pyx":323
+  /* "skbio/metadata/_intersection.pyx":325
  *         assert start <= end, "start must be less than end"
  *         self.start  = start
  *         self.end   = end             # <<<<<<<<<<<<<<
@@ -4933,7 +4933,7 @@ static int __pyx_pf_5skbio_8metadata_13_intersection_11IntervalObj___init__(stru
  */
   __pyx_v_self->end = __pyx_v_end;
 
-  /* "skbio/metadata/_intersection.pyx":324
+  /* "skbio/metadata/_intersection.pyx":326
  *         self.start  = start
  *         self.end   = end
  *         self.value = value             # <<<<<<<<<<<<<<
@@ -4946,7 +4946,7 @@ static int __pyx_pf_5skbio_8metadata_13_intersection_11IntervalObj___init__(stru
   __Pyx_DECREF(__pyx_v_self->value);
   __pyx_v_self->value = __pyx_v_value;
 
-  /* "skbio/metadata/_intersection.pyx":325
+  /* "skbio/metadata/_intersection.pyx":327
  *         self.end   = end
  *         self.value = value
  *         self.chrom = chrom             # <<<<<<<<<<<<<<
@@ -4959,7 +4959,7 @@ static int __pyx_pf_5skbio_8metadata_13_intersection_11IntervalObj___init__(stru
   __Pyx_DECREF(__pyx_v_self->chrom);
   __pyx_v_self->chrom = __pyx_v_chrom;
 
-  /* "skbio/metadata/_intersection.pyx":326
+  /* "skbio/metadata/_intersection.pyx":328
  *         self.value = value
  *         self.chrom = chrom
  *         self.strand = strand             # <<<<<<<<<<<<<<
@@ -4972,7 +4972,7 @@ static int __pyx_pf_5skbio_8metadata_13_intersection_11IntervalObj___init__(stru
   __Pyx_DECREF(__pyx_v_self->strand);
   __pyx_v_self->strand = __pyx_v_strand;
 
-  /* "skbio/metadata/_intersection.pyx":320
+  /* "skbio/metadata/_intersection.pyx":322
  *     cdef public object value, chrom, strand
  * 
  *     def __init__(self, int start, int end, object value=None, object chrom=None, object strand=None ):             # <<<<<<<<<<<<<<
@@ -4991,7 +4991,7 @@ static int __pyx_pf_5skbio_8metadata_13_intersection_11IntervalObj___init__(stru
   return __pyx_r;
 }
 
-/* "skbio/metadata/_intersection.pyx":328
+/* "skbio/metadata/_intersection.pyx":330
  *         self.strand = strand
  * 
  *     def __repr__(self):             # <<<<<<<<<<<<<<
@@ -5023,18 +5023,18 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_11IntervalObj_2__repr
   int __pyx_t_5;
   __Pyx_RefNannySetupContext("__repr__", 0);
 
-  /* "skbio/metadata/_intersection.pyx":329
+  /* "skbio/metadata/_intersection.pyx":331
  * 
  *     def __repr__(self):
  *         fstr = "IntervalObj(%d, %d" % (self.start, self.end)             # <<<<<<<<<<<<<<
  *         if not self.value is None:
  *             fstr += ", value=" + str(self.value)
  */
-  __pyx_t_1 = __Pyx_PyInt_From_int(__pyx_v_self->start); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 329, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyInt_From_int(__pyx_v_self->start); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 331, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_2 = __Pyx_PyInt_From_int(__pyx_v_self->end); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 329, __pyx_L1_error)
+  __pyx_t_2 = __Pyx_PyInt_From_int(__pyx_v_self->end); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 331, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
-  __pyx_t_3 = PyTuple_New(2); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 329, __pyx_L1_error)
+  __pyx_t_3 = PyTuple_New(2); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 331, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
   __Pyx_GIVEREF(__pyx_t_1);
   PyTuple_SET_ITEM(__pyx_t_3, 0, __pyx_t_1);
@@ -5042,13 +5042,13 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_11IntervalObj_2__repr
   PyTuple_SET_ITEM(__pyx_t_3, 1, __pyx_t_2);
   __pyx_t_1 = 0;
   __pyx_t_2 = 0;
-  __pyx_t_2 = __Pyx_PyString_Format(__pyx_kp_s_IntervalObj_d_d, __pyx_t_3); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 329, __pyx_L1_error)
+  __pyx_t_2 = __Pyx_PyString_Format(__pyx_kp_s_IntervalObj_d_d, __pyx_t_3); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 331, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
   __pyx_v_fstr = __pyx_t_2;
   __pyx_t_2 = 0;
 
-  /* "skbio/metadata/_intersection.pyx":330
+  /* "skbio/metadata/_intersection.pyx":332
  *     def __repr__(self):
  *         fstr = "IntervalObj(%d, %d" % (self.start, self.end)
  *         if not self.value is None:             # <<<<<<<<<<<<<<
@@ -5059,31 +5059,31 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_11IntervalObj_2__repr
   __pyx_t_5 = (__pyx_t_4 != 0);
   if (__pyx_t_5) {
 
-    /* "skbio/metadata/_intersection.pyx":331
+    /* "skbio/metadata/_intersection.pyx":333
  *         fstr = "IntervalObj(%d, %d" % (self.start, self.end)
  *         if not self.value is None:
  *             fstr += ", value=" + str(self.value)             # <<<<<<<<<<<<<<
  *         fstr += ")"
  *         return fstr
  */
-    __pyx_t_2 = PyTuple_New(1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 331, __pyx_L1_error)
+    __pyx_t_2 = PyTuple_New(1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 333, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_2);
     __Pyx_INCREF(__pyx_v_self->value);
     __Pyx_GIVEREF(__pyx_v_self->value);
     PyTuple_SET_ITEM(__pyx_t_2, 0, __pyx_v_self->value);
-    __pyx_t_3 = __Pyx_PyObject_Call(((PyObject *)(&PyString_Type)), __pyx_t_2, NULL); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 331, __pyx_L1_error)
+    __pyx_t_3 = __Pyx_PyObject_Call(((PyObject *)(&PyString_Type)), __pyx_t_2, NULL); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 333, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
     __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
-    __pyx_t_2 = PyNumber_Add(__pyx_kp_s_value_2, __pyx_t_3); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 331, __pyx_L1_error)
+    __pyx_t_2 = PyNumber_Add(__pyx_kp_s_value_2, __pyx_t_3); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 333, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_2);
     __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
-    __pyx_t_3 = PyNumber_InPlaceAdd(__pyx_v_fstr, __pyx_t_2); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 331, __pyx_L1_error)
+    __pyx_t_3 = PyNumber_InPlaceAdd(__pyx_v_fstr, __pyx_t_2); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 333, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
     __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
     __Pyx_DECREF_SET(__pyx_v_fstr, __pyx_t_3);
     __pyx_t_3 = 0;
 
-    /* "skbio/metadata/_intersection.pyx":330
+    /* "skbio/metadata/_intersection.pyx":332
  *     def __repr__(self):
  *         fstr = "IntervalObj(%d, %d" % (self.start, self.end)
  *         if not self.value is None:             # <<<<<<<<<<<<<<
@@ -5092,19 +5092,19 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_11IntervalObj_2__repr
  */
   }
 
-  /* "skbio/metadata/_intersection.pyx":332
+  /* "skbio/metadata/_intersection.pyx":334
  *         if not self.value is None:
  *             fstr += ", value=" + str(self.value)
  *         fstr += ")"             # <<<<<<<<<<<<<<
  *         return fstr
  * 
  */
-  __pyx_t_3 = PyNumber_InPlaceAdd(__pyx_v_fstr, __pyx_kp_s__3); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 332, __pyx_L1_error)
+  __pyx_t_3 = PyNumber_InPlaceAdd(__pyx_v_fstr, __pyx_kp_s__3); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 334, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
   __Pyx_DECREF_SET(__pyx_v_fstr, __pyx_t_3);
   __pyx_t_3 = 0;
 
-  /* "skbio/metadata/_intersection.pyx":333
+  /* "skbio/metadata/_intersection.pyx":335
  *             fstr += ", value=" + str(self.value)
  *         fstr += ")"
  *         return fstr             # <<<<<<<<<<<<<<
@@ -5116,7 +5116,7 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_11IntervalObj_2__repr
   __pyx_r = __pyx_v_fstr;
   goto __pyx_L0;
 
-  /* "skbio/metadata/_intersection.pyx":328
+  /* "skbio/metadata/_intersection.pyx":330
  *         self.strand = strand
  * 
  *     def __repr__(self):             # <<<<<<<<<<<<<<
@@ -5138,7 +5138,7 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_11IntervalObj_2__repr
   return __pyx_r;
 }
 
-/* "skbio/metadata/_intersection.pyx":335
+/* "skbio/metadata/_intersection.pyx":337
  *         return fstr
  * 
  *     def __richcmp__(self, other, op):             # <<<<<<<<<<<<<<
@@ -5153,7 +5153,7 @@ static PyObject *__pyx_pw_5skbio_8metadata_13_intersection_11IntervalObj_5__rich
   PyObject *__pyx_r = 0;
   __Pyx_RefNannyDeclarations
   __Pyx_RefNannySetupContext("__richcmp__ (wrapper)", 0);
-  __pyx_v_op = __Pyx_PyInt_From_int(__pyx_arg_op); if (unlikely(!__pyx_v_op)) __PYX_ERR(0, 335, __pyx_L3_error)
+  __pyx_v_op = __Pyx_PyInt_From_int(__pyx_arg_op); if (unlikely(!__pyx_v_op)) __PYX_ERR(0, 337, __pyx_L3_error)
   __Pyx_GOTREF(__pyx_v_op);
   goto __pyx_L4_argument_unpacking_done;
   __pyx_L3_error:;
@@ -5179,20 +5179,20 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_11IntervalObj_4__rich
   PyObject *__pyx_t_5 = NULL;
   __Pyx_RefNannySetupContext("__richcmp__", 0);
 
-  /* "skbio/metadata/_intersection.pyx":336
+  /* "skbio/metadata/_intersection.pyx":338
  * 
  *     def __richcmp__(self, other, op):
  *         if op == 0:             # <<<<<<<<<<<<<<
  *             # <
  *             return self.start < other.start or self.end < other.end
  */
-  __pyx_t_1 = __Pyx_PyInt_EqObjC(__pyx_v_op, __pyx_int_0, 0, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 336, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyInt_EqObjC(__pyx_v_op, __pyx_int_0, 0, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 338, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_2 = __Pyx_PyObject_IsTrue(__pyx_t_1); if (unlikely(__pyx_t_2 < 0)) __PYX_ERR(0, 336, __pyx_L1_error)
+  __pyx_t_2 = __Pyx_PyObject_IsTrue(__pyx_t_1); if (unlikely(__pyx_t_2 < 0)) __PYX_ERR(0, 338, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   if (__pyx_t_2) {
 
-    /* "skbio/metadata/_intersection.pyx":338
+    /* "skbio/metadata/_intersection.pyx":340
  *         if op == 0:
  *             # <
  *             return self.start < other.start or self.end < other.end             # <<<<<<<<<<<<<<
@@ -5200,14 +5200,14 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_11IntervalObj_4__rich
  *             # <=
  */
     __Pyx_XDECREF(__pyx_r);
-    __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_v_self, __pyx_n_s_start); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 338, __pyx_L1_error)
+    __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_v_self, __pyx_n_s_start); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 340, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
-    __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_v_other, __pyx_n_s_start); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 338, __pyx_L1_error)
+    __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_v_other, __pyx_n_s_start); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 340, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_4);
-    __pyx_t_5 = PyObject_RichCompare(__pyx_t_3, __pyx_t_4, Py_LT); __Pyx_XGOTREF(__pyx_t_5); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 338, __pyx_L1_error)
+    __pyx_t_5 = PyObject_RichCompare(__pyx_t_3, __pyx_t_4, Py_LT); __Pyx_XGOTREF(__pyx_t_5); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 340, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
     __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
-    __pyx_t_2 = __Pyx_PyObject_IsTrue(__pyx_t_5); if (unlikely(__pyx_t_2 < 0)) __PYX_ERR(0, 338, __pyx_L1_error)
+    __pyx_t_2 = __Pyx_PyObject_IsTrue(__pyx_t_5); if (unlikely(__pyx_t_2 < 0)) __PYX_ERR(0, 340, __pyx_L1_error)
     if (!__pyx_t_2) {
       __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
     } else {
@@ -5216,11 +5216,11 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_11IntervalObj_4__rich
       __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
       goto __pyx_L4_bool_binop_done;
     }
-    __pyx_t_5 = __Pyx_PyObject_GetAttrStr(__pyx_v_self, __pyx_n_s_end); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 338, __pyx_L1_error)
+    __pyx_t_5 = __Pyx_PyObject_GetAttrStr(__pyx_v_self, __pyx_n_s_end); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 340, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_5);
-    __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_v_other, __pyx_n_s_end); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 338, __pyx_L1_error)
+    __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_v_other, __pyx_n_s_end); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 340, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_4);
-    __pyx_t_3 = PyObject_RichCompare(__pyx_t_5, __pyx_t_4, Py_LT); __Pyx_XGOTREF(__pyx_t_3); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 338, __pyx_L1_error)
+    __pyx_t_3 = PyObject_RichCompare(__pyx_t_5, __pyx_t_4, Py_LT); __Pyx_XGOTREF(__pyx_t_3); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 340, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
     __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
     __Pyx_INCREF(__pyx_t_3);
@@ -5231,7 +5231,7 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_11IntervalObj_4__rich
     __pyx_t_1 = 0;
     goto __pyx_L0;
 
-    /* "skbio/metadata/_intersection.pyx":336
+    /* "skbio/metadata/_intersection.pyx":338
  * 
  *     def __richcmp__(self, other, op):
  *         if op == 0:             # <<<<<<<<<<<<<<
@@ -5240,20 +5240,20 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_11IntervalObj_4__rich
  */
   }
 
-  /* "skbio/metadata/_intersection.pyx":339
+  /* "skbio/metadata/_intersection.pyx":341
  *             # <
  *             return self.start < other.start or self.end < other.end
  *         elif op == 1:             # <<<<<<<<<<<<<<
  *             # <=
  *             return self == other or self < other
  */
-  __pyx_t_1 = __Pyx_PyInt_EqObjC(__pyx_v_op, __pyx_int_1, 1, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 339, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyInt_EqObjC(__pyx_v_op, __pyx_int_1, 1, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 341, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_2 = __Pyx_PyObject_IsTrue(__pyx_t_1); if (unlikely(__pyx_t_2 < 0)) __PYX_ERR(0, 339, __pyx_L1_error)
+  __pyx_t_2 = __Pyx_PyObject_IsTrue(__pyx_t_1); if (unlikely(__pyx_t_2 < 0)) __PYX_ERR(0, 341, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   if (__pyx_t_2) {
 
-    /* "skbio/metadata/_intersection.pyx":341
+    /* "skbio/metadata/_intersection.pyx":343
  *         elif op == 1:
  *             # <=
  *             return self == other or self < other             # <<<<<<<<<<<<<<
@@ -5261,8 +5261,8 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_11IntervalObj_4__rich
  *             # ==
  */
     __Pyx_XDECREF(__pyx_r);
-    __pyx_t_3 = PyObject_RichCompare(__pyx_v_self, __pyx_v_other, Py_EQ); __Pyx_XGOTREF(__pyx_t_3); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 341, __pyx_L1_error)
-    __pyx_t_2 = __Pyx_PyObject_IsTrue(__pyx_t_3); if (unlikely(__pyx_t_2 < 0)) __PYX_ERR(0, 341, __pyx_L1_error)
+    __pyx_t_3 = PyObject_RichCompare(__pyx_v_self, __pyx_v_other, Py_EQ); __Pyx_XGOTREF(__pyx_t_3); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 343, __pyx_L1_error)
+    __pyx_t_2 = __Pyx_PyObject_IsTrue(__pyx_t_3); if (unlikely(__pyx_t_2 < 0)) __PYX_ERR(0, 343, __pyx_L1_error)
     if (!__pyx_t_2) {
       __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
     } else {
@@ -5271,7 +5271,7 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_11IntervalObj_4__rich
       __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
       goto __pyx_L6_bool_binop_done;
     }
-    __pyx_t_3 = PyObject_RichCompare(__pyx_v_self, __pyx_v_other, Py_LT); __Pyx_XGOTREF(__pyx_t_3); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 341, __pyx_L1_error)
+    __pyx_t_3 = PyObject_RichCompare(__pyx_v_self, __pyx_v_other, Py_LT); __Pyx_XGOTREF(__pyx_t_3); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 343, __pyx_L1_error)
     __Pyx_INCREF(__pyx_t_3);
     __pyx_t_1 = __pyx_t_3;
     __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
@@ -5280,7 +5280,7 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_11IntervalObj_4__rich
     __pyx_t_1 = 0;
     goto __pyx_L0;
 
-    /* "skbio/metadata/_intersection.pyx":339
+    /* "skbio/metadata/_intersection.pyx":341
  *             # <
  *             return self.start < other.start or self.end < other.end
  *         elif op == 1:             # <<<<<<<<<<<<<<
@@ -5289,20 +5289,20 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_11IntervalObj_4__rich
  */
   }
 
-  /* "skbio/metadata/_intersection.pyx":342
+  /* "skbio/metadata/_intersection.pyx":344
  *             # <=
  *             return self == other or self < other
  *         elif op == 2:             # <<<<<<<<<<<<<<
  *             # ==
  *             return self.start == other.start and self.end == other.end
  */
-  __pyx_t_1 = __Pyx_PyInt_EqObjC(__pyx_v_op, __pyx_int_2, 2, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 342, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyInt_EqObjC(__pyx_v_op, __pyx_int_2, 2, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 344, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_2 = __Pyx_PyObject_IsTrue(__pyx_t_1); if (unlikely(__pyx_t_2 < 0)) __PYX_ERR(0, 342, __pyx_L1_error)
+  __pyx_t_2 = __Pyx_PyObject_IsTrue(__pyx_t_1); if (unlikely(__pyx_t_2 < 0)) __PYX_ERR(0, 344, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   if (__pyx_t_2) {
 
-    /* "skbio/metadata/_intersection.pyx":344
+    /* "skbio/metadata/_intersection.pyx":346
  *         elif op == 2:
  *             # ==
  *             return self.start == other.start and self.end == other.end             # <<<<<<<<<<<<<<
@@ -5310,14 +5310,14 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_11IntervalObj_4__rich
  *             # !=
  */
     __Pyx_XDECREF(__pyx_r);
-    __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_v_self, __pyx_n_s_start); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 344, __pyx_L1_error)
+    __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_v_self, __pyx_n_s_start); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 346, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
-    __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_v_other, __pyx_n_s_start); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 344, __pyx_L1_error)
+    __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_v_other, __pyx_n_s_start); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 346, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_4);
-    __pyx_t_5 = PyObject_RichCompare(__pyx_t_3, __pyx_t_4, Py_EQ); __Pyx_XGOTREF(__pyx_t_5); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 344, __pyx_L1_error)
+    __pyx_t_5 = PyObject_RichCompare(__pyx_t_3, __pyx_t_4, Py_EQ); __Pyx_XGOTREF(__pyx_t_5); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 346, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
     __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
-    __pyx_t_2 = __Pyx_PyObject_IsTrue(__pyx_t_5); if (unlikely(__pyx_t_2 < 0)) __PYX_ERR(0, 344, __pyx_L1_error)
+    __pyx_t_2 = __Pyx_PyObject_IsTrue(__pyx_t_5); if (unlikely(__pyx_t_2 < 0)) __PYX_ERR(0, 346, __pyx_L1_error)
     if (__pyx_t_2) {
       __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
     } else {
@@ -5326,11 +5326,11 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_11IntervalObj_4__rich
       __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
       goto __pyx_L8_bool_binop_done;
     }
-    __pyx_t_5 = __Pyx_PyObject_GetAttrStr(__pyx_v_self, __pyx_n_s_end); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 344, __pyx_L1_error)
+    __pyx_t_5 = __Pyx_PyObject_GetAttrStr(__pyx_v_self, __pyx_n_s_end); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 346, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_5);
-    __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_v_other, __pyx_n_s_end); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 344, __pyx_L1_error)
+    __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_v_other, __pyx_n_s_end); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 346, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_4);
-    __pyx_t_3 = PyObject_RichCompare(__pyx_t_5, __pyx_t_4, Py_EQ); __Pyx_XGOTREF(__pyx_t_3); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 344, __pyx_L1_error)
+    __pyx_t_3 = PyObject_RichCompare(__pyx_t_5, __pyx_t_4, Py_EQ); __Pyx_XGOTREF(__pyx_t_3); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 346, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
     __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
     __Pyx_INCREF(__pyx_t_3);
@@ -5341,7 +5341,7 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_11IntervalObj_4__rich
     __pyx_t_1 = 0;
     goto __pyx_L0;
 
-    /* "skbio/metadata/_intersection.pyx":342
+    /* "skbio/metadata/_intersection.pyx":344
  *             # <=
  *             return self == other or self < other
  *         elif op == 2:             # <<<<<<<<<<<<<<
@@ -5350,20 +5350,20 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_11IntervalObj_4__rich
  */
   }
 
-  /* "skbio/metadata/_intersection.pyx":345
+  /* "skbio/metadata/_intersection.pyx":347
  *             # ==
  *             return self.start == other.start and self.end == other.end
  *         elif op == 3:             # <<<<<<<<<<<<<<
  *             # !=
  *             return self.start != other.start or self.end != other.end
  */
-  __pyx_t_1 = __Pyx_PyInt_EqObjC(__pyx_v_op, __pyx_int_3, 3, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 345, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyInt_EqObjC(__pyx_v_op, __pyx_int_3, 3, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 347, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_2 = __Pyx_PyObject_IsTrue(__pyx_t_1); if (unlikely(__pyx_t_2 < 0)) __PYX_ERR(0, 345, __pyx_L1_error)
+  __pyx_t_2 = __Pyx_PyObject_IsTrue(__pyx_t_1); if (unlikely(__pyx_t_2 < 0)) __PYX_ERR(0, 347, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   if (__pyx_t_2) {
 
-    /* "skbio/metadata/_intersection.pyx":347
+    /* "skbio/metadata/_intersection.pyx":349
  *         elif op == 3:
  *             # !=
  *             return self.start != other.start or self.end != other.end             # <<<<<<<<<<<<<<
@@ -5371,14 +5371,14 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_11IntervalObj_4__rich
  *             # >
  */
     __Pyx_XDECREF(__pyx_r);
-    __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_v_self, __pyx_n_s_start); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 347, __pyx_L1_error)
+    __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_v_self, __pyx_n_s_start); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 349, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
-    __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_v_other, __pyx_n_s_start); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 347, __pyx_L1_error)
+    __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_v_other, __pyx_n_s_start); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 349, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_4);
-    __pyx_t_5 = PyObject_RichCompare(__pyx_t_3, __pyx_t_4, Py_NE); __Pyx_XGOTREF(__pyx_t_5); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 347, __pyx_L1_error)
+    __pyx_t_5 = PyObject_RichCompare(__pyx_t_3, __pyx_t_4, Py_NE); __Pyx_XGOTREF(__pyx_t_5); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 349, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
     __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
-    __pyx_t_2 = __Pyx_PyObject_IsTrue(__pyx_t_5); if (unlikely(__pyx_t_2 < 0)) __PYX_ERR(0, 347, __pyx_L1_error)
+    __pyx_t_2 = __Pyx_PyObject_IsTrue(__pyx_t_5); if (unlikely(__pyx_t_2 < 0)) __PYX_ERR(0, 349, __pyx_L1_error)
     if (!__pyx_t_2) {
       __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
     } else {
@@ -5387,11 +5387,11 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_11IntervalObj_4__rich
       __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
       goto __pyx_L10_bool_binop_done;
     }
-    __pyx_t_5 = __Pyx_PyObject_GetAttrStr(__pyx_v_self, __pyx_n_s_end); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 347, __pyx_L1_error)
+    __pyx_t_5 = __Pyx_PyObject_GetAttrStr(__pyx_v_self, __pyx_n_s_end); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 349, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_5);
-    __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_v_other, __pyx_n_s_end); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 347, __pyx_L1_error)
+    __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_v_other, __pyx_n_s_end); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 349, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_4);
-    __pyx_t_3 = PyObject_RichCompare(__pyx_t_5, __pyx_t_4, Py_NE); __Pyx_XGOTREF(__pyx_t_3); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 347, __pyx_L1_error)
+    __pyx_t_3 = PyObject_RichCompare(__pyx_t_5, __pyx_t_4, Py_NE); __Pyx_XGOTREF(__pyx_t_3); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 349, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
     __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
     __Pyx_INCREF(__pyx_t_3);
@@ -5402,7 +5402,7 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_11IntervalObj_4__rich
     __pyx_t_1 = 0;
     goto __pyx_L0;
 
-    /* "skbio/metadata/_intersection.pyx":345
+    /* "skbio/metadata/_intersection.pyx":347
  *             # ==
  *             return self.start == other.start and self.end == other.end
  *         elif op == 3:             # <<<<<<<<<<<<<<
@@ -5411,20 +5411,20 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_11IntervalObj_4__rich
  */
   }
 
-  /* "skbio/metadata/_intersection.pyx":348
+  /* "skbio/metadata/_intersection.pyx":350
  *             # !=
  *             return self.start != other.start or self.end != other.end
  *         elif op == 4:             # <<<<<<<<<<<<<<
  *             # >
  *             return self.start > other.start or self.end > other.end
  */
-  __pyx_t_1 = __Pyx_PyInt_EqObjC(__pyx_v_op, __pyx_int_4, 4, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 348, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyInt_EqObjC(__pyx_v_op, __pyx_int_4, 4, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 350, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_2 = __Pyx_PyObject_IsTrue(__pyx_t_1); if (unlikely(__pyx_t_2 < 0)) __PYX_ERR(0, 348, __pyx_L1_error)
+  __pyx_t_2 = __Pyx_PyObject_IsTrue(__pyx_t_1); if (unlikely(__pyx_t_2 < 0)) __PYX_ERR(0, 350, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   if (__pyx_t_2) {
 
-    /* "skbio/metadata/_intersection.pyx":350
+    /* "skbio/metadata/_intersection.pyx":352
  *         elif op == 4:
  *             # >
  *             return self.start > other.start or self.end > other.end             # <<<<<<<<<<<<<<
@@ -5432,14 +5432,14 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_11IntervalObj_4__rich
  *             # >=
  */
     __Pyx_XDECREF(__pyx_r);
-    __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_v_self, __pyx_n_s_start); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 350, __pyx_L1_error)
+    __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_v_self, __pyx_n_s_start); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 352, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
-    __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_v_other, __pyx_n_s_start); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 350, __pyx_L1_error)
+    __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_v_other, __pyx_n_s_start); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 352, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_4);
-    __pyx_t_5 = PyObject_RichCompare(__pyx_t_3, __pyx_t_4, Py_GT); __Pyx_XGOTREF(__pyx_t_5); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 350, __pyx_L1_error)
+    __pyx_t_5 = PyObject_RichCompare(__pyx_t_3, __pyx_t_4, Py_GT); __Pyx_XGOTREF(__pyx_t_5); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 352, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
     __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
-    __pyx_t_2 = __Pyx_PyObject_IsTrue(__pyx_t_5); if (unlikely(__pyx_t_2 < 0)) __PYX_ERR(0, 350, __pyx_L1_error)
+    __pyx_t_2 = __Pyx_PyObject_IsTrue(__pyx_t_5); if (unlikely(__pyx_t_2 < 0)) __PYX_ERR(0, 352, __pyx_L1_error)
     if (!__pyx_t_2) {
       __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
     } else {
@@ -5448,11 +5448,11 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_11IntervalObj_4__rich
       __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
       goto __pyx_L12_bool_binop_done;
     }
-    __pyx_t_5 = __Pyx_PyObject_GetAttrStr(__pyx_v_self, __pyx_n_s_end); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 350, __pyx_L1_error)
+    __pyx_t_5 = __Pyx_PyObject_GetAttrStr(__pyx_v_self, __pyx_n_s_end); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 352, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_5);
-    __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_v_other, __pyx_n_s_end); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 350, __pyx_L1_error)
+    __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_v_other, __pyx_n_s_end); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 352, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_4);
-    __pyx_t_3 = PyObject_RichCompare(__pyx_t_5, __pyx_t_4, Py_GT); __Pyx_XGOTREF(__pyx_t_3); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 350, __pyx_L1_error)
+    __pyx_t_3 = PyObject_RichCompare(__pyx_t_5, __pyx_t_4, Py_GT); __Pyx_XGOTREF(__pyx_t_3); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 352, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
     __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
     __Pyx_INCREF(__pyx_t_3);
@@ -5463,7 +5463,7 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_11IntervalObj_4__rich
     __pyx_t_1 = 0;
     goto __pyx_L0;
 
-    /* "skbio/metadata/_intersection.pyx":348
+    /* "skbio/metadata/_intersection.pyx":350
  *             # !=
  *             return self.start != other.start or self.end != other.end
  *         elif op == 4:             # <<<<<<<<<<<<<<
@@ -5472,20 +5472,20 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_11IntervalObj_4__rich
  */
   }
 
-  /* "skbio/metadata/_intersection.pyx":351
+  /* "skbio/metadata/_intersection.pyx":353
  *             # >
  *             return self.start > other.start or self.end > other.end
  *         elif op == 5:             # <<<<<<<<<<<<<<
  *             # >=
  *             return self == other or self > other
  */
-  __pyx_t_1 = __Pyx_PyInt_EqObjC(__pyx_v_op, __pyx_int_5, 5, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 351, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyInt_EqObjC(__pyx_v_op, __pyx_int_5, 5, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 353, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_2 = __Pyx_PyObject_IsTrue(__pyx_t_1); if (unlikely(__pyx_t_2 < 0)) __PYX_ERR(0, 351, __pyx_L1_error)
+  __pyx_t_2 = __Pyx_PyObject_IsTrue(__pyx_t_1); if (unlikely(__pyx_t_2 < 0)) __PYX_ERR(0, 353, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   if (__pyx_t_2) {
 
-    /* "skbio/metadata/_intersection.pyx":353
+    /* "skbio/metadata/_intersection.pyx":355
  *         elif op == 5:
  *             # >=
  *             return self == other or self > other             # <<<<<<<<<<<<<<
@@ -5493,8 +5493,8 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_11IntervalObj_4__rich
  * cdef class IntervalTree:
  */
     __Pyx_XDECREF(__pyx_r);
-    __pyx_t_3 = PyObject_RichCompare(__pyx_v_self, __pyx_v_other, Py_EQ); __Pyx_XGOTREF(__pyx_t_3); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 353, __pyx_L1_error)
-    __pyx_t_2 = __Pyx_PyObject_IsTrue(__pyx_t_3); if (unlikely(__pyx_t_2 < 0)) __PYX_ERR(0, 353, __pyx_L1_error)
+    __pyx_t_3 = PyObject_RichCompare(__pyx_v_self, __pyx_v_other, Py_EQ); __Pyx_XGOTREF(__pyx_t_3); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 355, __pyx_L1_error)
+    __pyx_t_2 = __Pyx_PyObject_IsTrue(__pyx_t_3); if (unlikely(__pyx_t_2 < 0)) __PYX_ERR(0, 355, __pyx_L1_error)
     if (!__pyx_t_2) {
       __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
     } else {
@@ -5503,7 +5503,7 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_11IntervalObj_4__rich
       __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
       goto __pyx_L14_bool_binop_done;
     }
-    __pyx_t_3 = PyObject_RichCompare(__pyx_v_self, __pyx_v_other, Py_GT); __Pyx_XGOTREF(__pyx_t_3); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 353, __pyx_L1_error)
+    __pyx_t_3 = PyObject_RichCompare(__pyx_v_self, __pyx_v_other, Py_GT); __Pyx_XGOTREF(__pyx_t_3); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 355, __pyx_L1_error)
     __Pyx_INCREF(__pyx_t_3);
     __pyx_t_1 = __pyx_t_3;
     __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
@@ -5512,7 +5512,7 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_11IntervalObj_4__rich
     __pyx_t_1 = 0;
     goto __pyx_L0;
 
-    /* "skbio/metadata/_intersection.pyx":351
+    /* "skbio/metadata/_intersection.pyx":353
  *             # >
  *             return self.start > other.start or self.end > other.end
  *         elif op == 5:             # <<<<<<<<<<<<<<
@@ -5521,7 +5521,7 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_11IntervalObj_4__rich
  */
   }
 
-  /* "skbio/metadata/_intersection.pyx":335
+  /* "skbio/metadata/_intersection.pyx":337
  *         return fstr
  * 
  *     def __richcmp__(self, other, op):             # <<<<<<<<<<<<<<
@@ -5545,7 +5545,7 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_11IntervalObj_4__rich
   return __pyx_r;
 }
 
-/* "skbio/metadata/_intersection.pyx":317
+/* "skbio/metadata/_intersection.pyx":319
  * 
  *     """
  *     cdef public int start, end             # <<<<<<<<<<<<<<
@@ -5572,7 +5572,7 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_11IntervalObj_5start_
   PyObject *__pyx_t_1 = NULL;
   __Pyx_RefNannySetupContext("__get__", 0);
   __Pyx_XDECREF(__pyx_r);
-  __pyx_t_1 = __Pyx_PyInt_From_int(__pyx_v_self->start); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 317, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyInt_From_int(__pyx_v_self->start); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 319, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __pyx_r = __pyx_t_1;
   __pyx_t_1 = 0;
@@ -5607,7 +5607,7 @@ static int __pyx_pf_5skbio_8metadata_13_intersection_11IntervalObj_5start_2__set
   __Pyx_RefNannyDeclarations
   int __pyx_t_1;
   __Pyx_RefNannySetupContext("__set__", 0);
-  __pyx_t_1 = __Pyx_PyInt_As_int(__pyx_v_value); if (unlikely((__pyx_t_1 == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 317, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyInt_As_int(__pyx_v_value); if (unlikely((__pyx_t_1 == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 319, __pyx_L1_error)
   __pyx_v_self->start = __pyx_t_1;
 
   /* function exit code */
@@ -5640,7 +5640,7 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_11IntervalObj_3end___
   PyObject *__pyx_t_1 = NULL;
   __Pyx_RefNannySetupContext("__get__", 0);
   __Pyx_XDECREF(__pyx_r);
-  __pyx_t_1 = __Pyx_PyInt_From_int(__pyx_v_self->end); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 317, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyInt_From_int(__pyx_v_self->end); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 319, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __pyx_r = __pyx_t_1;
   __pyx_t_1 = 0;
@@ -5675,7 +5675,7 @@ static int __pyx_pf_5skbio_8metadata_13_intersection_11IntervalObj_3end_2__set__
   __Pyx_RefNannyDeclarations
   int __pyx_t_1;
   __Pyx_RefNannySetupContext("__set__", 0);
-  __pyx_t_1 = __Pyx_PyInt_As_int(__pyx_v_value); if (unlikely((__pyx_t_1 == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 317, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyInt_As_int(__pyx_v_value); if (unlikely((__pyx_t_1 == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 319, __pyx_L1_error)
   __pyx_v_self->end = __pyx_t_1;
 
   /* function exit code */
@@ -5689,7 +5689,7 @@ static int __pyx_pf_5skbio_8metadata_13_intersection_11IntervalObj_3end_2__set__
   return __pyx_r;
 }
 
-/* "skbio/metadata/_intersection.pyx":318
+/* "skbio/metadata/_intersection.pyx":320
  *     """
  *     cdef public int start, end
  *     cdef public object value, chrom, strand             # <<<<<<<<<<<<<<
@@ -5958,7 +5958,7 @@ static int __pyx_pf_5skbio_8metadata_13_intersection_11IntervalObj_6strand_4__de
   return __pyx_r;
 }
 
-/* "skbio/metadata/_intersection.pyx":413
+/* "skbio/metadata/_intersection.pyx":415
  *     cdef IntervalNode root
  * 
  *     def __cinit__( self ):             # <<<<<<<<<<<<<<
@@ -5988,7 +5988,7 @@ static int __pyx_pf_5skbio_8metadata_13_intersection_12IntervalTree___cinit__(CY
   __Pyx_RefNannyDeclarations
   __Pyx_RefNannySetupContext("__cinit__", 0);
 
-  /* "skbio/metadata/_intersection.pyx":414
+  /* "skbio/metadata/_intersection.pyx":416
  * 
  *     def __cinit__( self ):
  *         root = None             # <<<<<<<<<<<<<<
@@ -5998,7 +5998,7 @@ static int __pyx_pf_5skbio_8metadata_13_intersection_12IntervalTree___cinit__(CY
   __Pyx_INCREF(Py_None);
   __pyx_v_root = Py_None;
 
-  /* "skbio/metadata/_intersection.pyx":413
+  /* "skbio/metadata/_intersection.pyx":415
  *     cdef IntervalNode root
  * 
  *     def __cinit__( self ):             # <<<<<<<<<<<<<<
@@ -6013,7 +6013,7 @@ static int __pyx_pf_5skbio_8metadata_13_intersection_12IntervalTree___cinit__(CY
   return __pyx_r;
 }
 
-/* "skbio/metadata/_intersection.pyx":418
+/* "skbio/metadata/_intersection.pyx":420
  *     # ---- Position based interfaces -----------------------------------------
  * 
  *     def insert( self, int start, int end, object value=None ):             # <<<<<<<<<<<<<<
@@ -6053,7 +6053,7 @@ static PyObject *__pyx_pw_5skbio_8metadata_13_intersection_12IntervalTree_3inser
         case  1:
         if (likely((values[1] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_end)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("insert", 0, 2, 3, 1); __PYX_ERR(0, 418, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("insert", 0, 2, 3, 1); __PYX_ERR(0, 420, __pyx_L3_error)
         }
         case  2:
         if (kw_args > 0) {
@@ -6062,7 +6062,7 @@ static PyObject *__pyx_pw_5skbio_8metadata_13_intersection_12IntervalTree_3inser
         }
       }
       if (unlikely(kw_args > 0)) {
-        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "insert") < 0)) __PYX_ERR(0, 418, __pyx_L3_error)
+        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "insert") < 0)) __PYX_ERR(0, 420, __pyx_L3_error)
       }
     } else {
       switch (PyTuple_GET_SIZE(__pyx_args)) {
@@ -6073,13 +6073,13 @@ static PyObject *__pyx_pw_5skbio_8metadata_13_intersection_12IntervalTree_3inser
         default: goto __pyx_L5_argtuple_error;
       }
     }
-    __pyx_v_start = __Pyx_PyInt_As_int(values[0]); if (unlikely((__pyx_v_start == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 418, __pyx_L3_error)
-    __pyx_v_end = __Pyx_PyInt_As_int(values[1]); if (unlikely((__pyx_v_end == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 418, __pyx_L3_error)
+    __pyx_v_start = __Pyx_PyInt_As_int(values[0]); if (unlikely((__pyx_v_start == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 420, __pyx_L3_error)
+    __pyx_v_end = __Pyx_PyInt_As_int(values[1]); if (unlikely((__pyx_v_end == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 420, __pyx_L3_error)
     __pyx_v_value = values[2];
   }
   goto __pyx_L4_argument_unpacking_done;
   __pyx_L5_argtuple_error:;
-  __Pyx_RaiseArgtupleInvalid("insert", 0, 2, 3, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 418, __pyx_L3_error)
+  __Pyx_RaiseArgtupleInvalid("insert", 0, 2, 3, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 420, __pyx_L3_error)
   __pyx_L3_error:;
   __Pyx_AddTraceback("skbio.metadata._intersection.IntervalTree.insert", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __Pyx_RefNannyFinishContext();
@@ -6102,7 +6102,7 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_12IntervalTree_2inser
   PyObject *__pyx_t_5 = NULL;
   __Pyx_RefNannySetupContext("insert", 0);
 
-  /* "skbio/metadata/_intersection.pyx":422
+  /* "skbio/metadata/_intersection.pyx":424
  *         Insert the interval [start,end) associated with value `value`.
  *         """
  *         if self.root is None:             # <<<<<<<<<<<<<<
@@ -6113,18 +6113,18 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_12IntervalTree_2inser
   __pyx_t_2 = (__pyx_t_1 != 0);
   if (__pyx_t_2) {
 
-    /* "skbio/metadata/_intersection.pyx":423
+    /* "skbio/metadata/_intersection.pyx":425
  *         """
  *         if self.root is None:
  *             self.root = IntervalNode( start, end, value )             # <<<<<<<<<<<<<<
  *         else:
  *             self.root = self.root.insert( start, end, value )
  */
-    __pyx_t_3 = __Pyx_PyInt_From_int(__pyx_v_start); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 423, __pyx_L1_error)
+    __pyx_t_3 = __Pyx_PyInt_From_int(__pyx_v_start); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 425, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
-    __pyx_t_4 = __Pyx_PyInt_From_int(__pyx_v_end); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 423, __pyx_L1_error)
+    __pyx_t_4 = __Pyx_PyInt_From_int(__pyx_v_end); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 425, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_4);
-    __pyx_t_5 = PyTuple_New(3); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 423, __pyx_L1_error)
+    __pyx_t_5 = PyTuple_New(3); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 425, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_5);
     __Pyx_GIVEREF(__pyx_t_3);
     PyTuple_SET_ITEM(__pyx_t_5, 0, __pyx_t_3);
@@ -6135,7 +6135,7 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_12IntervalTree_2inser
     PyTuple_SET_ITEM(__pyx_t_5, 2, __pyx_v_value);
     __pyx_t_3 = 0;
     __pyx_t_4 = 0;
-    __pyx_t_4 = __Pyx_PyObject_Call(((PyObject *)__pyx_ptype_5skbio_8metadata_13_intersection_IntervalNode), __pyx_t_5, NULL); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 423, __pyx_L1_error)
+    __pyx_t_4 = __Pyx_PyObject_Call(((PyObject *)__pyx_ptype_5skbio_8metadata_13_intersection_IntervalNode), __pyx_t_5, NULL); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 425, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_4);
     __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
     __Pyx_GIVEREF(__pyx_t_4);
@@ -6144,7 +6144,7 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_12IntervalTree_2inser
     __pyx_v_self->root = ((struct __pyx_obj_5skbio_8metadata_13_intersection_IntervalNode *)__pyx_t_4);
     __pyx_t_4 = 0;
 
-    /* "skbio/metadata/_intersection.pyx":422
+    /* "skbio/metadata/_intersection.pyx":424
  *         Insert the interval [start,end) associated with value `value`.
  *         """
  *         if self.root is None:             # <<<<<<<<<<<<<<
@@ -6154,7 +6154,7 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_12IntervalTree_2inser
     goto __pyx_L3;
   }
 
-  /* "skbio/metadata/_intersection.pyx":425
+  /* "skbio/metadata/_intersection.pyx":427
  *             self.root = IntervalNode( start, end, value )
  *         else:
  *             self.root = self.root.insert( start, end, value )             # <<<<<<<<<<<<<<
@@ -6162,7 +6162,7 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_12IntervalTree_2inser
  *     add = insert
  */
   /*else*/ {
-    __pyx_t_4 = ((PyObject *)((struct __pyx_vtabstruct_5skbio_8metadata_13_intersection_IntervalNode *)__pyx_v_self->root->__pyx_vtab)->insert(__pyx_v_self->root, __pyx_v_start, __pyx_v_end, __pyx_v_value, 0)); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 425, __pyx_L1_error)
+    __pyx_t_4 = ((PyObject *)((struct __pyx_vtabstruct_5skbio_8metadata_13_intersection_IntervalNode *)__pyx_v_self->root->__pyx_vtab)->insert(__pyx_v_self->root, __pyx_v_start, __pyx_v_end, __pyx_v_value, 0)); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 427, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_4);
     __Pyx_GIVEREF(__pyx_t_4);
     __Pyx_GOTREF(__pyx_v_self->root);
@@ -6172,7 +6172,7 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_12IntervalTree_2inser
   }
   __pyx_L3:;
 
-  /* "skbio/metadata/_intersection.pyx":418
+  /* "skbio/metadata/_intersection.pyx":420
  *     # ---- Position based interfaces -----------------------------------------
  * 
  *     def insert( self, int start, int end, object value=None ):             # <<<<<<<<<<<<<<
@@ -6195,7 +6195,7 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_12IntervalTree_2inser
   return __pyx_r;
 }
 
-/* "skbio/metadata/_intersection.pyx":430
+/* "skbio/metadata/_intersection.pyx":432
  * 
  * 
  *     def update( self, start, end, old_feature, new_feature):             # <<<<<<<<<<<<<<
@@ -6236,21 +6236,21 @@ static PyObject *__pyx_pw_5skbio_8metadata_13_intersection_12IntervalTree_5updat
         case  1:
         if (likely((values[1] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_end)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("update", 1, 4, 4, 1); __PYX_ERR(0, 430, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("update", 1, 4, 4, 1); __PYX_ERR(0, 432, __pyx_L3_error)
         }
         case  2:
         if (likely((values[2] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_old_feature)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("update", 1, 4, 4, 2); __PYX_ERR(0, 430, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("update", 1, 4, 4, 2); __PYX_ERR(0, 432, __pyx_L3_error)
         }
         case  3:
         if (likely((values[3] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_new_feature)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("update", 1, 4, 4, 3); __PYX_ERR(0, 430, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("update", 1, 4, 4, 3); __PYX_ERR(0, 432, __pyx_L3_error)
         }
       }
       if (unlikely(kw_args > 0)) {
-        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "update") < 0)) __PYX_ERR(0, 430, __pyx_L3_error)
+        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "update") < 0)) __PYX_ERR(0, 432, __pyx_L3_error)
       }
     } else if (PyTuple_GET_SIZE(__pyx_args) != 4) {
       goto __pyx_L5_argtuple_error;
@@ -6267,7 +6267,7 @@ static PyObject *__pyx_pw_5skbio_8metadata_13_intersection_12IntervalTree_5updat
   }
   goto __pyx_L4_argument_unpacking_done;
   __pyx_L5_argtuple_error:;
-  __Pyx_RaiseArgtupleInvalid("update", 1, 4, 4, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 430, __pyx_L3_error)
+  __Pyx_RaiseArgtupleInvalid("update", 1, 4, 4, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 432, __pyx_L3_error)
   __pyx_L3_error:;
   __Pyx_AddTraceback("skbio.metadata._intersection.IntervalTree.update", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __Pyx_RefNannyFinishContext();
@@ -6289,7 +6289,7 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_12IntervalTree_4updat
   int __pyx_t_4;
   __Pyx_RefNannySetupContext("update", 0);
 
-  /* "skbio/metadata/_intersection.pyx":435
+  /* "skbio/metadata/_intersection.pyx":437
  *         match the `old_feature` with `new_feature`.
  *         """
  *         if self.root is not None:             # <<<<<<<<<<<<<<
@@ -6300,18 +6300,18 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_12IntervalTree_4updat
   __pyx_t_2 = (__pyx_t_1 != 0);
   if (__pyx_t_2) {
 
-    /* "skbio/metadata/_intersection.pyx":436
+    /* "skbio/metadata/_intersection.pyx":438
  *         """
  *         if self.root is not None:
  *             self.root.update(start, end, old_feature, new_feature)             # <<<<<<<<<<<<<<
  * 
  * 
  */
-    __pyx_t_3 = __Pyx_PyInt_As_int(__pyx_v_start); if (unlikely((__pyx_t_3 == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 436, __pyx_L1_error)
-    __pyx_t_4 = __Pyx_PyInt_As_int(__pyx_v_end); if (unlikely((__pyx_t_4 == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 436, __pyx_L1_error)
+    __pyx_t_3 = __Pyx_PyInt_As_int(__pyx_v_start); if (unlikely((__pyx_t_3 == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 438, __pyx_L1_error)
+    __pyx_t_4 = __Pyx_PyInt_As_int(__pyx_v_end); if (unlikely((__pyx_t_4 == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 438, __pyx_L1_error)
     ((struct __pyx_vtabstruct_5skbio_8metadata_13_intersection_IntervalNode *)__pyx_v_self->root->__pyx_vtab)->update(__pyx_v_self->root, __pyx_t_3, __pyx_t_4, __pyx_v_old_feature, __pyx_v_new_feature, 0);
 
-    /* "skbio/metadata/_intersection.pyx":435
+    /* "skbio/metadata/_intersection.pyx":437
  *         match the `old_feature` with `new_feature`.
  *         """
  *         if self.root is not None:             # <<<<<<<<<<<<<<
@@ -6320,7 +6320,7 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_12IntervalTree_4updat
  */
   }
 
-  /* "skbio/metadata/_intersection.pyx":430
+  /* "skbio/metadata/_intersection.pyx":432
  * 
  * 
  *     def update( self, start, end, old_feature, new_feature):             # <<<<<<<<<<<<<<
@@ -6340,7 +6340,7 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_12IntervalTree_4updat
   return __pyx_r;
 }
 
-/* "skbio/metadata/_intersection.pyx":439
+/* "skbio/metadata/_intersection.pyx":441
  * 
  * 
  *     def find( self, start, end ):             # <<<<<<<<<<<<<<
@@ -6377,11 +6377,11 @@ static PyObject *__pyx_pw_5skbio_8metadata_13_intersection_12IntervalTree_7find(
         case  1:
         if (likely((values[1] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_end)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("find", 1, 2, 2, 1); __PYX_ERR(0, 439, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("find", 1, 2, 2, 1); __PYX_ERR(0, 441, __pyx_L3_error)
         }
       }
       if (unlikely(kw_args > 0)) {
-        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "find") < 0)) __PYX_ERR(0, 439, __pyx_L3_error)
+        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "find") < 0)) __PYX_ERR(0, 441, __pyx_L3_error)
       }
     } else if (PyTuple_GET_SIZE(__pyx_args) != 2) {
       goto __pyx_L5_argtuple_error;
@@ -6394,7 +6394,7 @@ static PyObject *__pyx_pw_5skbio_8metadata_13_intersection_12IntervalTree_7find(
   }
   goto __pyx_L4_argument_unpacking_done;
   __pyx_L5_argtuple_error:;
-  __Pyx_RaiseArgtupleInvalid("find", 1, 2, 2, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 439, __pyx_L3_error)
+  __Pyx_RaiseArgtupleInvalid("find", 1, 2, 2, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 441, __pyx_L3_error)
   __pyx_L3_error:;
   __Pyx_AddTraceback("skbio.metadata._intersection.IntervalTree.find", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __Pyx_RefNannyFinishContext();
@@ -6419,7 +6419,7 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_12IntervalTree_6find(
   PyObject *__pyx_t_7 = NULL;
   __Pyx_RefNannySetupContext("find", 0);
 
-  /* "skbio/metadata/_intersection.pyx":443
+  /* "skbio/metadata/_intersection.pyx":445
  *         Return a sorted list of all intervals overlapping [start,end).
  *         """
  *         if self.root is None:             # <<<<<<<<<<<<<<
@@ -6430,7 +6430,7 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_12IntervalTree_6find(
   __pyx_t_2 = (__pyx_t_1 != 0);
   if (__pyx_t_2) {
 
-    /* "skbio/metadata/_intersection.pyx":444
+    /* "skbio/metadata/_intersection.pyx":446
  *         """
  *         if self.root is None:
  *             return []             # <<<<<<<<<<<<<<
@@ -6438,13 +6438,13 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_12IntervalTree_6find(
  * 
  */
     __Pyx_XDECREF(__pyx_r);
-    __pyx_t_3 = PyList_New(0); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 444, __pyx_L1_error)
+    __pyx_t_3 = PyList_New(0); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 446, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
     __pyx_r = __pyx_t_3;
     __pyx_t_3 = 0;
     goto __pyx_L0;
 
-    /* "skbio/metadata/_intersection.pyx":443
+    /* "skbio/metadata/_intersection.pyx":445
  *         Return a sorted list of all intervals overlapping [start,end).
  *         """
  *         if self.root is None:             # <<<<<<<<<<<<<<
@@ -6453,7 +6453,7 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_12IntervalTree_6find(
  */
   }
 
-  /* "skbio/metadata/_intersection.pyx":445
+  /* "skbio/metadata/_intersection.pyx":447
  *         if self.root is None:
  *             return []
  *         return self.root.find( start, end )             # <<<<<<<<<<<<<<
@@ -6461,7 +6461,7 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_12IntervalTree_6find(
  *     def before( self, position, num_intervals=1, max_dist=2500 ):
  */
   __Pyx_XDECREF(__pyx_r);
-  __pyx_t_4 = __Pyx_PyObject_GetAttrStr(((PyObject *)__pyx_v_self->root), __pyx_n_s_find); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 445, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_PyObject_GetAttrStr(((PyObject *)__pyx_v_self->root), __pyx_n_s_find); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 447, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
   __pyx_t_5 = NULL;
   __pyx_t_6 = 0;
@@ -6475,7 +6475,7 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_12IntervalTree_6find(
       __pyx_t_6 = 1;
     }
   }
-  __pyx_t_7 = PyTuple_New(2+__pyx_t_6); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 445, __pyx_L1_error)
+  __pyx_t_7 = PyTuple_New(2+__pyx_t_6); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 447, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_7);
   if (__pyx_t_5) {
     __Pyx_GIVEREF(__pyx_t_5); PyTuple_SET_ITEM(__pyx_t_7, 0, __pyx_t_5); __pyx_t_5 = NULL;
@@ -6486,7 +6486,7 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_12IntervalTree_6find(
   __Pyx_INCREF(__pyx_v_end);
   __Pyx_GIVEREF(__pyx_v_end);
   PyTuple_SET_ITEM(__pyx_t_7, 1+__pyx_t_6, __pyx_v_end);
-  __pyx_t_3 = __Pyx_PyObject_Call(__pyx_t_4, __pyx_t_7, NULL); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 445, __pyx_L1_error)
+  __pyx_t_3 = __Pyx_PyObject_Call(__pyx_t_4, __pyx_t_7, NULL); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 447, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
   __Pyx_DECREF(__pyx_t_7); __pyx_t_7 = 0;
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
@@ -6494,7 +6494,7 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_12IntervalTree_6find(
   __pyx_t_3 = 0;
   goto __pyx_L0;
 
-  /* "skbio/metadata/_intersection.pyx":439
+  /* "skbio/metadata/_intersection.pyx":441
  * 
  * 
  *     def find( self, start, end ):             # <<<<<<<<<<<<<<
@@ -6516,7 +6516,7 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_12IntervalTree_6find(
   return __pyx_r;
 }
 
-/* "skbio/metadata/_intersection.pyx":447
+/* "skbio/metadata/_intersection.pyx":449
  *         return self.root.find( start, end )
  * 
  *     def before( self, position, num_intervals=1, max_dist=2500 ):             # <<<<<<<<<<<<<<
@@ -6566,7 +6566,7 @@ static PyObject *__pyx_pw_5skbio_8metadata_13_intersection_12IntervalTree_9befor
         }
       }
       if (unlikely(kw_args > 0)) {
-        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "before") < 0)) __PYX_ERR(0, 447, __pyx_L3_error)
+        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "before") < 0)) __PYX_ERR(0, 449, __pyx_L3_error)
       }
     } else {
       switch (PyTuple_GET_SIZE(__pyx_args)) {
@@ -6583,7 +6583,7 @@ static PyObject *__pyx_pw_5skbio_8metadata_13_intersection_12IntervalTree_9befor
   }
   goto __pyx_L4_argument_unpacking_done;
   __pyx_L5_argtuple_error:;
-  __Pyx_RaiseArgtupleInvalid("before", 0, 1, 3, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 447, __pyx_L3_error)
+  __Pyx_RaiseArgtupleInvalid("before", 0, 1, 3, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 449, __pyx_L3_error)
   __pyx_L3_error:;
   __Pyx_AddTraceback("skbio.metadata._intersection.IntervalTree.before", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __Pyx_RefNannyFinishContext();
@@ -6607,7 +6607,7 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_12IntervalTree_8befor
   struct __pyx_opt_args_5skbio_8metadata_13_intersection_12IntervalNode_left __pyx_t_6;
   __Pyx_RefNannySetupContext("before", 0);
 
-  /* "skbio/metadata/_intersection.pyx":452
+  /* "skbio/metadata/_intersection.pyx":454
  *         further than `max_dist` positions away
  *         """
  *         if self.root is None:             # <<<<<<<<<<<<<<
@@ -6618,7 +6618,7 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_12IntervalTree_8befor
   __pyx_t_2 = (__pyx_t_1 != 0);
   if (__pyx_t_2) {
 
-    /* "skbio/metadata/_intersection.pyx":453
+    /* "skbio/metadata/_intersection.pyx":455
  *         """
  *         if self.root is None:
  *             return []             # <<<<<<<<<<<<<<
@@ -6626,13 +6626,13 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_12IntervalTree_8befor
  * 
  */
     __Pyx_XDECREF(__pyx_r);
-    __pyx_t_3 = PyList_New(0); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 453, __pyx_L1_error)
+    __pyx_t_3 = PyList_New(0); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 455, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
     __pyx_r = __pyx_t_3;
     __pyx_t_3 = 0;
     goto __pyx_L0;
 
-    /* "skbio/metadata/_intersection.pyx":452
+    /* "skbio/metadata/_intersection.pyx":454
  *         further than `max_dist` positions away
  *         """
  *         if self.root is None:             # <<<<<<<<<<<<<<
@@ -6641,7 +6641,7 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_12IntervalTree_8befor
  */
   }
 
-  /* "skbio/metadata/_intersection.pyx":454
+  /* "skbio/metadata/_intersection.pyx":456
  *         if self.root is None:
  *             return []
  *         return self.root.left( position, num_intervals, max_dist )             # <<<<<<<<<<<<<<
@@ -6649,18 +6649,18 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_12IntervalTree_8befor
  *     def after( self, position, num_intervals=1, max_dist=2500 ):
  */
   __Pyx_XDECREF(__pyx_r);
-  __pyx_t_4 = __Pyx_PyInt_As_int(__pyx_v_num_intervals); if (unlikely((__pyx_t_4 == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 454, __pyx_L1_error)
-  __pyx_t_5 = __Pyx_PyInt_As_int(__pyx_v_max_dist); if (unlikely((__pyx_t_5 == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 454, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_PyInt_As_int(__pyx_v_num_intervals); if (unlikely((__pyx_t_4 == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 456, __pyx_L1_error)
+  __pyx_t_5 = __Pyx_PyInt_As_int(__pyx_v_max_dist); if (unlikely((__pyx_t_5 == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 456, __pyx_L1_error)
   __pyx_t_6.__pyx_n = 2;
   __pyx_t_6.n = __pyx_t_4;
   __pyx_t_6.max_dist = __pyx_t_5;
-  __pyx_t_3 = ((struct __pyx_vtabstruct_5skbio_8metadata_13_intersection_IntervalNode *)__pyx_v_self->root->__pyx_vtab)->left(__pyx_v_self->root, __pyx_v_position, 0, &__pyx_t_6); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 454, __pyx_L1_error)
+  __pyx_t_3 = ((struct __pyx_vtabstruct_5skbio_8metadata_13_intersection_IntervalNode *)__pyx_v_self->root->__pyx_vtab)->left(__pyx_v_self->root, __pyx_v_position, 0, &__pyx_t_6); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 456, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
   __pyx_r = __pyx_t_3;
   __pyx_t_3 = 0;
   goto __pyx_L0;
 
-  /* "skbio/metadata/_intersection.pyx":447
+  /* "skbio/metadata/_intersection.pyx":449
  *         return self.root.find( start, end )
  * 
  *     def before( self, position, num_intervals=1, max_dist=2500 ):             # <<<<<<<<<<<<<<
@@ -6679,7 +6679,7 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_12IntervalTree_8befor
   return __pyx_r;
 }
 
-/* "skbio/metadata/_intersection.pyx":456
+/* "skbio/metadata/_intersection.pyx":458
  *         return self.root.left( position, num_intervals, max_dist )
  * 
  *     def after( self, position, num_intervals=1, max_dist=2500 ):             # <<<<<<<<<<<<<<
@@ -6729,7 +6729,7 @@ static PyObject *__pyx_pw_5skbio_8metadata_13_intersection_12IntervalTree_11afte
         }
       }
       if (unlikely(kw_args > 0)) {
-        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "after") < 0)) __PYX_ERR(0, 456, __pyx_L3_error)
+        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "after") < 0)) __PYX_ERR(0, 458, __pyx_L3_error)
       }
     } else {
       switch (PyTuple_GET_SIZE(__pyx_args)) {
@@ -6746,7 +6746,7 @@ static PyObject *__pyx_pw_5skbio_8metadata_13_intersection_12IntervalTree_11afte
   }
   goto __pyx_L4_argument_unpacking_done;
   __pyx_L5_argtuple_error:;
-  __Pyx_RaiseArgtupleInvalid("after", 0, 1, 3, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 456, __pyx_L3_error)
+  __Pyx_RaiseArgtupleInvalid("after", 0, 1, 3, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 458, __pyx_L3_error)
   __pyx_L3_error:;
   __Pyx_AddTraceback("skbio.metadata._intersection.IntervalTree.after", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __Pyx_RefNannyFinishContext();
@@ -6770,7 +6770,7 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_12IntervalTree_10afte
   struct __pyx_opt_args_5skbio_8metadata_13_intersection_12IntervalNode_right __pyx_t_6;
   __Pyx_RefNannySetupContext("after", 0);
 
-  /* "skbio/metadata/_intersection.pyx":461
+  /* "skbio/metadata/_intersection.pyx":463
  *         further than `max_dist` positions away
  *         """
  *         if self.root is None:             # <<<<<<<<<<<<<<
@@ -6781,7 +6781,7 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_12IntervalTree_10afte
   __pyx_t_2 = (__pyx_t_1 != 0);
   if (__pyx_t_2) {
 
-    /* "skbio/metadata/_intersection.pyx":462
+    /* "skbio/metadata/_intersection.pyx":464
  *         """
  *         if self.root is None:
  *             return []             # <<<<<<<<<<<<<<
@@ -6789,13 +6789,13 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_12IntervalTree_10afte
  * 
  */
     __Pyx_XDECREF(__pyx_r);
-    __pyx_t_3 = PyList_New(0); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 462, __pyx_L1_error)
+    __pyx_t_3 = PyList_New(0); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 464, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
     __pyx_r = __pyx_t_3;
     __pyx_t_3 = 0;
     goto __pyx_L0;
 
-    /* "skbio/metadata/_intersection.pyx":461
+    /* "skbio/metadata/_intersection.pyx":463
  *         further than `max_dist` positions away
  *         """
  *         if self.root is None:             # <<<<<<<<<<<<<<
@@ -6804,7 +6804,7 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_12IntervalTree_10afte
  */
   }
 
-  /* "skbio/metadata/_intersection.pyx":463
+  /* "skbio/metadata/_intersection.pyx":465
  *         if self.root is None:
  *             return []
  *         return self.root.right( position, num_intervals, max_dist )             # <<<<<<<<<<<<<<
@@ -6812,18 +6812,18 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_12IntervalTree_10afte
  *     # ---- Interval-like object based interfaces -----------------------------
  */
   __Pyx_XDECREF(__pyx_r);
-  __pyx_t_4 = __Pyx_PyInt_As_int(__pyx_v_num_intervals); if (unlikely((__pyx_t_4 == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 463, __pyx_L1_error)
-  __pyx_t_5 = __Pyx_PyInt_As_int(__pyx_v_max_dist); if (unlikely((__pyx_t_5 == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 463, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_PyInt_As_int(__pyx_v_num_intervals); if (unlikely((__pyx_t_4 == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 465, __pyx_L1_error)
+  __pyx_t_5 = __Pyx_PyInt_As_int(__pyx_v_max_dist); if (unlikely((__pyx_t_5 == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 465, __pyx_L1_error)
   __pyx_t_6.__pyx_n = 2;
   __pyx_t_6.n = __pyx_t_4;
   __pyx_t_6.max_dist = __pyx_t_5;
-  __pyx_t_3 = ((struct __pyx_vtabstruct_5skbio_8metadata_13_intersection_IntervalNode *)__pyx_v_self->root->__pyx_vtab)->right(__pyx_v_self->root, __pyx_v_position, 0, &__pyx_t_6); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 463, __pyx_L1_error)
+  __pyx_t_3 = ((struct __pyx_vtabstruct_5skbio_8metadata_13_intersection_IntervalNode *)__pyx_v_self->root->__pyx_vtab)->right(__pyx_v_self->root, __pyx_v_position, 0, &__pyx_t_6); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 465, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
   __pyx_r = __pyx_t_3;
   __pyx_t_3 = 0;
   goto __pyx_L0;
 
-  /* "skbio/metadata/_intersection.pyx":456
+  /* "skbio/metadata/_intersection.pyx":458
  *         return self.root.left( position, num_intervals, max_dist )
  * 
  *     def after( self, position, num_intervals=1, max_dist=2500 ):             # <<<<<<<<<<<<<<
@@ -6842,7 +6842,7 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_12IntervalTree_10afte
   return __pyx_r;
 }
 
-/* "skbio/metadata/_intersection.pyx":467
+/* "skbio/metadata/_intersection.pyx":469
  *     # ---- Interval-like object based interfaces -----------------------------
  * 
  *     def insert_interval( self, interval ):             # <<<<<<<<<<<<<<
@@ -6876,18 +6876,18 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_12IntervalTree_12inse
   PyObject *__pyx_t_7 = NULL;
   __Pyx_RefNannySetupContext("insert_interval", 0);
 
-  /* "skbio/metadata/_intersection.pyx":472
+  /* "skbio/metadata/_intersection.pyx":474
  *         attributes)
  *         """
  *         self.insert( interval.start, interval.end, interval )             # <<<<<<<<<<<<<<
  * 
  *     add_interval = insert_interval
  */
-  __pyx_t_2 = __Pyx_PyObject_GetAttrStr(((PyObject *)__pyx_v_self), __pyx_n_s_insert); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 472, __pyx_L1_error)
+  __pyx_t_2 = __Pyx_PyObject_GetAttrStr(((PyObject *)__pyx_v_self), __pyx_n_s_insert); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 474, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
-  __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_v_interval, __pyx_n_s_start); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 472, __pyx_L1_error)
+  __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_v_interval, __pyx_n_s_start); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 474, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
-  __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_v_interval, __pyx_n_s_end); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 472, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_v_interval, __pyx_n_s_end); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 474, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
   __pyx_t_5 = NULL;
   __pyx_t_6 = 0;
@@ -6901,7 +6901,7 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_12IntervalTree_12inse
       __pyx_t_6 = 1;
     }
   }
-  __pyx_t_7 = PyTuple_New(3+__pyx_t_6); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 472, __pyx_L1_error)
+  __pyx_t_7 = PyTuple_New(3+__pyx_t_6); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 474, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_7);
   if (__pyx_t_5) {
     __Pyx_GIVEREF(__pyx_t_5); PyTuple_SET_ITEM(__pyx_t_7, 0, __pyx_t_5); __pyx_t_5 = NULL;
@@ -6915,13 +6915,13 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_12IntervalTree_12inse
   PyTuple_SET_ITEM(__pyx_t_7, 2+__pyx_t_6, __pyx_v_interval);
   __pyx_t_3 = 0;
   __pyx_t_4 = 0;
-  __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_2, __pyx_t_7, NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 472, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_2, __pyx_t_7, NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 474, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __Pyx_DECREF(__pyx_t_7); __pyx_t_7 = 0;
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
 
-  /* "skbio/metadata/_intersection.pyx":467
+  /* "skbio/metadata/_intersection.pyx":469
  *     # ---- Interval-like object based interfaces -----------------------------
  * 
  *     def insert_interval( self, interval ):             # <<<<<<<<<<<<<<
@@ -6947,7 +6947,7 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_12IntervalTree_12inse
   return __pyx_r;
 }
 
-/* "skbio/metadata/_intersection.pyx":476
+/* "skbio/metadata/_intersection.pyx":478
  *     add_interval = insert_interval
  * 
  *     def before_interval( self, interval, num_intervals=1, max_dist=2500 ):             # <<<<<<<<<<<<<<
@@ -6997,7 +6997,7 @@ static PyObject *__pyx_pw_5skbio_8metadata_13_intersection_12IntervalTree_15befo
         }
       }
       if (unlikely(kw_args > 0)) {
-        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "before_interval") < 0)) __PYX_ERR(0, 476, __pyx_L3_error)
+        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "before_interval") < 0)) __PYX_ERR(0, 478, __pyx_L3_error)
       }
     } else {
       switch (PyTuple_GET_SIZE(__pyx_args)) {
@@ -7014,7 +7014,7 @@ static PyObject *__pyx_pw_5skbio_8metadata_13_intersection_12IntervalTree_15befo
   }
   goto __pyx_L4_argument_unpacking_done;
   __pyx_L5_argtuple_error:;
-  __Pyx_RaiseArgtupleInvalid("before_interval", 0, 1, 3, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 476, __pyx_L3_error)
+  __Pyx_RaiseArgtupleInvalid("before_interval", 0, 1, 3, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 478, __pyx_L3_error)
   __pyx_L3_error:;
   __Pyx_AddTraceback("skbio.metadata._intersection.IntervalTree.before_interval", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __Pyx_RefNannyFinishContext();
@@ -7039,7 +7039,7 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_12IntervalTree_14befo
   struct __pyx_opt_args_5skbio_8metadata_13_intersection_12IntervalNode_left __pyx_t_7;
   __Pyx_RefNannySetupContext("before_interval", 0);
 
-  /* "skbio/metadata/_intersection.pyx":481
+  /* "skbio/metadata/_intersection.pyx":483
  *         and are no further than `max_dist` positions away
  *         """
  *         if self.root is None:             # <<<<<<<<<<<<<<
@@ -7050,7 +7050,7 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_12IntervalTree_14befo
   __pyx_t_2 = (__pyx_t_1 != 0);
   if (__pyx_t_2) {
 
-    /* "skbio/metadata/_intersection.pyx":482
+    /* "skbio/metadata/_intersection.pyx":484
  *         """
  *         if self.root is None:
  *             return []             # <<<<<<<<<<<<<<
@@ -7058,13 +7058,13 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_12IntervalTree_14befo
  * 
  */
     __Pyx_XDECREF(__pyx_r);
-    __pyx_t_3 = PyList_New(0); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 482, __pyx_L1_error)
+    __pyx_t_3 = PyList_New(0); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 484, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
     __pyx_r = __pyx_t_3;
     __pyx_t_3 = 0;
     goto __pyx_L0;
 
-    /* "skbio/metadata/_intersection.pyx":481
+    /* "skbio/metadata/_intersection.pyx":483
  *         and are no further than `max_dist` positions away
  *         """
  *         if self.root is None:             # <<<<<<<<<<<<<<
@@ -7073,7 +7073,7 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_12IntervalTree_14befo
  */
   }
 
-  /* "skbio/metadata/_intersection.pyx":483
+  /* "skbio/metadata/_intersection.pyx":485
  *         if self.root is None:
  *             return []
  *         return self.root.left( interval.start, num_intervals, max_dist )             # <<<<<<<<<<<<<<
@@ -7081,21 +7081,21 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_12IntervalTree_14befo
  *     def after_interval( self, interval, num_intervals=1, max_dist=2500 ):
  */
   __Pyx_XDECREF(__pyx_r);
-  __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_v_interval, __pyx_n_s_start); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 483, __pyx_L1_error)
+  __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_v_interval, __pyx_n_s_start); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 485, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
-  __pyx_t_4 = __Pyx_PyInt_As_int(__pyx_v_num_intervals); if (unlikely((__pyx_t_4 == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 483, __pyx_L1_error)
-  __pyx_t_5 = __Pyx_PyInt_As_int(__pyx_v_max_dist); if (unlikely((__pyx_t_5 == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 483, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_PyInt_As_int(__pyx_v_num_intervals); if (unlikely((__pyx_t_4 == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 485, __pyx_L1_error)
+  __pyx_t_5 = __Pyx_PyInt_As_int(__pyx_v_max_dist); if (unlikely((__pyx_t_5 == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 485, __pyx_L1_error)
   __pyx_t_7.__pyx_n = 2;
   __pyx_t_7.n = __pyx_t_4;
   __pyx_t_7.max_dist = __pyx_t_5;
-  __pyx_t_6 = ((struct __pyx_vtabstruct_5skbio_8metadata_13_intersection_IntervalNode *)__pyx_v_self->root->__pyx_vtab)->left(__pyx_v_self->root, __pyx_t_3, 0, &__pyx_t_7); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 483, __pyx_L1_error)
+  __pyx_t_6 = ((struct __pyx_vtabstruct_5skbio_8metadata_13_intersection_IntervalNode *)__pyx_v_self->root->__pyx_vtab)->left(__pyx_v_self->root, __pyx_t_3, 0, &__pyx_t_7); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 485, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_6);
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
   __pyx_r = __pyx_t_6;
   __pyx_t_6 = 0;
   goto __pyx_L0;
 
-  /* "skbio/metadata/_intersection.pyx":476
+  /* "skbio/metadata/_intersection.pyx":478
  *     add_interval = insert_interval
  * 
  *     def before_interval( self, interval, num_intervals=1, max_dist=2500 ):             # <<<<<<<<<<<<<<
@@ -7115,7 +7115,7 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_12IntervalTree_14befo
   return __pyx_r;
 }
 
-/* "skbio/metadata/_intersection.pyx":485
+/* "skbio/metadata/_intersection.pyx":487
  *         return self.root.left( interval.start, num_intervals, max_dist )
  * 
  *     def after_interval( self, interval, num_intervals=1, max_dist=2500 ):             # <<<<<<<<<<<<<<
@@ -7165,7 +7165,7 @@ static PyObject *__pyx_pw_5skbio_8metadata_13_intersection_12IntervalTree_17afte
         }
       }
       if (unlikely(kw_args > 0)) {
-        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "after_interval") < 0)) __PYX_ERR(0, 485, __pyx_L3_error)
+        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "after_interval") < 0)) __PYX_ERR(0, 487, __pyx_L3_error)
       }
     } else {
       switch (PyTuple_GET_SIZE(__pyx_args)) {
@@ -7182,7 +7182,7 @@ static PyObject *__pyx_pw_5skbio_8metadata_13_intersection_12IntervalTree_17afte
   }
   goto __pyx_L4_argument_unpacking_done;
   __pyx_L5_argtuple_error:;
-  __Pyx_RaiseArgtupleInvalid("after_interval", 0, 1, 3, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 485, __pyx_L3_error)
+  __Pyx_RaiseArgtupleInvalid("after_interval", 0, 1, 3, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 487, __pyx_L3_error)
   __pyx_L3_error:;
   __Pyx_AddTraceback("skbio.metadata._intersection.IntervalTree.after_interval", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __Pyx_RefNannyFinishContext();
@@ -7207,7 +7207,7 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_12IntervalTree_16afte
   struct __pyx_opt_args_5skbio_8metadata_13_intersection_12IntervalNode_right __pyx_t_7;
   __Pyx_RefNannySetupContext("after_interval", 0);
 
-  /* "skbio/metadata/_intersection.pyx":490
+  /* "skbio/metadata/_intersection.pyx":492
  *         are no further than `max_dist` positions away
  *         """
  *         if self.root is None:             # <<<<<<<<<<<<<<
@@ -7218,7 +7218,7 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_12IntervalTree_16afte
   __pyx_t_2 = (__pyx_t_1 != 0);
   if (__pyx_t_2) {
 
-    /* "skbio/metadata/_intersection.pyx":491
+    /* "skbio/metadata/_intersection.pyx":493
  *         """
  *         if self.root is None:
  *             return []             # <<<<<<<<<<<<<<
@@ -7226,13 +7226,13 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_12IntervalTree_16afte
  * 
  */
     __Pyx_XDECREF(__pyx_r);
-    __pyx_t_3 = PyList_New(0); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 491, __pyx_L1_error)
+    __pyx_t_3 = PyList_New(0); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 493, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
     __pyx_r = __pyx_t_3;
     __pyx_t_3 = 0;
     goto __pyx_L0;
 
-    /* "skbio/metadata/_intersection.pyx":490
+    /* "skbio/metadata/_intersection.pyx":492
  *         are no further than `max_dist` positions away
  *         """
  *         if self.root is None:             # <<<<<<<<<<<<<<
@@ -7241,7 +7241,7 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_12IntervalTree_16afte
  */
   }
 
-  /* "skbio/metadata/_intersection.pyx":492
+  /* "skbio/metadata/_intersection.pyx":494
  *         if self.root is None:
  *             return []
  *         return self.root.right( interval.end, num_intervals, max_dist )             # <<<<<<<<<<<<<<
@@ -7249,21 +7249,21 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_12IntervalTree_16afte
  *     def upstream_of_interval( self, interval, num_intervals=1, max_dist=2500 ):
  */
   __Pyx_XDECREF(__pyx_r);
-  __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_v_interval, __pyx_n_s_end); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 492, __pyx_L1_error)
+  __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_v_interval, __pyx_n_s_end); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 494, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
-  __pyx_t_4 = __Pyx_PyInt_As_int(__pyx_v_num_intervals); if (unlikely((__pyx_t_4 == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 492, __pyx_L1_error)
-  __pyx_t_5 = __Pyx_PyInt_As_int(__pyx_v_max_dist); if (unlikely((__pyx_t_5 == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 492, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_PyInt_As_int(__pyx_v_num_intervals); if (unlikely((__pyx_t_4 == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 494, __pyx_L1_error)
+  __pyx_t_5 = __Pyx_PyInt_As_int(__pyx_v_max_dist); if (unlikely((__pyx_t_5 == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 494, __pyx_L1_error)
   __pyx_t_7.__pyx_n = 2;
   __pyx_t_7.n = __pyx_t_4;
   __pyx_t_7.max_dist = __pyx_t_5;
-  __pyx_t_6 = ((struct __pyx_vtabstruct_5skbio_8metadata_13_intersection_IntervalNode *)__pyx_v_self->root->__pyx_vtab)->right(__pyx_v_self->root, __pyx_t_3, 0, &__pyx_t_7); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 492, __pyx_L1_error)
+  __pyx_t_6 = ((struct __pyx_vtabstruct_5skbio_8metadata_13_intersection_IntervalNode *)__pyx_v_self->root->__pyx_vtab)->right(__pyx_v_self->root, __pyx_t_3, 0, &__pyx_t_7); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 494, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_6);
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
   __pyx_r = __pyx_t_6;
   __pyx_t_6 = 0;
   goto __pyx_L0;
 
-  /* "skbio/metadata/_intersection.pyx":485
+  /* "skbio/metadata/_intersection.pyx":487
  *         return self.root.left( interval.start, num_intervals, max_dist )
  * 
  *     def after_interval( self, interval, num_intervals=1, max_dist=2500 ):             # <<<<<<<<<<<<<<
@@ -7283,7 +7283,7 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_12IntervalTree_16afte
   return __pyx_r;
 }
 
-/* "skbio/metadata/_intersection.pyx":494
+/* "skbio/metadata/_intersection.pyx":496
  *         return self.root.right( interval.end, num_intervals, max_dist )
  * 
  *     def upstream_of_interval( self, interval, num_intervals=1, max_dist=2500 ):             # <<<<<<<<<<<<<<
@@ -7333,7 +7333,7 @@ static PyObject *__pyx_pw_5skbio_8metadata_13_intersection_12IntervalTree_19upst
         }
       }
       if (unlikely(kw_args > 0)) {
-        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "upstream_of_interval") < 0)) __PYX_ERR(0, 494, __pyx_L3_error)
+        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "upstream_of_interval") < 0)) __PYX_ERR(0, 496, __pyx_L3_error)
       }
     } else {
       switch (PyTuple_GET_SIZE(__pyx_args)) {
@@ -7350,7 +7350,7 @@ static PyObject *__pyx_pw_5skbio_8metadata_13_intersection_12IntervalTree_19upst
   }
   goto __pyx_L4_argument_unpacking_done;
   __pyx_L5_argtuple_error:;
-  __Pyx_RaiseArgtupleInvalid("upstream_of_interval", 0, 1, 3, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 494, __pyx_L3_error)
+  __Pyx_RaiseArgtupleInvalid("upstream_of_interval", 0, 1, 3, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 496, __pyx_L3_error)
   __pyx_L3_error:;
   __Pyx_AddTraceback("skbio.metadata._intersection.IntervalTree.upstream_of_interval", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __Pyx_RefNannyFinishContext();
@@ -7376,7 +7376,7 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_12IntervalTree_18upst
   struct __pyx_opt_args_5skbio_8metadata_13_intersection_12IntervalNode_left __pyx_t_8;
   __Pyx_RefNannySetupContext("upstream_of_interval", 0);
 
-  /* "skbio/metadata/_intersection.pyx":499
+  /* "skbio/metadata/_intersection.pyx":501
  *         `interval` and are no further than `max_dist` positions away
  *         """
  *         if self.root is None:             # <<<<<<<<<<<<<<
@@ -7387,7 +7387,7 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_12IntervalTree_18upst
   __pyx_t_2 = (__pyx_t_1 != 0);
   if (__pyx_t_2) {
 
-    /* "skbio/metadata/_intersection.pyx":500
+    /* "skbio/metadata/_intersection.pyx":502
  *         """
  *         if self.root is None:
  *             return []             # <<<<<<<<<<<<<<
@@ -7395,13 +7395,13 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_12IntervalTree_18upst
  *             return self.root.right( interval.end, num_intervals, max_dist )
  */
     __Pyx_XDECREF(__pyx_r);
-    __pyx_t_3 = PyList_New(0); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 500, __pyx_L1_error)
+    __pyx_t_3 = PyList_New(0); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 502, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
     __pyx_r = __pyx_t_3;
     __pyx_t_3 = 0;
     goto __pyx_L0;
 
-    /* "skbio/metadata/_intersection.pyx":499
+    /* "skbio/metadata/_intersection.pyx":501
  *         `interval` and are no further than `max_dist` positions away
  *         """
  *         if self.root is None:             # <<<<<<<<<<<<<<
@@ -7410,34 +7410,34 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_12IntervalTree_18upst
  */
   }
 
-  /* "skbio/metadata/_intersection.pyx":501
+  /* "skbio/metadata/_intersection.pyx":503
  *         if self.root is None:
  *             return []
  *         if interval.strand == -1 or interval.strand == "-":             # <<<<<<<<<<<<<<
  *             return self.root.right( interval.end, num_intervals, max_dist )
  *         else:
  */
-  __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_v_interval, __pyx_n_s_strand); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 501, __pyx_L1_error)
+  __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_v_interval, __pyx_n_s_strand); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 503, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
-  __pyx_t_4 = __Pyx_PyInt_EqObjC(__pyx_t_3, __pyx_int_neg_1, -1L, 0); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 501, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_PyInt_EqObjC(__pyx_t_3, __pyx_int_neg_1, -1L, 0); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 503, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
-  __pyx_t_1 = __Pyx_PyObject_IsTrue(__pyx_t_4); if (unlikely(__pyx_t_1 < 0)) __PYX_ERR(0, 501, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyObject_IsTrue(__pyx_t_4); if (unlikely(__pyx_t_1 < 0)) __PYX_ERR(0, 503, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
   if (!__pyx_t_1) {
   } else {
     __pyx_t_2 = __pyx_t_1;
     goto __pyx_L5_bool_binop_done;
   }
-  __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_v_interval, __pyx_n_s_strand); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 501, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_v_interval, __pyx_n_s_strand); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 503, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
-  __pyx_t_1 = (__Pyx_PyString_Equals(__pyx_t_4, __pyx_kp_s__4, Py_EQ)); if (unlikely(__pyx_t_1 < 0)) __PYX_ERR(0, 501, __pyx_L1_error)
+  __pyx_t_1 = (__Pyx_PyString_Equals(__pyx_t_4, __pyx_kp_s__4, Py_EQ)); if (unlikely(__pyx_t_1 < 0)) __PYX_ERR(0, 503, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
   __pyx_t_2 = __pyx_t_1;
   __pyx_L5_bool_binop_done:;
   if (__pyx_t_2) {
 
-    /* "skbio/metadata/_intersection.pyx":502
+    /* "skbio/metadata/_intersection.pyx":504
  *             return []
  *         if interval.strand == -1 or interval.strand == "-":
  *             return self.root.right( interval.end, num_intervals, max_dist )             # <<<<<<<<<<<<<<
@@ -7445,21 +7445,21 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_12IntervalTree_18upst
  *             return self.root.left( interval.start, num_intervals, max_dist )
  */
     __Pyx_XDECREF(__pyx_r);
-    __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_v_interval, __pyx_n_s_end); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 502, __pyx_L1_error)
+    __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_v_interval, __pyx_n_s_end); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 504, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_4);
-    __pyx_t_5 = __Pyx_PyInt_As_int(__pyx_v_num_intervals); if (unlikely((__pyx_t_5 == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 502, __pyx_L1_error)
-    __pyx_t_6 = __Pyx_PyInt_As_int(__pyx_v_max_dist); if (unlikely((__pyx_t_6 == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 502, __pyx_L1_error)
+    __pyx_t_5 = __Pyx_PyInt_As_int(__pyx_v_num_intervals); if (unlikely((__pyx_t_5 == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 504, __pyx_L1_error)
+    __pyx_t_6 = __Pyx_PyInt_As_int(__pyx_v_max_dist); if (unlikely((__pyx_t_6 == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 504, __pyx_L1_error)
     __pyx_t_7.__pyx_n = 2;
     __pyx_t_7.n = __pyx_t_5;
     __pyx_t_7.max_dist = __pyx_t_6;
-    __pyx_t_3 = ((struct __pyx_vtabstruct_5skbio_8metadata_13_intersection_IntervalNode *)__pyx_v_self->root->__pyx_vtab)->right(__pyx_v_self->root, __pyx_t_4, 0, &__pyx_t_7); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 502, __pyx_L1_error)
+    __pyx_t_3 = ((struct __pyx_vtabstruct_5skbio_8metadata_13_intersection_IntervalNode *)__pyx_v_self->root->__pyx_vtab)->right(__pyx_v_self->root, __pyx_t_4, 0, &__pyx_t_7); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 504, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
     __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
     __pyx_r = __pyx_t_3;
     __pyx_t_3 = 0;
     goto __pyx_L0;
 
-    /* "skbio/metadata/_intersection.pyx":501
+    /* "skbio/metadata/_intersection.pyx":503
  *         if self.root is None:
  *             return []
  *         if interval.strand == -1 or interval.strand == "-":             # <<<<<<<<<<<<<<
@@ -7468,7 +7468,7 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_12IntervalTree_18upst
  */
   }
 
-  /* "skbio/metadata/_intersection.pyx":504
+  /* "skbio/metadata/_intersection.pyx":506
  *             return self.root.right( interval.end, num_intervals, max_dist )
  *         else:
  *             return self.root.left( interval.start, num_intervals, max_dist )             # <<<<<<<<<<<<<<
@@ -7477,14 +7477,14 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_12IntervalTree_18upst
  */
   /*else*/ {
     __Pyx_XDECREF(__pyx_r);
-    __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_v_interval, __pyx_n_s_start); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 504, __pyx_L1_error)
+    __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_v_interval, __pyx_n_s_start); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 506, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
-    __pyx_t_6 = __Pyx_PyInt_As_int(__pyx_v_num_intervals); if (unlikely((__pyx_t_6 == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 504, __pyx_L1_error)
-    __pyx_t_5 = __Pyx_PyInt_As_int(__pyx_v_max_dist); if (unlikely((__pyx_t_5 == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 504, __pyx_L1_error)
+    __pyx_t_6 = __Pyx_PyInt_As_int(__pyx_v_num_intervals); if (unlikely((__pyx_t_6 == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 506, __pyx_L1_error)
+    __pyx_t_5 = __Pyx_PyInt_As_int(__pyx_v_max_dist); if (unlikely((__pyx_t_5 == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 506, __pyx_L1_error)
     __pyx_t_8.__pyx_n = 2;
     __pyx_t_8.n = __pyx_t_6;
     __pyx_t_8.max_dist = __pyx_t_5;
-    __pyx_t_4 = ((struct __pyx_vtabstruct_5skbio_8metadata_13_intersection_IntervalNode *)__pyx_v_self->root->__pyx_vtab)->left(__pyx_v_self->root, __pyx_t_3, 0, &__pyx_t_8); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 504, __pyx_L1_error)
+    __pyx_t_4 = ((struct __pyx_vtabstruct_5skbio_8metadata_13_intersection_IntervalNode *)__pyx_v_self->root->__pyx_vtab)->left(__pyx_v_self->root, __pyx_t_3, 0, &__pyx_t_8); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 506, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_4);
     __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
     __pyx_r = __pyx_t_4;
@@ -7492,7 +7492,7 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_12IntervalTree_18upst
     goto __pyx_L0;
   }
 
-  /* "skbio/metadata/_intersection.pyx":494
+  /* "skbio/metadata/_intersection.pyx":496
  *         return self.root.right( interval.end, num_intervals, max_dist )
  * 
  *     def upstream_of_interval( self, interval, num_intervals=1, max_dist=2500 ):             # <<<<<<<<<<<<<<
@@ -7512,7 +7512,7 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_12IntervalTree_18upst
   return __pyx_r;
 }
 
-/* "skbio/metadata/_intersection.pyx":506
+/* "skbio/metadata/_intersection.pyx":508
  *             return self.root.left( interval.start, num_intervals, max_dist )
  * 
  *     def downstream_of_interval( self, interval, num_intervals=1, max_dist=2500 ):             # <<<<<<<<<<<<<<
@@ -7562,7 +7562,7 @@ static PyObject *__pyx_pw_5skbio_8metadata_13_intersection_12IntervalTree_21down
         }
       }
       if (unlikely(kw_args > 0)) {
-        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "downstream_of_interval") < 0)) __PYX_ERR(0, 506, __pyx_L3_error)
+        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "downstream_of_interval") < 0)) __PYX_ERR(0, 508, __pyx_L3_error)
       }
     } else {
       switch (PyTuple_GET_SIZE(__pyx_args)) {
@@ -7579,7 +7579,7 @@ static PyObject *__pyx_pw_5skbio_8metadata_13_intersection_12IntervalTree_21down
   }
   goto __pyx_L4_argument_unpacking_done;
   __pyx_L5_argtuple_error:;
-  __Pyx_RaiseArgtupleInvalid("downstream_of_interval", 0, 1, 3, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 506, __pyx_L3_error)
+  __Pyx_RaiseArgtupleInvalid("downstream_of_interval", 0, 1, 3, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 508, __pyx_L3_error)
   __pyx_L3_error:;
   __Pyx_AddTraceback("skbio.metadata._intersection.IntervalTree.downstream_of_interval", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __Pyx_RefNannyFinishContext();
@@ -7605,7 +7605,7 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_12IntervalTree_20down
   struct __pyx_opt_args_5skbio_8metadata_13_intersection_12IntervalNode_right __pyx_t_8;
   __Pyx_RefNannySetupContext("downstream_of_interval", 0);
 
-  /* "skbio/metadata/_intersection.pyx":511
+  /* "skbio/metadata/_intersection.pyx":513
  *         `interval` and are no further than `max_dist` positions away
  *         """
  *         if self.root is None:             # <<<<<<<<<<<<<<
@@ -7616,7 +7616,7 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_12IntervalTree_20down
   __pyx_t_2 = (__pyx_t_1 != 0);
   if (__pyx_t_2) {
 
-    /* "skbio/metadata/_intersection.pyx":512
+    /* "skbio/metadata/_intersection.pyx":514
  *         """
  *         if self.root is None:
  *             return []             # <<<<<<<<<<<<<<
@@ -7624,13 +7624,13 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_12IntervalTree_20down
  *             return self.root.left( interval.start, num_intervals, max_dist )
  */
     __Pyx_XDECREF(__pyx_r);
-    __pyx_t_3 = PyList_New(0); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 512, __pyx_L1_error)
+    __pyx_t_3 = PyList_New(0); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 514, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
     __pyx_r = __pyx_t_3;
     __pyx_t_3 = 0;
     goto __pyx_L0;
 
-    /* "skbio/metadata/_intersection.pyx":511
+    /* "skbio/metadata/_intersection.pyx":513
  *         `interval` and are no further than `max_dist` positions away
  *         """
  *         if self.root is None:             # <<<<<<<<<<<<<<
@@ -7639,34 +7639,34 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_12IntervalTree_20down
  */
   }
 
-  /* "skbio/metadata/_intersection.pyx":513
+  /* "skbio/metadata/_intersection.pyx":515
  *         if self.root is None:
  *             return []
  *         if interval.strand == -1 or interval.strand == "-":             # <<<<<<<<<<<<<<
  *             return self.root.left( interval.start, num_intervals, max_dist )
  *         else:
  */
-  __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_v_interval, __pyx_n_s_strand); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 513, __pyx_L1_error)
+  __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_v_interval, __pyx_n_s_strand); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 515, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
-  __pyx_t_4 = __Pyx_PyInt_EqObjC(__pyx_t_3, __pyx_int_neg_1, -1L, 0); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 513, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_PyInt_EqObjC(__pyx_t_3, __pyx_int_neg_1, -1L, 0); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 515, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
-  __pyx_t_1 = __Pyx_PyObject_IsTrue(__pyx_t_4); if (unlikely(__pyx_t_1 < 0)) __PYX_ERR(0, 513, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyObject_IsTrue(__pyx_t_4); if (unlikely(__pyx_t_1 < 0)) __PYX_ERR(0, 515, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
   if (!__pyx_t_1) {
   } else {
     __pyx_t_2 = __pyx_t_1;
     goto __pyx_L5_bool_binop_done;
   }
-  __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_v_interval, __pyx_n_s_strand); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 513, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_v_interval, __pyx_n_s_strand); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 515, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
-  __pyx_t_1 = (__Pyx_PyString_Equals(__pyx_t_4, __pyx_kp_s__4, Py_EQ)); if (unlikely(__pyx_t_1 < 0)) __PYX_ERR(0, 513, __pyx_L1_error)
+  __pyx_t_1 = (__Pyx_PyString_Equals(__pyx_t_4, __pyx_kp_s__4, Py_EQ)); if (unlikely(__pyx_t_1 < 0)) __PYX_ERR(0, 515, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
   __pyx_t_2 = __pyx_t_1;
   __pyx_L5_bool_binop_done:;
   if (__pyx_t_2) {
 
-    /* "skbio/metadata/_intersection.pyx":514
+    /* "skbio/metadata/_intersection.pyx":516
  *             return []
  *         if interval.strand == -1 or interval.strand == "-":
  *             return self.root.left( interval.start, num_intervals, max_dist )             # <<<<<<<<<<<<<<
@@ -7674,21 +7674,21 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_12IntervalTree_20down
  *             return self.root.right( interval.end, num_intervals, max_dist )
  */
     __Pyx_XDECREF(__pyx_r);
-    __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_v_interval, __pyx_n_s_start); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 514, __pyx_L1_error)
+    __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_v_interval, __pyx_n_s_start); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 516, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_4);
-    __pyx_t_5 = __Pyx_PyInt_As_int(__pyx_v_num_intervals); if (unlikely((__pyx_t_5 == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 514, __pyx_L1_error)
-    __pyx_t_6 = __Pyx_PyInt_As_int(__pyx_v_max_dist); if (unlikely((__pyx_t_6 == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 514, __pyx_L1_error)
+    __pyx_t_5 = __Pyx_PyInt_As_int(__pyx_v_num_intervals); if (unlikely((__pyx_t_5 == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 516, __pyx_L1_error)
+    __pyx_t_6 = __Pyx_PyInt_As_int(__pyx_v_max_dist); if (unlikely((__pyx_t_6 == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 516, __pyx_L1_error)
     __pyx_t_7.__pyx_n = 2;
     __pyx_t_7.n = __pyx_t_5;
     __pyx_t_7.max_dist = __pyx_t_6;
-    __pyx_t_3 = ((struct __pyx_vtabstruct_5skbio_8metadata_13_intersection_IntervalNode *)__pyx_v_self->root->__pyx_vtab)->left(__pyx_v_self->root, __pyx_t_4, 0, &__pyx_t_7); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 514, __pyx_L1_error)
+    __pyx_t_3 = ((struct __pyx_vtabstruct_5skbio_8metadata_13_intersection_IntervalNode *)__pyx_v_self->root->__pyx_vtab)->left(__pyx_v_self->root, __pyx_t_4, 0, &__pyx_t_7); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 516, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
     __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
     __pyx_r = __pyx_t_3;
     __pyx_t_3 = 0;
     goto __pyx_L0;
 
-    /* "skbio/metadata/_intersection.pyx":513
+    /* "skbio/metadata/_intersection.pyx":515
  *         if self.root is None:
  *             return []
  *         if interval.strand == -1 or interval.strand == "-":             # <<<<<<<<<<<<<<
@@ -7697,7 +7697,7 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_12IntervalTree_20down
  */
   }
 
-  /* "skbio/metadata/_intersection.pyx":516
+  /* "skbio/metadata/_intersection.pyx":518
  *             return self.root.left( interval.start, num_intervals, max_dist )
  *         else:
  *             return self.root.right( interval.end, num_intervals, max_dist )             # <<<<<<<<<<<<<<
@@ -7706,14 +7706,14 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_12IntervalTree_20down
  */
   /*else*/ {
     __Pyx_XDECREF(__pyx_r);
-    __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_v_interval, __pyx_n_s_end); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 516, __pyx_L1_error)
+    __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_v_interval, __pyx_n_s_end); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 518, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
-    __pyx_t_6 = __Pyx_PyInt_As_int(__pyx_v_num_intervals); if (unlikely((__pyx_t_6 == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 516, __pyx_L1_error)
-    __pyx_t_5 = __Pyx_PyInt_As_int(__pyx_v_max_dist); if (unlikely((__pyx_t_5 == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 516, __pyx_L1_error)
+    __pyx_t_6 = __Pyx_PyInt_As_int(__pyx_v_num_intervals); if (unlikely((__pyx_t_6 == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 518, __pyx_L1_error)
+    __pyx_t_5 = __Pyx_PyInt_As_int(__pyx_v_max_dist); if (unlikely((__pyx_t_5 == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 518, __pyx_L1_error)
     __pyx_t_8.__pyx_n = 2;
     __pyx_t_8.n = __pyx_t_6;
     __pyx_t_8.max_dist = __pyx_t_5;
-    __pyx_t_4 = ((struct __pyx_vtabstruct_5skbio_8metadata_13_intersection_IntervalNode *)__pyx_v_self->root->__pyx_vtab)->right(__pyx_v_self->root, __pyx_t_3, 0, &__pyx_t_8); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 516, __pyx_L1_error)
+    __pyx_t_4 = ((struct __pyx_vtabstruct_5skbio_8metadata_13_intersection_IntervalNode *)__pyx_v_self->root->__pyx_vtab)->right(__pyx_v_self->root, __pyx_t_3, 0, &__pyx_t_8); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 518, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_4);
     __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
     __pyx_r = __pyx_t_4;
@@ -7721,7 +7721,7 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_12IntervalTree_20down
     goto __pyx_L0;
   }
 
-  /* "skbio/metadata/_intersection.pyx":506
+  /* "skbio/metadata/_intersection.pyx":508
  *             return self.root.left( interval.start, num_intervals, max_dist )
  * 
  *     def downstream_of_interval( self, interval, num_intervals=1, max_dist=2500 ):             # <<<<<<<<<<<<<<
@@ -7741,7 +7741,7 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_12IntervalTree_20down
   return __pyx_r;
 }
 
-/* "skbio/metadata/_intersection.pyx":518
+/* "skbio/metadata/_intersection.pyx":520
  *             return self.root.right( interval.end, num_intervals, max_dist )
  * 
  *     def traverse(self, fn):             # <<<<<<<<<<<<<<
@@ -7774,7 +7774,7 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_12IntervalTree_22trav
   PyObject *__pyx_t_6 = NULL;
   __Pyx_RefNannySetupContext("traverse", 0);
 
-  /* "skbio/metadata/_intersection.pyx":522
+  /* "skbio/metadata/_intersection.pyx":524
  *         call fn for each element in the tree
  *         """
  *         if self.root is None:             # <<<<<<<<<<<<<<
@@ -7785,7 +7785,7 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_12IntervalTree_22trav
   __pyx_t_2 = (__pyx_t_1 != 0);
   if (__pyx_t_2) {
 
-    /* "skbio/metadata/_intersection.pyx":523
+    /* "skbio/metadata/_intersection.pyx":525
  *         """
  *         if self.root is None:
  *             return None             # <<<<<<<<<<<<<<
@@ -7797,7 +7797,7 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_12IntervalTree_22trav
     __pyx_r = Py_None;
     goto __pyx_L0;
 
-    /* "skbio/metadata/_intersection.pyx":522
+    /* "skbio/metadata/_intersection.pyx":524
  *         call fn for each element in the tree
  *         """
  *         if self.root is None:             # <<<<<<<<<<<<<<
@@ -7806,7 +7806,7 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_12IntervalTree_22trav
  */
   }
 
-  /* "skbio/metadata/_intersection.pyx":524
+  /* "skbio/metadata/_intersection.pyx":526
  *         if self.root is None:
  *             return None
  *         return self.root.traverse(fn)             # <<<<<<<<<<<<<<
@@ -7814,7 +7814,7 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_12IntervalTree_22trav
  * # For backward compatibility
  */
   __Pyx_XDECREF(__pyx_r);
-  __pyx_t_4 = __Pyx_PyObject_GetAttrStr(((PyObject *)__pyx_v_self->root), __pyx_n_s_traverse); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 524, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_PyObject_GetAttrStr(((PyObject *)__pyx_v_self->root), __pyx_n_s_traverse); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 526, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
   __pyx_t_5 = NULL;
   if (CYTHON_COMPILING_IN_CPYTHON && likely(PyMethod_Check(__pyx_t_4))) {
@@ -7827,16 +7827,16 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_12IntervalTree_22trav
     }
   }
   if (!__pyx_t_5) {
-    __pyx_t_3 = __Pyx_PyObject_CallOneArg(__pyx_t_4, __pyx_v_fn); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 524, __pyx_L1_error)
+    __pyx_t_3 = __Pyx_PyObject_CallOneArg(__pyx_t_4, __pyx_v_fn); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 526, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
   } else {
-    __pyx_t_6 = PyTuple_New(1+1); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 524, __pyx_L1_error)
+    __pyx_t_6 = PyTuple_New(1+1); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 526, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_6);
     __Pyx_GIVEREF(__pyx_t_5); PyTuple_SET_ITEM(__pyx_t_6, 0, __pyx_t_5); __pyx_t_5 = NULL;
     __Pyx_INCREF(__pyx_v_fn);
     __Pyx_GIVEREF(__pyx_v_fn);
     PyTuple_SET_ITEM(__pyx_t_6, 0+1, __pyx_v_fn);
-    __pyx_t_3 = __Pyx_PyObject_Call(__pyx_t_4, __pyx_t_6, NULL); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 524, __pyx_L1_error)
+    __pyx_t_3 = __Pyx_PyObject_Call(__pyx_t_4, __pyx_t_6, NULL); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 526, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
     __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
   }
@@ -7845,7 +7845,7 @@ static PyObject *__pyx_pf_5skbio_8metadata_13_intersection_12IntervalTree_22trav
   __pyx_t_3 = 0;
   goto __pyx_L0;
 
-  /* "skbio/metadata/_intersection.pyx":518
+  /* "skbio/metadata/_intersection.pyx":520
  *             return self.root.right( interval.end, num_intervals, max_dist )
  * 
  *     def traverse(self, fn):             # <<<<<<<<<<<<<<
@@ -8460,36 +8460,36 @@ static int __Pyx_InitCachedConstants(void) {
   __Pyx_RefNannyDeclarations
   __Pyx_RefNannySetupContext("__Pyx_InitCachedConstants", 0);
 
-  /* "skbio/metadata/_intersection.pyx":273
+  /* "skbio/metadata/_intersection.pyx":275
  *         if len(results) == n: return results
  *         r = results
  *         r.sort(key=operator.attrgetter('end'), reverse=True)             # <<<<<<<<<<<<<<
  *         return r[:n]
  * 
  */
-  __pyx_tuple_ = PyTuple_Pack(1, __pyx_n_s_end); if (unlikely(!__pyx_tuple_)) __PYX_ERR(0, 273, __pyx_L1_error)
+  __pyx_tuple_ = PyTuple_Pack(1, __pyx_n_s_end); if (unlikely(!__pyx_tuple_)) __PYX_ERR(0, 275, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_tuple_);
   __Pyx_GIVEREF(__pyx_tuple_);
 
-  /* "skbio/metadata/_intersection.pyx":288
+  /* "skbio/metadata/_intersection.pyx":290
  *         if len(results) == n: return results
  *         r = results
  *         r.sort(key=operator.attrgetter('start'))             # <<<<<<<<<<<<<<
  *         return r[:n]
  * 
  */
-  __pyx_tuple__2 = PyTuple_Pack(1, __pyx_n_s_start); if (unlikely(!__pyx_tuple__2)) __PYX_ERR(0, 288, __pyx_L1_error)
+  __pyx_tuple__2 = PyTuple_Pack(1, __pyx_n_s_start); if (unlikely(!__pyx_tuple__2)) __PYX_ERR(0, 290, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_tuple__2);
   __Pyx_GIVEREF(__pyx_tuple__2);
 
-  /* "skbio/metadata/_intersection.pyx":299
+  /* "skbio/metadata/_intersection.pyx":301
  *         if self.cright is not EmptyNode: self.cright._traverse(func)
  * 
  * cdef IntervalNode EmptyNode = IntervalNode( 0, 0, IntervalObj(0, 0))             # <<<<<<<<<<<<<<
  * 
  * ## ---- Wrappers that retain the old interface -------------------------------
  */
-  __pyx_tuple__5 = PyTuple_Pack(2, __pyx_int_0, __pyx_int_0); if (unlikely(!__pyx_tuple__5)) __PYX_ERR(0, 299, __pyx_L1_error)
+  __pyx_tuple__5 = PyTuple_Pack(2, __pyx_int_0, __pyx_int_0); if (unlikely(!__pyx_tuple__5)) __PYX_ERR(0, 301, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_tuple__5);
   __Pyx_GIVEREF(__pyx_tuple__5);
   __Pyx_RefNannyFinishContext();
@@ -8618,13 +8618,13 @@ PyMODINIT_FUNC PyInit__intersection(void)
   if (__Pyx_SetVtable(__pyx_type_5skbio_8metadata_13_intersection_IntervalNode.tp_dict, __pyx_vtabptr_5skbio_8metadata_13_intersection_IntervalNode) < 0) __PYX_ERR(0, 66, __pyx_L1_error)
   if (PyObject_SetAttrString(__pyx_m, "IntervalNode", (PyObject *)&__pyx_type_5skbio_8metadata_13_intersection_IntervalNode) < 0) __PYX_ERR(0, 66, __pyx_L1_error)
   __pyx_ptype_5skbio_8metadata_13_intersection_IntervalNode = &__pyx_type_5skbio_8metadata_13_intersection_IntervalNode;
-  if (PyType_Ready(&__pyx_type_5skbio_8metadata_13_intersection_IntervalObj) < 0) __PYX_ERR(0, 303, __pyx_L1_error)
+  if (PyType_Ready(&__pyx_type_5skbio_8metadata_13_intersection_IntervalObj) < 0) __PYX_ERR(0, 305, __pyx_L1_error)
   __pyx_type_5skbio_8metadata_13_intersection_IntervalObj.tp_print = 0;
-  if (PyObject_SetAttrString(__pyx_m, "IntervalObj", (PyObject *)&__pyx_type_5skbio_8metadata_13_intersection_IntervalObj) < 0) __PYX_ERR(0, 303, __pyx_L1_error)
+  if (PyObject_SetAttrString(__pyx_m, "IntervalObj", (PyObject *)&__pyx_type_5skbio_8metadata_13_intersection_IntervalObj) < 0) __PYX_ERR(0, 305, __pyx_L1_error)
   __pyx_ptype_5skbio_8metadata_13_intersection_IntervalObj = &__pyx_type_5skbio_8metadata_13_intersection_IntervalObj;
-  if (PyType_Ready(&__pyx_type_5skbio_8metadata_13_intersection_IntervalTree) < 0) __PYX_ERR(0, 355, __pyx_L1_error)
+  if (PyType_Ready(&__pyx_type_5skbio_8metadata_13_intersection_IntervalTree) < 0) __PYX_ERR(0, 357, __pyx_L1_error)
   __pyx_type_5skbio_8metadata_13_intersection_IntervalTree.tp_print = 0;
-  if (PyObject_SetAttrString(__pyx_m, "IntervalTree", (PyObject *)&__pyx_type_5skbio_8metadata_13_intersection_IntervalTree) < 0) __PYX_ERR(0, 355, __pyx_L1_error)
+  if (PyObject_SetAttrString(__pyx_m, "IntervalTree", (PyObject *)&__pyx_type_5skbio_8metadata_13_intersection_IntervalTree) < 0) __PYX_ERR(0, 357, __pyx_L1_error)
   __pyx_ptype_5skbio_8metadata_13_intersection_IntervalTree = &__pyx_type_5skbio_8metadata_13_intersection_IntervalTree;
   /*--- Type import code ---*/
   /*--- Variable import code ---*/
@@ -8673,16 +8673,16 @@ PyMODINIT_FUNC PyInit__intersection(void)
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   PyType_Modified(__pyx_ptype_5skbio_8metadata_13_intersection_IntervalNode);
 
-  /* "skbio/metadata/_intersection.pyx":299
+  /* "skbio/metadata/_intersection.pyx":301
  *         if self.cright is not EmptyNode: self.cright._traverse(func)
  * 
  * cdef IntervalNode EmptyNode = IntervalNode( 0, 0, IntervalObj(0, 0))             # <<<<<<<<<<<<<<
  * 
  * ## ---- Wrappers that retain the old interface -------------------------------
  */
-  __pyx_t_1 = __Pyx_PyObject_Call(((PyObject *)__pyx_ptype_5skbio_8metadata_13_intersection_IntervalObj), __pyx_tuple__5, NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 299, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyObject_Call(((PyObject *)__pyx_ptype_5skbio_8metadata_13_intersection_IntervalObj), __pyx_tuple__5, NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 301, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_3 = PyTuple_New(3); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 299, __pyx_L1_error)
+  __pyx_t_3 = PyTuple_New(3); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 301, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
   __Pyx_INCREF(__pyx_int_0);
   __Pyx_GIVEREF(__pyx_int_0);
@@ -8693,7 +8693,7 @@ PyMODINIT_FUNC PyInit__intersection(void)
   __Pyx_GIVEREF(__pyx_t_1);
   PyTuple_SET_ITEM(__pyx_t_3, 2, __pyx_t_1);
   __pyx_t_1 = 0;
-  __pyx_t_1 = __Pyx_PyObject_Call(((PyObject *)__pyx_ptype_5skbio_8metadata_13_intersection_IntervalNode), __pyx_t_3, NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 299, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyObject_Call(((PyObject *)__pyx_ptype_5skbio_8metadata_13_intersection_IntervalNode), __pyx_t_3, NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 301, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
   __Pyx_XGOTREF(((PyObject *)__pyx_v_5skbio_8metadata_13_intersection_EmptyNode));
@@ -8701,38 +8701,38 @@ PyMODINIT_FUNC PyInit__intersection(void)
   __Pyx_GIVEREF(__pyx_t_1);
   __pyx_t_1 = 0;
 
-  /* "skbio/metadata/_intersection.pyx":427
+  /* "skbio/metadata/_intersection.pyx":429
  *             self.root = self.root.insert( start, end, value )
  * 
  *     add = insert             # <<<<<<<<<<<<<<
  * 
  * 
  */
-  __pyx_t_1 = __Pyx_GetNameInClass((PyObject *)__pyx_ptype_5skbio_8metadata_13_intersection_IntervalTree, __pyx_n_s_insert); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 427, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_GetNameInClass((PyObject *)__pyx_ptype_5skbio_8metadata_13_intersection_IntervalTree, __pyx_n_s_insert); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 429, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  if (PyDict_SetItem((PyObject *)__pyx_ptype_5skbio_8metadata_13_intersection_IntervalTree->tp_dict, __pyx_n_s_add, __pyx_t_1) < 0) __PYX_ERR(0, 427, __pyx_L1_error)
+  if (PyDict_SetItem((PyObject *)__pyx_ptype_5skbio_8metadata_13_intersection_IntervalTree->tp_dict, __pyx_n_s_add, __pyx_t_1) < 0) __PYX_ERR(0, 429, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   PyType_Modified(__pyx_ptype_5skbio_8metadata_13_intersection_IntervalTree);
 
-  /* "skbio/metadata/_intersection.pyx":474
+  /* "skbio/metadata/_intersection.pyx":476
  *         self.insert( interval.start, interval.end, interval )
  * 
  *     add_interval = insert_interval             # <<<<<<<<<<<<<<
  * 
  *     def before_interval( self, interval, num_intervals=1, max_dist=2500 ):
  */
-  __pyx_t_1 = __Pyx_GetNameInClass((PyObject *)__pyx_ptype_5skbio_8metadata_13_intersection_IntervalTree, __pyx_n_s_insert_interval); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 474, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_GetNameInClass((PyObject *)__pyx_ptype_5skbio_8metadata_13_intersection_IntervalTree, __pyx_n_s_insert_interval); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 476, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  if (PyDict_SetItem((PyObject *)__pyx_ptype_5skbio_8metadata_13_intersection_IntervalTree->tp_dict, __pyx_n_s_add_interval, __pyx_t_1) < 0) __PYX_ERR(0, 474, __pyx_L1_error)
+  if (PyDict_SetItem((PyObject *)__pyx_ptype_5skbio_8metadata_13_intersection_IntervalTree->tp_dict, __pyx_n_s_add_interval, __pyx_t_1) < 0) __PYX_ERR(0, 476, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   PyType_Modified(__pyx_ptype_5skbio_8metadata_13_intersection_IntervalTree);
 
-  /* "skbio/metadata/_intersection.pyx":527
+  /* "skbio/metadata/_intersection.pyx":529
  * 
  * # For backward compatibility
  * Intersecter = IntervalTree             # <<<<<<<<<<<<<<
  */
-  if (PyDict_SetItem(__pyx_d, __pyx_n_s_Intersecter, ((PyObject *)__pyx_ptype_5skbio_8metadata_13_intersection_IntervalTree)) < 0) __PYX_ERR(0, 527, __pyx_L1_error)
+  if (PyDict_SetItem(__pyx_d, __pyx_n_s_Intersecter, ((PyObject *)__pyx_ptype_5skbio_8metadata_13_intersection_IntervalTree)) < 0) __PYX_ERR(0, 529, __pyx_L1_error)
 
   /* "skbio/metadata/_intersection.pyx":1
  * # -----------------------------------------------------------------------------             # <<<<<<<<<<<<<<

--- a/skbio/metadata/_intersection.pyx
+++ b/skbio/metadata/_intersection.pyx
@@ -182,22 +182,24 @@ cdef class IntervalNode:
     find = intersect
 
     cdef void _intersect( IntervalNode self, int start, int end, list results):
+        cdef int send, qend
+
         # Left subtree
-        if self.cleft is not EmptyNode and self.cleft.maxend > start:
+        if self.cleft is not EmptyNode and self.cleft.maxend >= start:
             self.cleft._intersect( start, end, results )
         # This interval
-        if self.end == self.start:
-            send = self.end
-        else:
-            send = self.end - 1
         if start == end:
             qend = end
         else:
             qend = end - 1
+        if self.end == self.start:
+            send = self.end
+        else:
+            send = self.end - 1
         if ( send >= start ) and ( self.start <= qend ):
             results.append( self.interval )
         # Right subtree
-        if self.cright is not EmptyNode and self.start < end:
+        if self.cright is not EmptyNode and self.start <= qend:
             self.cright._intersect( start, end, results )
 
     cpdef void update(IntervalNode self, int start, int end,

--- a/skbio/metadata/tests/test_intersection.py
+++ b/skbio/metadata/tests/test_intersection.py
@@ -193,6 +193,7 @@ class IntervalTreeTest(unittest.TestCase):
         iv = IntervalTree()
         iv.insert(1, 1, 'foo')
         iv.insert(3, 7, 'spam')
+        iv.insert(8, 8, 'abc')
         self.assertEqual(iv.find(0, 1), [])
         self.assertEqual(iv.find(1, 1), ['foo'])
         self.assertEqual(iv.find(1, 2), ['foo'])
@@ -202,6 +203,12 @@ class IntervalTreeTest(unittest.TestCase):
         self.assertEqual(iv.find(6, 7), ['spam'])
         self.assertEqual(iv.find(7, 7), [])
         self.assertEqual(iv.find(0, 8), ['foo', 'spam'])
+        self.assertEqual(iv.find(8, 8), ['abc'])
+        self.assertEqual(iv.find(8, 9), ['abc'])
+        self.assertEqual(iv.find(9, 9), [])
+        self.assertEqual(iv.find(0, 10), ['foo', 'spam', 'abc'])
+        self.assertEqual(iv.find(6, 10), ['spam', 'abc'])
+        self.assertEqual(iv.find(7, 9), ['abc'])
 
     def test_traverse(self):
         a = []


### PR DESCRIPTION
This addresses #1448. The bug is that I need to change the greater/less-than signs to greater/less-than-or-equal-to sign to search for left/right subtree.

The fact that tests passes in some environment was confusing and misleading. The reason for that behavior is that OSX and linux starts with different interval nodes to search intersection. If it started with the lucky node (as in OSX), it would find the expected nodes; if it is not (as in some cases in linux), it ignored left or right subtree and returned empty.