### PR TITLE
BLD/TST: gating numpydoc, 0.8.0 throws the following exception:

### DIFF
--- a/ci/pip_requirements.txt
+++ b/ci/pip_requirements.txt
@@ -5,5 +5,5 @@ lockfile
 CacheControl
 Sphinx
 sphinx-bootstrap-theme
-numpydoc
+numpydoc < 0.8.0
 check-manifest


### PR DESCRIPTION
numpydoc 0.8.0 throws the following, restricting to numpydoc < 0.8.0.

```bash
Traceback (most recent call last):
  File
"/Users/mcdonadt/miniconda3/envs/py36-skbio/lib/python3.6/site-packages/sphinx/config.py",
line 161, in __init__
    execfile_(filename, config)
  File
"/Users/mcdonadt/miniconda3/envs/py36-skbio/lib/python3.6/site-packages/sphinx/util/pycompat.py",
line 150, in execfile_
    exec_(code, _globals)
  File "conf.py", line 73, in <module>
    import numpydoc
ModuleNotFoundError: No module named 'numpydoc'
```

Please complete the following checklist:

* [X] I have read the guidelines in [CONTRIBUTING.md](https://github.com/biocore/scikit-bio/blob/master/CONTRIBUTING.md).

* [ ] I have documented all public-facing changes in [CHANGELOG.md](https://github.com/biocore/scikit-bio/blob/master/CHANGELOG.md).

* [ ] **This pull request includes code, documentation, or other content derived from external source(s).** If this is the case, ensure the external source's license is compatible with scikit-bio's [license](https://github.com/biocore/scikit-bio/blob/master/COPYING.txt). Include the license in the `licenses` directory and add a comment in the code giving proper attribution. Ensure any other requirements set forth by the license and/or author are satisfied. **It is your responsibility to disclose code, documentation, or other content derived from external source(s).** If you have questions about whether something can be included in the project or how to give proper attribution, include those questions in your pull request and a reviewer will assist you.

* [X] **This pull request does not include code, documentation, or other content derived from external source(s).**

**Note:** [REVIEWING.md](https://github.com/biocore/scikit-bio/blob/master/REVIEWING.md) may also be helpful to see some of the things code reviewers will be verifying when reviewing your pull request.
