### PR TITLE
more speedups to `nj` (issue #431)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 ### Backward-incompatible changes [experimental]
 
 ### Performance enhancements
-* `skbio.tree.nj` wall-clock time was decreased about 66% by vectorizing `skbio.tree._nj._compute_q`. ([#1512](https://github.com/biocore/scikit-bio/pull/1512))
+* `skbio.tree.nj` wall-clock time was decreased about 99% by vectorizing `skbio.tree._nj._compute_q` and avoiding unnecessary recalculations. ([#1512](https://github.com/biocore/scikit-bio/pull/1512), [#XXXX](https://github.com/biocore/scikit-bio/pull/XXXX))
 
 ### Bug fixes
 * The `include_self` parameter was not being honored in `skbio.TreeNode.tips`. The scope of this bug was that if `TreeNode.tips` was called on a tip, it would always result in an empty `list` when unrolled.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 ### Backward-incompatible changes [experimental]
 
 ### Performance enhancements
-* `skbio.tree.nj` wall-clock time was decreased about 99% by vectorizing `skbio.tree._nj._compute_q` and avoiding unnecessary recalculations. ([#1512](https://github.com/biocore/scikit-bio/pull/1512), [#XXXX](https://github.com/biocore/scikit-bio/pull/XXXX))
+* `skbio.tree.nj` wall-clock time was decreased about 99% by vectorizing `skbio.tree._nj._compute_q` and avoiding unnecessary recalculations. ([#1512](https://github.com/biocore/scikit-bio/pull/1512), [#1513](https://github.com/biocore/scikit-bio/pull/1513))
 
 ### Bug fixes
 * The `include_self` parameter was not being honored in `skbio.TreeNode.tips`. The scope of this bug was that if `TreeNode.tips` was called on a tip, it would always result in an empty `list` when unrolled.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 ### Backward-incompatible changes [experimental]
 
 ### Performance enhancements
-* `skbio.tree.nj` wall-clock time was decreased about 99% by vectorizing `skbio.tree._nj._compute_q` and avoiding unnecessary recalculations. ([#1512](https://github.com/biocore/scikit-bio/pull/1512), [#1513](https://github.com/biocore/scikit-bio/pull/1513))
+* `skbio.tree.nj` wall-clock runtime was decreased by 99% for a 500x500 distance matrix and 93% for a 100x100 distance matrix. ([#1512](https://github.com/biocore/scikit-bio/pull/1512), [#1513](https://github.com/biocore/scikit-bio/pull/1513))
 
 ### Bug fixes
 * The `include_self` parameter was not being honored in `skbio.TreeNode.tips`. The scope of this bug was that if `TreeNode.tips` was called on a tip, it would always result in an empty `list` when unrolled.

--- a/skbio/tree/_nj.py
+++ b/skbio/tree/_nj.py
@@ -211,7 +211,6 @@ def _compute_collapsed_dm(dm, i, j, disallow_negative_branch_length,
     # drop nodes being joined
     k_to_u = np.delete(k_to_u, ij_indexes)
     # assign the distances to the result array
-    #result[0] = result[:, 0] = np.array([0] + k_to_u.data.tolist())
     result[0] = result[:, 0] = np.concatenate([[0], k_to_u])
     return DistanceMatrix(result, out_ids)
 

--- a/skbio/tree/_nj.py
+++ b/skbio/tree/_nj.py
@@ -242,34 +242,6 @@ def _lowest_index(dm):
     return tuple([res_coords[0], res_coords[1]])
 
 
-def x_otu_to_new_node(dm, i, j, k, disallow_negative_branch_length):
-    """Return the distance between a new node and some other node.
-
-    Parameters
-    ----------
-    dm : skbio.DistanceMatrix
-        The input distance matrix.
-    i, j : str
-        Identifiers of entries in the distance matrix to be collapsed. These
-        get collapsed to a new node, internally represented as `u`.
-    k : str
-        Identifier of the entry in the distance matrix for which distance to
-        `u` will be computed.
-    disallow_negative_branch_length : bool
-        Neighbor joining can result in negative branch lengths, which don't
-        make sense in an evolutionary context. If `True`, negative branch
-        lengths will be returned as zero, a common strategy for handling this
-        issue that was proposed by the original developers of the algorithm.
-
-    """
-    k_to_u = 0.5 * (dm[i, k] + dm[j, k] - dm[i, j])
-
-    if disallow_negative_branch_length and k_to_u < 0:
-        k_to_u = 0
-
-    return k_to_u
-
-
 def _pair_members_to_new_node(dm, i, j, disallow_negative_branch_length):
     """Return the distance between a new node and decendants of that new node.
 

--- a/skbio/tree/_nj.py
+++ b/skbio/tree/_nj.py
@@ -211,7 +211,8 @@ def _compute_collapsed_dm(dm, i, j, disallow_negative_branch_length,
     # drop nodes being joined
     k_to_u = np.delete(k_to_u, ij_indexes)
     # assign the distances to the result array
-    result[0] = result[:, 0] = np.array([0] + k_to_u.data.tolist())
+    #result[0] = result[:, 0] = np.array([0] + k_to_u.data.tolist())
+    result[0] = result[:, 0] = np.concatenate([[0], k_to_u])
     return DistanceMatrix(result, out_ids)
 
 

--- a/skbio/tree/tests/test_nj.py
+++ b/skbio/tree/tests/test_nj.py
@@ -11,7 +11,7 @@ from unittest import TestCase, main
 
 from skbio import DistanceMatrix, TreeNode, nj
 from skbio.tree._nj import (
-    _compute_q, _compute_collapsed_dm, _lowest_index, _otu_to_new_node,
+    _compute_q, _compute_collapsed_dm, _lowest_index,
     _pair_members_to_new_node)
 
 
@@ -166,20 +166,6 @@ class NjTests(TestCase):
     def test_lowest_index(self):
         self.assertEqual(_lowest_index(self.dm1), (4, 3))
         self.assertEqual(_lowest_index(_compute_q(self.dm1)), (1, 0))
-
-    def test_otu_to_new_node(self):
-        self.assertEqual(_otu_to_new_node(self.dm1, 'a', 'b', 'c', True), 7)
-        self.assertEqual(_otu_to_new_node(self.dm1, 'a', 'b', 'd', True), 7)
-        self.assertEqual(_otu_to_new_node(self.dm1, 'a', 'b', 'e', True), 6)
-
-    def test_otu_to_new_node_zero_branch_length(self):
-        data = [[0, 40, 3],
-                [40, 0, 3],
-                [3, 3, 0]]
-        ids = ['a', 'b', 'c']
-        dm = DistanceMatrix(data, ids)
-        self.assertEqual(_otu_to_new_node(dm, 'a', 'b', 'c', True), 0)
-        self.assertEqual(_otu_to_new_node(dm, 'a', 'b', 'c', False), -17)
 
     def test_pair_members_to_new_node(self):
         self.assertEqual(_pair_members_to_new_node(self.dm1, 'a', 'b', True),


### PR DESCRIPTION
Please complete the following checklist:

* [X] I have read the guidelines in [CONTRIBUTING.md](https://github.com/biocore/scikit-bio/blob/master/CONTRIBUTING.md).

* [X] I have documented all public-facing changes in [CHANGELOG.md](https://github.com/biocore/scikit-bio/blob/master/CHANGELOG.md).

* [ ] **This pull request includes code, documentation, or other content derived from external source(s).** If this is the case, ensure the external source's license is compatible with scikit-bio's [license](https://github.com/biocore/scikit-bio/blob/master/COPYING.txt). Include the license in the `licenses` directory and add a comment in the code giving proper attribution. Ensure any other requirements set forth by the license and/or author are satisfied. **It is your responsibility to disclose code, documentation, or other content derived from external source(s).** If you have questions about whether something can be included in the project or how to give proper attribution, include those questions in your pull request and a reviewer will assist you.

* [X] **This pull request does not include code, documentation, or other content derived from external source(s).**

**Note:** [REVIEWING.md](https://github.com/biocore/scikit-bio/blob/master/REVIEWING.md) may also be helpful to see some of the things code reviewers will be verifying when reviewing your pull request.

------

Hello,

This pull request references issue #431 by modifying `_lowest_index` and `_compute_collapsed_dm` to avoid item-by-item testing or copying. In the case of `_lowest_index`, the item-by-item checking is replaced with a call to `amin` on the dense form of the distance matrix data followed by point selection to produce the same behavior as point-by-point ordered checking. In the case of `_compute_collapsed_dm`, the existing `DistanceMatrix` data which can be re-used is copied as a single block before point-by-point computation of the distance values for `new_node_id`. On my test 500x500 distance matrix, computation time for `nj` is reduced from 289 seconds to 6 seconds, a 97% reduction in wall-clock time.

Steve