### PR TITLE
BUG: fixed bug in _parse_loc_str - fixes #1489

### DIFF
--- a/skbio/io/format/_sequence_feature_vocabulary.py
+++ b/skbio/io/format/_sequence_feature_vocabulary.py
@@ -208,7 +208,7 @@ def _parse_loc_str(loc_str):
     b = r'(?P<B>\d+\^\d+)'
     c = r'(?P<C>\d+\.\d+)'
     d = r'(?P<D><?\d+\.\.>?\d+)'
-    e_left = r'(?P<EL><?[a-zA-Z_0-9\.]+:\d+\.\.>?\d+)'
+    e_left = r'(?P<EL>[a-zA-Z_0-9\.]+:<?\d+\.\.>?\d+)'
     e_right = r'(?P<ER><?\d+\.\.>?[a-zA-Z_0-9\.]+:\d+)'
     illegal = r'(?P<ILLEGAL>.+)'
     # The order of tokens in the master regular expression also
@@ -246,6 +246,18 @@ def _parse_loc_str(loc_str):
                 start, end = v.split('.')
             else:
                 start, end = v.split('..')
+            fuzzy_s = fuzzy_e = False
+            if start.startswith('<'):
+                start = start[1:]
+                fuzzy_s = True
+            if end.startswith('>'):
+                end = end[1:]
+                fuzzy_e = True
+            bounds.append((int(start)-1, int(end)))
+            fuzzy.append((fuzzy_s, fuzzy_e))
+        elif p == 'EL':
+            entry, interval = v.split(":")
+            start, end = interval.split('..')
             fuzzy_s = fuzzy_e = False
             if start.startswith('<'):
                 start = start[1:]

--- a/skbio/io/format/tests/test_sequence_feature_vocabulary.py
+++ b/skbio/io/format/tests/test_sequence_feature_vocabulary.py
@@ -44,7 +44,9 @@ class Tests(TestCase):
             'join(J00194.1:1..9,3..8)',
             'join(3..8,J00194.1:1..9)',
             '1.9',
-            '1^2']
+            '1^2',
+            'J00194.1:100..202',
+            'AB000684.1:<1..>275']
 
         expects = [
             ([(8, 9)], [(False, False)], {'strand': '+'}),
@@ -54,10 +56,14 @@ class Tests(TestCase):
             ([(2, 8)], [(False, True)],  {'strand': '-'}),
             ([(2, 5), (6, 9)], [(False, True), (True, False)],
              {'strand': '-'}),
-            ([(2, 8)], [(False, False)], {'strand': '+'}),
-            ([(2, 8)], [(False, False)], {'strand': '+'}),
+            ([(0, 9), (2, 8)], [(False, False), (False, False)],
+             {'strand': '+'}),
+            ([(2, 8), (0, 9)], [(False, False), (False, False)],
+             {'strand': '+'}),
             ([(0, 9)], [(False, False)], {'strand': '+'}),
-            ([(0, 1)], [(False, False)], {'strand': '+'})]
+            ([(0, 1)], [(False, False)], {'strand': '+'}),
+            ([(99, 202)], [(False, False)], {'strand': '+'}),
+            ([(0, 275)], [(True, True)], {'strand': '+'})]
 
         for example, expect in zip(examples, expects):
             parsed = _parse_loc_str(example)


### PR DESCRIPTION
Now `_parse_loc_str` can deal with `loc_str` like `AB000684.1:<1..>275`

Please complete the following checklist:

* [x] I have read the guidelines in [CONTRIBUTING.md](https://github.com/biocore/scikit-bio/blob/master/CONTRIBUTING.md).

* [x] I have documented all public-facing changes in [CHANGELOG.md](https://github.com/biocore/scikit-bio/blob/master/CHANGELOG.md).

* [ ] **This pull request includes code, documentation, or other content derived from external source(s).** If this is the case, ensure the external source's license is compatible with scikit-bio's [license](https://github.com/biocore/scikit-bio/blob/master/COPYING.txt). Include the license in the `licenses` directory and add a comment in the code giving proper attribution. Ensure any other requirements set forth by the license and/or author are satisfied. **It is your responsibility to disclose code, documentation, or other content derived from external source(s).** If you have questions about whether something can be included in the project or how to give proper attribution, include those questions in your pull request and a reviewer will assist you.

* [x] **This pull request does not include code, documentation, or other content derived from external source(s).**

**Note:** [REVIEWING.md](https://github.com/biocore/scikit-bio/blob/master/REVIEWING.md) may also be helpful to see some of the things code reviewers will be verifying when reviewing your pull request.
