### PR TITLE
DOC: update release document

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-This guide explains how to release a new version of scikit-bio. To illustrate examples of commands you might run, let's assume that the current version is 1.2.3-dev and we want to release version 1.2.4. Our versioning system is based on Semantic Versioning, which you can read about at http://semver.org.
+This guide explains how to release a new version of scikit-bio. To illustrate examples of commands you might run, let's assume that the current version is x.y.y-dev and we want to release version x.y.z.
 
 **Note:** The following commands assume you are in the top-level directory of the scikit-bio repository unless otherwise noted. They also assume that you have [Miniconda3](http://conda.pydata.org/miniconda.html) installed. It is important that you use Miniconda3, and not Miniconda2, because the root `conda` environment needs Python 3 for the build steps below.
 
@@ -10,9 +10,9 @@ This guide explains how to release a new version of scikit-bio. To illustrate ex
 
 1. Ensure the Travis build is passing against master.
 
-2. Update the version strings (1.2.3-dev) to the new version (1.2.4). This will include `__version__` defined in ``skbio/__init__.py``, as well as any `@experimental/@stable/@deprecated` [API stability decorators](http://scikit-bio.org/docs/latest/user/api_stability.html) with `as_of='1.2.3-dev'`. ``grep`` for the current version string to find all occurrences:
+2. Update the version strings (x.y.y-dev) to the new version (x.y.z). This will include `__version__` defined in ``skbio/__init__.py``, as well as any `@experimental/@stable/@deprecated` [API stability decorators](http://scikit-bio.org/docs/latest/user/api_stability.html) with `as_of='x.y.y-dev'`. ``grep`` for the current version string to find all occurrences:
 
-        grep -r '1\.2\.3-dev' .
+        grep -r 'x\.y\.y-dev' .
 
 3. Remove any deprecated functionality that was scheduled for removal on or before this release. When removing deprecated functionality, make sure the functionality has been in a deprecated state for the appropriate number of releases described in the [API stability docs](http://scikit-bio.org/docs/latest/user/api_stability.html). If there is functionality that shouldn't be removed yet, bump the `until` version to a future version. To find all deprecated functionality, search for `@deprecated` decorators:
 
@@ -20,13 +20,13 @@ This guide explains how to release a new version of scikit-bio. To illustrate ex
 
     Note any deprecated functionality that was removed in the `### Miscellaneous` section of `CHANGELOG.md`.
 
-4. Update ``CHANGELOG.md`` to include descriptions of all **user-facing** changes that made it into this release. Be sure to update the heading to include the new version (1.2.4) and the date of the release. Use the existing structure in the file as a template/guide.
+4. Update ``CHANGELOG.md`` to include descriptions of all **user-facing** changes that made it into this release. Be sure to update the heading to include the new version (x.y.z) and the date of the release. Use the existing structure in the file as a template/guide.
 
 5. Submit a pull request and merge when Travis-CI tests are passing.
 
 ## Build website docs
 
-You will need to **fully install** the latest master branch of scikit-bio (including built extensions) and build the docs from this version. Make sure the version of scikit-bio that is imported by ``import skbio`` is the correct one before building the docs.
+You will need to **fully install** the latest master branch of scikit-bio (including built extensions) and build the docs from this version. **Make sure the version of scikit-bio that is imported by ``import skbio`` is the correct one before building the docs.**
 
 1. Build the documentation locally:
 
@@ -38,20 +38,22 @@ You will need to **fully install** the latest master branch of scikit-bio (inclu
 
         git rm -rf docs/latest
 
-4. Copy over the built documentation to ``docs/1.2.4`` and ``docs/latest``:
+4. Copy over the built documentation to ``docs/x.y.z`` and ``docs/latest``:
 
         cp -r doc/build/html docs/latest
-        cp -r doc/build/html docs/1.2.4
+        cp -r doc/build/html docs/x.y.z
 
-5. Add a new list item to ``index.html`` to link to ``docs/1.2.4/index.html``.
+5. Add a new list item to ``index.html`` to link to ``docs/x.y.z/index.html``.
 
-6. Test out your changes by opening the site locally in a browser. Be sure to check the error console for any errors.
+6. Port content from ``README.md`` to ``index.html`` if there are any changes that need to be included on the front page.
 
-7. Submit a pull request with the website updates and merge. **Note:** Once merged, the live website is updated, so be sure to poke through the live site to make sure things are rendered correctly with the right version strings.
+7. Test out your changes by opening the site locally in a browser. Be sure to check the error console for any errors.
+
+8. Submit a pull request with the website updates and merge. **Note:** Once merged, the live website is updated, so be sure to poke through the live site to make sure things are rendered correctly with the right version strings.
 
 ## Tag the release
 
-From the [scikit-bio GitHub page](https://github.com/biocore/scikit-bio), click on the releases tab and draft a new release. Use the version number for the tag name (1.2.4) and create the tag against master. Fill in a release title that is consistent with previous release titles and add a summary of the release (linking to ``CHANGELOG.md`` is a good idea). This release summary will be the primary information that we point users to when we announce the release.
+From the [scikit-bio GitHub page](https://github.com/biocore/scikit-bio), click on the releases tab and draft a new release. Use the version number for the tag name (x.y.z) and create the tag against master. Fill in a release title that is consistent with previous release titles and add a summary of the release (linking to ``CHANGELOG.md`` is a good idea). This release summary will be the primary information that we point users to when we announce the release.
 
 Once the release is created on GitHub, it's a good idea to test out the release tarball before publishing to PyPI:
 
@@ -62,7 +64,7 @@ Once the release is created on GitHub, it's a good idea to test out the release 
 
 2. Install the release tarball from GitHub and run the tests:
 
-        pip install https://github.com/biocore/scikit-bio/archive/1.2.4.tar.gz
+        pip install https://github.com/biocore/scikit-bio/archive/x.y.z.tar.gz
         python -m skbio.test
 
 ## Publish the release
@@ -77,7 +79,7 @@ Assuming the GitHub release tarball correctly installs and passes its tests, you
 
 3. Create and activate a new `conda` environment, and test the `sdist`:
 
-        pip install dist/scikit-bio-1.2.4.tar.gz
+        pip install dist/scikit-bio-x.y.z.tar.gz
         cd  # cd somewhere outside the extracted scikit-bio directory
         python -m skbio.test
 
@@ -130,12 +132,12 @@ Assuming the GitHub release tarball correctly installs and passes its tests, you
 
 ## Post-release cleanup
 
-1. Submit and merge a pull request to update the version strings from 1.2.4 to 1.2.4-dev (`skbio.__version__` should be the only thing needing an update). Update ``CHANGELOG.md`` to include a new section for 1.2.4-dev (there won't be any changes to note here yet).
+1. Submit and merge a pull request to update the version strings from x.y.z to x.y.z-dev (`skbio.__version__` should be the only thing needing an update). Update ``CHANGELOG.md`` to include a new section for x.y.z-dev (there won't be any changes to note here yet).
 
 2. Close the release milestone on the GitHub issue tracker if there was one.
 
 3. Send an email to the skbio developers list and anyone else who might be interested (e.g., lab mailing lists). You might include links to the GitHub release page.
 
-4. Tweet about the release from `@scikit-bio`, including a link to the GitHub release page (for example, https://github.com/biocore/scikit-bio/releases/tag/1.2.4). Post a similar message to [scikit-bio's Gitter](https://gitter.im/biocore/scikit-bio).
+4. Tweet about the release from `@scikit-bio`, including a link to the GitHub release page (for example, https://github.com/biocore/scikit-bio/releases/tag/x.y.z). Post a similar message to [scikit-bio's Gitter](https://gitter.im/biocore/scikit-bio).
 
 5. :beers:

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,27 +4,29 @@
 
 This guide explains how to release a new version of scikit-bio. To illustrate examples of commands you might run, let's assume that the current version is 1.2.3-dev and we want to release version 1.2.4. Our versioning system is based on Semantic Versioning, which you can read about at http://semver.org.
 
-**Note:** The following commands assume you are in the top-level directory of the scikit-bio repository unless otherwise noted. They also assume that you have [virtualenv](http://virtualenv.readthedocs.org/en/latest/#)/[virtualenvwrapper](http://virtualenvwrapper.readthedocs.org/en/latest/) installed.
+**Note:** The following commands assume you are in the top-level directory of the scikit-bio repository unless otherwise noted. They also assume that you have [Miniconda3](http://conda.pydata.org/miniconda.html) installed. It is important that you use Miniconda3, and not Miniconda2, because the root `conda` environment needs Python 3 for the build steps below.
 
-**Tip:** It can be efficient to have the help of a couple other devs, as some steps can be run in parallel. It's also useful to have a variety of platforms/environments to test on during the release process, so find friends that are Linux and Mac users!
-
-## Prep the release (part 1)
+## Prep the release
 
 1. Ensure the Travis build is passing against master.
 
-2. Update the version strings (1.2.3-dev) to the new version (1.2.4). There should only be one place this needs to be done: ``skbio/__init__.py``. It's a good idea to ``grep`` for the current version string just to be safe:
+2. Update the version strings (1.2.3-dev) to the new version (1.2.4). This will include `__version__` defined in ``skbio/__init__.py``, as well as any `@experimental/@stable/@deprecated` [API stability decorators](http://scikit-bio.org/docs/latest/user/api_stability.html) with `as_of='1.2.3-dev'`. ``grep`` for the current version string to find all occurrences:
 
-        grep -ir '1\.2\.3-dev' *
+        grep -r '1\.2\.3-dev' .
 
-3. Update ``CHANGELOG.md`` to include descriptions of the changes that made it into this release. Be sure to update the heading to include the new version (1.2.4) and the date of the release. Use the existing structure in the file as a template/guide.
+3. Remove any deprecated functionality that was scheduled for removal on or before this release. When removing deprecated functionality, make sure the functionality has been in a deprecated state for the appropriate number of releases described in the [API stability docs](http://scikit-bio.org/docs/latest/user/api_stability.html). If there is functionality that shouldn't be removed yet, bump the `until` version to a future version. To find all deprecated functionality, search for `@deprecated` decorators:
 
-4. Submit a pull request with these changes and let Travis run.
+        grep -r '@deprecated' .
 
-## Build the documentation
+    Note any deprecated functionality that was removed in the `### Miscellaneous` section of `CHANGELOG.md`.
 
-In the meantime, you can build the documentation and update the website.
+4. Update ``CHANGELOG.md`` to include descriptions of all **user-facing** changes that made it into this release. Be sure to update the heading to include the new version (1.2.4) and the date of the release. Use the existing structure in the file as a template/guide.
 
-**Note:** You will need to **fully install** (including built extensions) the exact version of scikit-bio that you are editing so that Sphinx will pull docstrings from the correct version of the code. **Make sure the version of scikit-bio that is imported by ``import skbio`` is the correct one!**
+5. Submit a pull request and merge when Travis-CI tests are passing.
+
+## Build website docs
+
+You will need to **fully install** the latest master branch of scikit-bio (including built extensions) and build the docs from this version. Make sure the version of scikit-bio that is imported by ``import skbio`` is the correct one before building the docs.
 
 1. Build the documentation locally:
 
@@ -32,29 +34,20 @@ In the meantime, you can build the documentation and update the website.
 
 2. Switch to the ``gh-pages`` branch of the repository.
 
-3. Remove everything from ``docs/latest/``:
+3. Remove ``docs/latest``:
 
-        git rm -rf docs/latest/*
+        git rm -rf docs/latest
 
-4. Create a directory for the new version of the docs and recreate the ``latest/`` directory:
+4. Copy over the built documentation to ``docs/1.2.4`` and ``docs/latest``:
 
-        mkdir docs/1.2.4
-        mkdir docs/latest
+        cp -r doc/build/html docs/latest
+        cp -r doc/build/html docs/1.2.4
 
-5. Copy over the built documentation to both ``docs/1.2.4/`` and ``docs/latest``:
+5. Add a new list item to ``index.html`` to link to ``docs/1.2.4/index.html``.
 
-        cp -r <path to skbio repo>/doc/build/html/* docs/1.2.4/
-        cp -r <path to skbio repo>/doc/build/html/* docs/latest/
+6. Test out your changes by opening the site locally in a browser. Be sure to check the error console for any errors.
 
-6. Add a new list item to ``index.html`` to link to ``docs/1.2.4/index.html``.
-
-7. Test out your changes by opening the site locally in a browser. Be sure to check the error console for any errors.
-
-8. Commit and push (either directly or as a pull request) to have the website updated. **Note:** This updates the live website, so be sure to poke through the live site to make sure things aren't broken and that version strings are correct.
-
-## Prep the release (part 2)
-
-If the tests passed on Travis (see step 4 of **Prep the release (part 1)** above), merge the pull request to update the version strings to 1.2.4.
+7. Submit a pull request with the website updates and merge. **Note:** Once merged, the live website is updated, so be sure to poke through the live site to make sure things are rendered correctly with the right version strings.
 
 ## Tag the release
 
@@ -62,21 +55,19 @@ From the [scikit-bio GitHub page](https://github.com/biocore/scikit-bio), click 
 
 Once the release is created on GitHub, it's a good idea to test out the release tarball before publishing to PyPI:
 
-1. Create a new virtualenv.
+1. Create a new `conda` environment for testing (fill in a name for `<environment>`):
 
-2. Download the release tarball from GitHub, extract it, and ``cd`` into the top-level directory.
+        conda create -n <environment> python=3.5 numpy
+        source activate <environment>
 
-3. Install the release and run the tests:
+2. Install the release tarball from GitHub and run the tests:
 
-        pip install .
-        cd
+        pip install https://github.com/biocore/scikit-bio/archive/1.2.4.tar.gz
         python -m skbio.test
 
-4. During this process (it can take awhile to install all of scikit-bio's dependencies), submit a pull request to update the version strings from 1.2.4 to 1.2.4-dev. Use the same strategy described above to update the version strings. Update ``CHANGELOG.md`` to include a new section for 1.2.4-dev (there won't be any changes to note here yet). **Do not merge this pull request yet.**
+## Publish the release
 
-## Test the source distribution
-
-Assuming the GitHub release tarball correctly installs and passes its tests, you're now ready to test the creation of the source distribution (``sdist``) that will be published to PyPI. It is important to test the source distribution because it is created in an entirely different way than the release tarball on GitHub. Thus, there is the danger of having two different release tarballs: the one created on GitHub and the one uploaded to PyPI.
+Assuming the GitHub release tarball correctly installs and passes its tests, you're ready to create the source distribution (``sdist``) that will be published to PyPI. It is important to test the source distribution because it is created in an entirely different way than the release tarball on GitHub. Thus, there is the danger of having two different release tarballs: the one created on GitHub and the one uploaded to PyPI.
 
 1. Download the release tarball from GitHub, extract it, and ``cd`` into the top-level directory.
 
@@ -84,10 +75,10 @@ Assuming the GitHub release tarball correctly installs and passes its tests, you
 
         python setup.py sdist
 
-3. Create a new virtualenv and run:
+3. Create and activate a new `conda` environment, and test the `sdist`:
 
-        cd
-        pip install <path to extracted scikit-bio release>/dist/scikit-bio-1.2.4.tar.gz
+        pip install dist/scikit-bio-1.2.4.tar.gz
+        cd  # cd somewhere outside the extracted scikit-bio directory
         python -m skbio.test
 
 4. If everything goes well, it is finally time to push the release to PyPI:
@@ -96,13 +87,13 @@ Assuming the GitHub release tarball correctly installs and passes its tests, you
 
     You must have the proper login credentials to add a release to PyPI. Currently [@gregcaporaso](https://github.com/gregcaporaso) has these, but they can be shared with other release managers.
 
-5. Once the release is available on PyPI, do a final round of testing. Create a new virtualenv and run:
+5. Once the release is available on PyPI, do a final round of testing. Create a new `conda` environment and run:
 
-        cd
         pip install scikit-bio
+        cd  # cd somewhere outside the extracted scikit-bio directory
         python -m skbio.test
 
-    If this succeeds, the pypi release appears to be a success.
+    If this succeeds, the PyPI release appears to be a success. Make sure the installed version is the correct one.
 
 6. Next, we'll prepare and post the release to [anaconda.org](http://www.anaconda.org).
 
@@ -115,6 +106,13 @@ Assuming the GitHub release tarball correctly installs and passes its tests, you
         conda skeleton pypi scikit-bio
         conda build scikit-bio --python 3.4
         conda build scikit-bio --python 3.5
+
+    **Note:** When building 64-bit Linux packages, it is recommended that you use conda-forge's `linux-anvil` Docker image. This ensures a consistent Linux build environment that has an old enough version of `libc` to be compatible on most Linux systems. To start up a `linux-anvil` Docker container:
+
+        docker run -i -t condaforge/linux-anvil
+        # Now you should be in the linux-anvil environment
+        sed -i '/conda-forge/d' ~/.condarc
+        # Run the build commands from above
 
     At this stage you have built Python 3.4 and 3.5 packages. The absolute path to the packages will be provided as output from each ``conda build`` commands. You should now create conda environments for each, and run the tests as described above. You can install these local packages as follows:
 
@@ -132,12 +130,12 @@ Assuming the GitHub release tarball correctly installs and passes its tests, you
 
 ## Post-release cleanup
 
-1. Merge the latest pull request to update version strings to 1.2.4-dev.
+1. Submit and merge a pull request to update the version strings from 1.2.4 to 1.2.4-dev (`skbio.__version__` should be the only thing needing an update). Update ``CHANGELOG.md`` to include a new section for 1.2.4-dev (there won't be any changes to note here yet).
 
-2. Close the release milestone on the GitHub issue tracker.
+2. Close the release milestone on the GitHub issue tracker if there was one.
 
-3. Send an email to the skbio users and developers lists, and anyone else who might be interested (e.g., lab mailing lists). You might include links to the GitHub release page and ``CHANGELOG.md``.
+3. Send an email to the skbio developers list and anyone else who might be interested (e.g., lab mailing lists). You might include links to the GitHub release page.
 
-4. Tweet about the release, including a link to the GitHub release page (for example, for 0.1.3, the URL to include was https://github.com/biocore/scikit-bio/releases/tag/0.1.3).
+4. Tweet about the release from `@scikit-bio`, including a link to the GitHub release page (for example, https://github.com/biocore/scikit-bio/releases/tag/1.2.4). Post a similar message to [scikit-bio's Gitter](https://gitter.im/biocore/scikit-bio).
 
 5. :beers:


### PR DESCRIPTION
Updated the release document to use conda instead of virtualenv. Added instructions for updating API stability decorator versions and removing deprecated functionality. Made other general improvements to the doc, including better CLI commands and clearer ordering of steps in the release process.

These new instructions roughly reflect the steps taken to build scikit-bio 0.5.1.

Fixes #1238.

Note: the diff is hard to follow. I recommend reading through the rendered doc.