### PR TITLE
fixing ./checklist.py imports - fixes #1481

### DIFF
--- a/skbio/alignment/tests/test_pairwise.py
+++ b/skbio/alignment/tests/test_pairwise.py
@@ -22,7 +22,8 @@ from skbio.alignment._pairwise import (
     _compute_score_and_traceback_matrices, _traceback, _first_largest,
     _compute_substitution_score)
 from skbio.sequence import GrammaredSequence
-from skbio.util._decorator import classproperty, overrides
+from skbio.util import classproperty
+from skbio.util._decorator import overrides
 
 
 class CustomSequence(GrammaredSequence):

--- a/skbio/alignment/tests/test_tabular_msa.py
+++ b/skbio/alignment/tests/test_tabular_msa.py
@@ -20,12 +20,13 @@ import scipy.stats
 
 from skbio import Sequence, DNA, RNA, Protein, TabularMSA
 from skbio.sequence import GrammaredSequence
-from skbio.util._decorator import classproperty, overrides
+from skbio.util import classproperty
+from skbio.util._decorator import overrides
 from skbio.util._testing import ReallyEqualMixin
 from skbio.metadata._testing import (MetadataMixinTests,
                                      PositionalMetadataMixinTests)
-from skbio.util._testing import (assert_index_equal,
-                                 assert_data_frame_almost_equal)
+from skbio.util import assert_data_frame_almost_equal
+from skbio.util._testing import assert_index_equal
 
 
 class TabularMSASubclass(TabularMSA):

--- a/skbio/io/format/tests/test_clustal.py
+++ b/skbio/io/format/tests/test_clustal.py
@@ -11,8 +11,9 @@ from io import StringIO
 from unittest import TestCase, main
 
 from skbio import TabularMSA
-from skbio.sequence._grammared_sequence import GrammaredSequence
-from skbio.util._decorator import classproperty, overrides
+from skbio.sequence import GrammaredSequence
+from skbio.util import classproperty
+from skbio.util._decorator import overrides
 from skbio.io.format.clustal import (
     _clustal_to_tabular_msa, _tabular_msa_to_clustal, _clustal_sniffer,
     _is_clustal_seq_line, _delete_trailing_number, _check_length,

--- a/skbio/io/format/tests/test_fasta.py
+++ b/skbio/io/format/tests/test_fasta.py
@@ -22,9 +22,10 @@ from skbio.io.format.fasta import (
     _fasta_to_tabular_msa, _generator_to_fasta,
     _sequence_to_fasta, _dna_to_fasta, _rna_to_fasta, _protein_to_fasta,
     _tabular_msa_to_fasta)
-from skbio.sequence._grammared_sequence import GrammaredSequence
+from skbio.sequence import GrammaredSequence
 from skbio.util import get_data_path
-from skbio.util._decorator import classproperty, overrides
+from skbio.util import classproperty
+from skbio.util._decorator import overrides
 
 
 class CustomSequence(GrammaredSequence):

--- a/skbio/io/format/tests/test_fastq.py
+++ b/skbio/io/format/tests/test_fastq.py
@@ -17,9 +17,10 @@ from skbio.io import FASTQFormatError
 from skbio.io.format.fastq import (
     _fastq_sniffer, _fastq_to_generator, _fastq_to_tabular_msa,
     _generator_to_fastq, _tabular_msa_to_fastq)
-from skbio.sequence._grammared_sequence import GrammaredSequence
+from skbio.sequence import GrammaredSequence
 from skbio.util import get_data_path
-from skbio.util._decorator import classproperty, overrides
+from skbio.util import classproperty
+from skbio.util._decorator import overrides
 
 import numpy as np
 


### PR DESCRIPTION
During `make test` in a development environment, `./checklist.py` returns a 1 status code and invalidate test phase. By importing modules from main modules, eg:
```    
-from skbio.util._decorator import classproperty, overrides
+from skbio.util import classproperty
+from skbio.util._decorator import overrides
````    
./checklist.py returns 0, and tests are OK