### PR TITLE
Scipy fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### Performance enhancements
 
 ### Bug fixes
+* `skbio.stats.composition.ancom` is compatible with scipy v0.18. ([#1472](https://github.com/biocore/scikit-bio/issues/1472)).
 
 ### Deprecated functionality [stable]
 

--- a/skbio/stats/composition.py
+++ b/skbio/stats/composition.py
@@ -973,8 +973,7 @@ def ancom(table, grouping,
 
     # Multiple comparisons
     if multiple_comparisons_correction == 'holm-bonferroni':
-        logratio_mat = np.vstack([_holm_bonferroni(logratio_mat[i, :])
-                                  for i in range(logratio_mat.shape[0])])
+        logratio_mat = np.vstack([_holm_bonferroni(i) for i in logratio_mat])
     np.fill_diagonal(logratio_mat, 1)
     W = (logratio_mat < alpha).sum(axis=1)
     c_start = W.max() / n_feat
@@ -1078,10 +1077,9 @@ def _log_compare(mat, cats,
         return significance_test(*[x[cats == k] for k in cs])
 
     for i in range(c-1):
-        ratio = (log_mat[:, i].T - log_mat[:, i+1:].T).T
-        p = np.array([func(ratio[:, i])[1]
-                      for i in range(ratio.shape[1])])
-        log_ratio[i, i+1:] = np.squeeze(np.array(p.T))
+        ratio = (log_mat[:, i].T - log_mat[:, i+1:].T)
+        p = np.array([func(i)[1] for i in ratio])
+        log_ratio[i, i+1:] = np.squeeze(p)
     return log_ratio
 
 

--- a/skbio/stats/composition.py
+++ b/skbio/stats/composition.py
@@ -104,7 +104,7 @@ import pandas as pd
 import scipy.stats
 import skbio.util
 from skbio.util._decorator import experimental
-
+import numpy.testing as npt
 
 @experimental(as_of="0.4.0")
 def closure(mat):
@@ -973,8 +973,8 @@ def ancom(table, grouping,
 
     # Multiple comparisons
     if multiple_comparisons_correction == 'holm-bonferroni':
-        logratio_mat = np.apply_along_axis(_holm_bonferroni,
-                                           1, logratio_mat)
+        logratio_mat = np.vstack([_holm_bonferroni(logratio_mat[i, :])
+                                   for i in range(logratio_mat.shape[0])])
     np.fill_diagonal(logratio_mat, 1)
     W = (logratio_mat < alpha).sum(axis=1)
     c_start = W.max() / n_feat

--- a/skbio/stats/composition.py
+++ b/skbio/stats/composition.py
@@ -1075,13 +1075,12 @@ def _log_compare(mat, cats,
     cs = np.unique(cats)
 
     def func(x):
-        return significance_test(*[x[cats == k] for k in cs])[1]
+        return significance_test(*[x[cats == k] for k in cs])
 
     for i in range(c-1):
         ratio = (log_mat[:, i].T - log_mat[:, i+1:].T).T
-        p = np.apply_along_axis(func,
-                                axis=0,
-                                arr=ratio)
+        p = np.array([func(ratio[:, i])[1]
+                      for i in range(ratio.shape[1])])
         log_ratio[i, i+1:] = np.squeeze(np.array(p.T))
     return log_ratio
 

--- a/skbio/stats/composition.py
+++ b/skbio/stats/composition.py
@@ -104,7 +104,7 @@ import pandas as pd
 import scipy.stats
 import skbio.util
 from skbio.util._decorator import experimental
-import numpy.testing as npt
+
 
 @experimental(as_of="0.4.0")
 def closure(mat):
@@ -974,7 +974,7 @@ def ancom(table, grouping,
     # Multiple comparisons
     if multiple_comparisons_correction == 'holm-bonferroni':
         logratio_mat = np.vstack([_holm_bonferroni(logratio_mat[i, :])
-                                   for i in range(logratio_mat.shape[0])])
+                                  for i in range(logratio_mat.shape[0])])
     np.fill_diagonal(logratio_mat, 1)
     W = (logratio_mat < alpha).sum(axis=1)
     c_start = W.max() / n_feat

--- a/skbio/stats/composition.py
+++ b/skbio/stats/composition.py
@@ -1075,13 +1075,13 @@ def _log_compare(mat, cats,
     cs = np.unique(cats)
 
     def func(x):
-        return significance_test(*[x[cats == k] for k in cs])
+        return significance_test(*[x[cats == k] for k in cs])[1]
 
     for i in range(c-1):
         ratio = (log_mat[:, i].T - log_mat[:, i+1:].T).T
-        m, p = np.apply_along_axis(func,
-                                   axis=0,
-                                   arr=ratio)
+        p = np.apply_along_axis(func,
+                                axis=0,
+                                arr=ratio)
         log_ratio[i, i+1:] = np.squeeze(np.array(p.T))
     return log_ratio
 


### PR DESCRIPTION
Please complete the following checklist:

* [x] I have read the guidelines in [CONTRIBUTING.md](https://github.com/biocore/scikit-bio/blob/master/CONTRIBUTING.md).

* [x] I have documented all public-facing changes in [CHANGELOG.md](https://github.com/biocore/scikit-bio/blob/master/CHANGELOG.md).

* [ ] **This pull request includes code, documentation, or other content derived from external source(s).** If this is the case, ensure the external source's license is compatible with scikit-bio's [license](https://github.com/biocore/scikit-bio/blob/master/COPYING.txt). Include the license in the `licenses` directory and add a comment in the code giving proper attribution. Ensure any other requirements set forth by the license and/or author are satisfied. **It is your responsibility to disclose code, documentation, or other content derived from external source(s).** If you have questions about whether something can be included in the project or how to give proper attribution, include those questions in your pull request and a reviewer will assist you.

* [x] **This pull request does not include code, documentation, or other content derived from external source(s).**

**Note:** [REVIEWING.md](https://github.com/biocore/scikit-bio/blob/master/REVIEWING.md) may also be helpful to see some of the things code reviewers will be verifying when reviewing your pull request.

From what I think is going on

in scipy-0.18, the outputs of the stats modules returned named tuples.
This turned out to be ok - that didn't break the tests.

However, there was a recent PR that looks like it could be the culprit: https://github.com/numpy/numpy/pull/7918

Solution - we just remove the dependence on `np.apply_along_axis` and just replace with a loop.
The running time shouldn't be affected, since this function is written in pure python anyways.