### PR TITLE
vectorized _compute_q (issue #431)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 ### Backward-incompatible changes [experimental]
 
 ### Performance enhancements
+* `skbio.tree.nj` wall-clock time was decreased about 66% by vectorizing `skbio.tree._nj._compute_q`.
 
 ### Bug fixes
 * The `include_self` parameter was not being honored in `skbio.TreeNode.tips`. The scope of this bug was that if `TreeNode.tips` was called on a tip, it would always result in an empty `list` when unrolled.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 ### Backward-incompatible changes [experimental]
 
 ### Performance enhancements
-* `skbio.tree.nj` wall-clock time was decreased about 66% by vectorizing `skbio.tree._nj._compute_q`.
+* `skbio.tree.nj` wall-clock time was decreased about 66% by vectorizing `skbio.tree._nj._compute_q`. ([#1512](https://github.com/biocore/scikit-bio/pull/1512))
 
 ### Bug fixes
 * The `include_self` parameter was not being honored in `skbio.TreeNode.tips`. The scope of this bug was that if `TreeNode.tips` was called on a tip, it would always result in an empty `list` when unrolled.

--- a/skbio/tree/_nj.py
+++ b/skbio/tree/_nj.py
@@ -175,10 +175,12 @@ def _compute_q(dm):
     """
     q = np.zeros(dm.shape)
     n = dm.shape[0]
-    for i in range(n):
-        for j in range(i):
-            q[i, j] = q[j, i] = \
-                ((n - 2) * dm[i, j]) - dm[i].sum() - dm[j].sum()
+    dmv = dm.to_data_frame().values
+    big_sum = np.array([dmv.sum(1)] * dm.shape[0])
+    big_sum_diffs = big_sum + big_sum.T
+    q = (n - 2) * dmv - big_sum_diffs
+    for i in range(q.shape[0]):
+        q[i, i] = 0.
     return DistanceMatrix(q, dm.ids)
 
 

--- a/skbio/tree/_nj.py
+++ b/skbio/tree/_nj.py
@@ -179,8 +179,7 @@ def _compute_q(dm):
     big_sum = np.array([dmv.sum(1)] * dm.shape[0])
     big_sum_diffs = big_sum + big_sum.T
     q = (n - 2) * dmv - big_sum_diffs
-    for i in range(q.shape[0]):
-        q[i, i] = 0.
+    np.fill_diagonal(q, 0)
     return DistanceMatrix(q, dm.ids)
 
 


### PR DESCRIPTION
Please complete the following checklist:

* [X] I have read the guidelines in [CONTRIBUTING.md](https://github.com/biocore/scikit-bio/blob/master/CONTRIBUTING.md).

* [X] I have documented all public-facing changes in [CHANGELOG.md](https://github.com/biocore/scikit-bio/blob/master/CHANGELOG.md).

* [ ] **This pull request includes code, documentation, or other content derived from external source(s).** If this is the case, ensure the external source's license is compatible with scikit-bio's [license](https://github.com/biocore/scikit-bio/blob/master/COPYING.txt). Include the license in the `licenses` directory and add a comment in the code giving proper attribution. Ensure any other requirements set forth by the license and/or author are satisfied. **It is your responsibility to disclose code, documentation, or other content derived from external source(s).** If you have questions about whether something can be included in the project or how to give proper attribution, include those questions in your pull request and a reviewer will assist you.

* [X] **This pull request does not include code, documentation, or other content derived from external source(s).**

**Note:** [REVIEWING.md](https://github.com/biocore/scikit-bio/blob/master/REVIEWING.md) may also be helpful to see some of the things code reviewers will be verifying when reviewing your pull request.

----------

Hello,

This pull request references issue #431 by modifying the `_compute_q` function to use CPU vector operations to achieve a significant speedup. I timed the code using `%timeit`, whereby the original function resulted in: `100 loops, best of 3: 181 ms per loop` and the vectorized function resulted in: `100 loops, best of 3: 568 µs per loop`. In addition, for a 10x larger distance matrix, the original code is still running in the time it took me to modify the code and create this pull request. Running `make test` appears to pass without issue and testing the results of the two versions of the function with `np.all(np.isclose(x.to_data_frame(), y.to_data_frame()))` returns `True`.

There are some obvious time sinkholes which remain, but I hope this code can speed up the `nj` function for other users as well.

Best,
Steve