### PR TITLE
MAINT: various changes to fix build/test failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 
 ### Miscellaneous
 * scikit-bio now depends on pandas >= 0.19.2, and is compatible with newer pandas versions (e.g. 0.20.3) that were previously incompatible.
+* scikit-bio now depends on `numpy >= 1.9.2, < 1.14.0` for compatibility with Python 3.4, 3.5, and 3.6 and the available numpy conda packages in `defaults` and `conda-forge` channels.
 * added support for running tests from `setup.py`. Both `python setup.py nosetests` and `python setup.py test` are now supported, however `python setup.py test` will only run a subset of the full test suite. ([#1341](https://github.com/biocore/scikit-bio/issues/1341))
 
 ## Version 0.5.1 (2016-11-12)

--- a/ci/conda_requirements.txt
+++ b/ci/conda_requirements.txt
@@ -1,5 +1,6 @@
 pip
-numpy
+# See note in setup.py install_requires about numpy version pin.
+numpy<1.14.0
 scipy
 matplotlib
 pandas

--- a/ci/pip_requirements.txt
+++ b/ci/pip_requirements.txt
@@ -3,7 +3,7 @@ coveralls
 natsort
 lockfile
 CacheControl
-git+git://github.com/sphinx-doc/sphinx.git
+Sphinx
 sphinx-bootstrap-theme
 numpydoc
 check-manifest

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -106,7 +106,7 @@ from skbio.util._decorator import classproperty
 # If your documentation needs a minimal Sphinx version, state it here.
 # Using `sphinx_version` doesn't work, likely because Sphinx is expecting a
 # version string of the form X.Y, not X.Y.Z.
-needs_sphinx = '1.2'
+needs_sphinx = '1.6'
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom

--- a/setup.py
+++ b/setup.py
@@ -114,7 +114,12 @@ setup(name='scikit-bio',
           'IPython >= 3.2.0',
           'matplotlib >= 1.4.3',
           'natsort >= 4.0.3',
-          'numpy >= 1.9.2',
+          # numpy array repr changed in 1.14.0 to use less whitespace, which
+          # breaks the doctests. The doctests can't be updated to match the new
+          # arrray repr because we still support Python 3.4, which doesn't have
+          # a numpy 1.14.0 conda package on `defaults` or `conda-forge`
+          # channels.
+          'numpy >= 1.9.2, < 1.14.0',
           'pandas >= 0.19.2',
           'scipy >= 0.15.1',
           'nose >= 1.3.7'

--- a/skbio/alignment/tests/test_pairwise.py
+++ b/skbio/alignment/tests/test_pairwise.py
@@ -744,15 +744,15 @@ class PairwiseAlignmentTests(TestCase):
         self.assertEqual(actual, expected)
 
     def test_first_largest(self):
-        l = [(5, 'a'), (5, 'b'), (5, 'c')]
-        self.assertEqual(_first_largest(l), (5, 'a'))
-        l = [(5, 'c'), (5, 'b'), (5, 'a')]
-        self.assertEqual(_first_largest(l), (5, 'c'))
-        l = [(5, 'c'), (6, 'b'), (5, 'a')]
-        self.assertEqual(_first_largest(l), (6, 'b'))
+        input = [(5, 'a'), (5, 'b'), (5, 'c')]
+        self.assertEqual(_first_largest(input), (5, 'a'))
+        input = [(5, 'c'), (5, 'b'), (5, 'a')]
+        self.assertEqual(_first_largest(input), (5, 'c'))
+        input = [(5, 'c'), (6, 'b'), (5, 'a')]
+        self.assertEqual(_first_largest(input), (6, 'b'))
         # works for more than three entries
-        l = [(5, 'c'), (6, 'b'), (5, 'a'), (7, 'd')]
-        self.assertEqual(_first_largest(l), (7, 'd'))
+        input = [(5, 'c'), (6, 'b'), (5, 'a'), (7, 'd')]
+        self.assertEqual(_first_largest(input), (7, 'd'))
         # Note that max([(5, 'a'), (5, 'c')]) == max([(5, 'c'), (5, 'a')])
         # but for the purposes needed here, we want the max to be the same
         # regardless of what the second item in the tuple is.

--- a/skbio/diversity/tests/test_driver.py
+++ b/skbio/diversity/tests/test_driver.py
@@ -305,7 +305,7 @@ class BetaDiversityTests(TestCase):
             beta_diversity('euclidean', [[0, 1, 3, -4], [0, 3, 12, 42]])
 
         # additional kwargs
-        error_msg = ("'not_a_real_kwarg'")
+        error_msg = "keyword argument"
         with self.assertRaisesRegex(TypeError, error_msg):
             beta_diversity('euclidean', [[0, 1, 3], [0, 3, 12]],
                            not_a_real_kwarg=42.0)

--- a/skbio/io/format/genbank.py
+++ b/skbio/io/format/genbank.py
@@ -570,7 +570,7 @@ def _parse_locus(lines):
             ['locus_name', 'size', 'unit', 'mol_type',
              'shape', 'division', 'date'],
             matches.groups()))
-    except:
+    except Exception:
         raise GenBankFormatError(
             "Could not parse the LOCUS line:\n%s" % line)
 

--- a/skbio/io/tests/test_util.py
+++ b/skbio/io/tests/test_util.py
@@ -588,10 +588,10 @@ class TestIterableReaderWriter(unittest.TestCase):
                 self.assertEqual(result.read(), 'abc')
 
     def test_open_with_newline(self):
-        l = ['a\r', 'b\r', 'c\r']
-        with skbio.io.open(l, newline='\r') as result:
+        lines = ['a\r', 'b\r', 'c\r']
+        with skbio.io.open(lines, newline='\r') as result:
             self.assertIsInstance(result, io.TextIOBase)
-            self.assertEqual(result.readlines(), l)
+            self.assertEqual(result.readlines(), lines)
 
     def test_open_invalid_iterable(self):
         with self.assertRaises(skbio.io.IOSourceError):
@@ -603,15 +603,15 @@ class TestIterableReaderWriter(unittest.TestCase):
             self.assertEqual(result.read(), '')
 
     def test_open_write_mode(self):
-        l = []
-        with skbio.io.open(l, mode='w') as fh:
+        lines = []
+        with skbio.io.open(lines, mode='w') as fh:
             fh.write('abc')
-        self.assertEqual(l, ['abc'])
+        self.assertEqual(lines, ['abc'])
 
-        l = []
-        with skbio.io.open(l, mode='w', newline='\r') as fh:
+        lines = []
+        with skbio.io.open(lines, mode='w', newline='\r') as fh:
             fh.write('ab\nc\n')
-        self.assertEqual(l, ['ab\r', 'c\r'])
+        self.assertEqual(lines, ['ab\r', 'c\r'])
 
         self.assertTrue(fh.closed)
         fh.close()

--- a/skbio/metadata/tests/test_intersection.py
+++ b/skbio/metadata/tests/test_intersection.py
@@ -132,8 +132,8 @@ class LotsaTestCase(unittest.TestCase):
         r = iv.right(1, n=33)
         self.assertEqual(len(r), 33)
 
-        l = iv.left(1, n=33)
-        self.assertEqual(len(l), 1)
+        left = iv.left(1, n=33)
+        self.assertEqual(len(left), 1)
 
         u = iv.right(1, n=9999)
         self.assertEqual(len(u), 250)

--- a/skbio/metadata/tests/test_interval.py
+++ b/skbio/metadata/tests/test_interval.py
@@ -354,7 +354,7 @@ class TestIntervalUtil(unittest.TestCase):
         for fuzzy in fuzzy:
             try:
                 _assert_valid_fuzzy(fuzzy)
-            except:
+            except Exception:
                 self.assertTrue(False)
 
     def test_assert_valid_fuzzy_wrong_value(self):

--- a/skbio/sequence/tests/test_nucleotide_sequences.py
+++ b/skbio/sequence/tests/test_nucleotide_sequences.py
@@ -326,11 +326,11 @@ class TestNucleotideSequence(unittest.TestCase):
             rc = constructor(seq_str).complement(reverse=True)
             self.assertEqual(rc, constructor(rev_comp_str))
 
-            l = len(seq_str)
-            im = IntervalMetadata(l)
+            length = len(seq_str)
+            im = IntervalMetadata(length)
             im.add([(0, 1)], metadata={'gene': 'p53'})
-            im_rc = IntervalMetadata(l)
-            im_rc.add([(l-1, l)], metadata={'gene': 'p53'})
+            im_rc = IntervalMetadata(length)
+            im_rc.add([(length-1, length)], metadata={'gene': 'p53'})
             original = constructor(
                 seq_str,
                 metadata={'id': 'foo', 'description': 'bar'},


### PR DESCRIPTION
Made the following changes to fix build/test failures:

- scikit-bio now depends on `numpy >= 1.9.2, < 1.14.0` for compatibility with Python 3.4, 3.5, and 3.6 and the available numpy conda packages in `defaults` and `conda-forge` channels.
- Use latest Sphinx release (1.6) instead of Sphinx master branch.
- Fix flake8 errors related to updated flake8 package.
- Fix unit test for beta_diversity error message to work across supported Python 3 versions.

Please complete the following checklist:

* [x] I have read the guidelines in [CONTRIBUTING.md](https://github.com/biocore/scikit-bio/blob/master/CONTRIBUTING.md).

* [x] I have documented all public-facing changes in [CHANGELOG.md](https://github.com/biocore/scikit-bio/blob/master/CHANGELOG.md).

* [ ] **This pull request includes code, documentation, or other content derived from external source(s).** If this is the case, ensure the external source's license is compatible with scikit-bio's [license](https://github.com/biocore/scikit-bio/blob/master/COPYING.txt). Include the license in the `licenses` directory and add a comment in the code giving proper attribution. Ensure any other requirements set forth by the license and/or author are satisfied. **It is your responsibility to disclose code, documentation, or other content derived from external source(s).** If you have questions about whether something can be included in the project or how to give proper attribution, include those questions in your pull request and a reviewer will assist you.

* [x] **This pull request does not include code, documentation, or other content derived from external source(s).**

**Note:** [REVIEWING.md](https://github.com/biocore/scikit-bio/blob/master/REVIEWING.md) may also be helpful to see some of the things code reviewers will be verifying when reviewing your pull request.
