### PR TITLE
WIP: Fix Pandas deprecation warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@
 ### Bug fixes
 * The `include_self` parameter was not being honored in `skbio.TreeNode.tips`. The scope of this bug was that if `TreeNode.tips` was called on a tip, it would always result in an empty `list` when unrolled.
 
+* In `ca`, `proportion_explained` is inclued in the returned `OrdinationResults` object. ([#1345](https://github.com/biocore/scikit-bio/issues/1345))
+
 ### Deprecated functionality [stable]
 
 ### Deprecated functionality [experimental]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 ### Bug fixes
 * The `include_self` parameter was not being honored in `skbio.TreeNode.tips`. The scope of this bug was that if `TreeNode.tips` was called on a tip, it would always result in an empty `list` when unrolled.
 
-* In `ca`, `proportion_explained` is inclued in the returned `OrdinationResults` object. ([#1345](https://github.com/biocore/scikit-bio/issues/1345))
+* In `skbio.stats.ordination.ca`, `proportion_explained` was missing in the returned `OrdinationResults` object. ([#1345](https://github.com/biocore/scikit-bio/issues/1345))
 
 ### Deprecated functionality [stable]
 

--- a/skbio/stats/distance/_base.py
+++ b/skbio/stats/distance/_base.py
@@ -1068,11 +1068,17 @@ def _df_to_vector(distance_matrix, df, column):
     if column not in df:
         raise ValueError("Column '%s' not in DataFrame." % column)
 
+
+    missing_ids = set(distance_matrix.ids) - set(df.index)
+
+    if missing_ids:
+        raise ValueError("One or more IDs in the distance matrix "
+                         "are not in the data frame: "
+                         "%s" % missing_ids)
+
+
     grouping = df.loc[distance_matrix.ids, column]
-    if grouping.isnull().any():
-        raise ValueError(
-            "One or more IDs in the distance matrix are not in the data "
-            "frame.")
+
     return grouping.tolist()
 
 

--- a/skbio/stats/ordination/_correspondence_analysis.py
+++ b/skbio/stats/ordination/_correspondence_analysis.py
@@ -70,7 +70,8 @@ def ca(X, scaling=1):
     -------
     OrdinationResults
         Object that stores the computed eigenvalues, the transformed sample
-        coordinates and the transformed features coordinates.
+        coordinates, the transformed features coordinates and the proportion
+        explained.
 
     Raises
     ------
@@ -186,6 +187,7 @@ def ca(X, scaling=1):
                                   range(eigvals.shape[0])])
     samples = pd.DataFrame(sample_scores, row_ids, sample_columns)
     features = pd.DataFrame(features_scores, column_ids, feature_columns)
-
+    proportion_explained = eigvals / eigvals.sum()
     return OrdinationResults(short_method_name, long_method_name, eigvals,
-                             samples=samples, features=features)
+                             samples=samples, features=features,
+                             proportion_explained=proportion_explained)

--- a/skbio/stats/ordination/_ordination_results.py
+++ b/skbio/stats/ordination/_ordination_results.py
@@ -323,13 +323,18 @@ class OrdinationResults(SkbioObject):
             if column not in df:
                 raise ValueError("Column '%s' not in data frame." % column)
 
+            missing_ids = set(ids) - set(df.index)
+
+            if missing_ids:
+                raise ValueError("One or more IDs in the ordination results "
+                                 "are not in the data frame: "
+                                 "%s" % missing_ids)
+
             col_vals = df.loc[ids, column]
 
             if col_vals.isnull().any():
-                raise ValueError("One or more IDs in the ordination results "
-                                 "are not in the data frame, or there is "
-                                 "missing data in the data frame's '%s' "
-                                 "column." % column)
+                raise ValueError("There are missing data in the data "
+                                 "frame's '%s' column." % column)
 
             category_to_color = None
             try:

--- a/skbio/stats/ordination/tests/test_correspondence_analysis.py
+++ b/skbio/stats/ordination/tests/test_correspondence_analysis.py
@@ -156,7 +156,7 @@ class TestCAResults(TestCase):
                                          [0.51685, -0.09517]]),
                                self.sample_ids,
                                self.pc_ids)
-        proportion_explained = pd.Series(np.array([0.701318, 0.298682]), 
+        proportion_explained = pd.Series(np.array([0.701318, 0.298682]),
                                          self.pc_ids)
 
         exp = OrdinationResults('CA', 'Correspondance Analysis',

--- a/skbio/stats/ordination/tests/test_correspondence_analysis.py
+++ b/skbio/stats/ordination/tests/test_correspondence_analysis.py
@@ -129,9 +129,13 @@ class TestCAResults(TestCase):
                                          [1.66697, -0.47032]]),
                                self.sample_ids,
                                self.pc_ids)
+
+        proportion_explained = pd.Series(np.array([0.701318, 0.298682]), self.pc_ids)
+
         exp = OrdinationResults('CA', 'Correspondance Analysis',
                                 eigvals=eigvals, features=features,
-                                samples=samples)
+                                samples=samples,
+                                proportion_explained=proportion_explained)
 
         scores = ca(self.contingency, 2)
 
@@ -151,9 +155,12 @@ class TestCAResults(TestCase):
                                          [0.51685, -0.09517]]),
                                self.sample_ids,
                                self.pc_ids)
+        proportion_explained =  pd.Series(np.array([0.701318, 0.298682]), self.pc_ids)
+
         exp = OrdinationResults('CA', 'Correspondance Analysis',
                                 eigvals=eigvals, features=features,
-                                samples=samples)
+                                samples=samples,
+                                proportion_explained=proportion_explained)
         scores = ca(self.contingency, 1)
 
         assert_ordination_results_equal(exp, scores, decimal=5,

--- a/skbio/stats/ordination/tests/test_correspondence_analysis.py
+++ b/skbio/stats/ordination/tests/test_correspondence_analysis.py
@@ -130,7 +130,8 @@ class TestCAResults(TestCase):
                                self.sample_ids,
                                self.pc_ids)
 
-        proportion_explained = pd.Series(np.array([0.701318, 0.298682]), self.pc_ids)
+        proportion_explained = pd.Series(np.array([0.701318, 0.298682]),
+                                         self.pc_ids)
 
         exp = OrdinationResults('CA', 'Correspondance Analysis',
                                 eigvals=eigvals, features=features,
@@ -155,7 +156,8 @@ class TestCAResults(TestCase):
                                          [0.51685, -0.09517]]),
                                self.sample_ids,
                                self.pc_ids)
-        proportion_explained =  pd.Series(np.array([0.701318, 0.298682]), self.pc_ids)
+        proportion_explained = pd.Series(np.array([0.701318, 0.298682]), 
+                                         self.pc_ids)
 
         exp = OrdinationResults('CA', 'Correspondance Analysis',
                                 eigvals=eigvals, features=features,

--- a/skbio/stats/ordination/tests/test_ordination_results.py
+++ b/skbio/stats/ordination/tests/test_ordination_results.py
@@ -196,7 +196,7 @@ class TestOrdinationResults(unittest.TestCase):
                                                         ['B', 'C'], 'jet')
 
         # id not in df
-        with self.assertRaisesRegex(ValueError, 'numeric'):
+        with self.assertRaisesRegex(ValueError, 'missingid'):
             self.min_ord_results._get_plot_point_colors(
                 self.df, 'numeric', ['B', 'C', 'missingid', 'A'], 'jet')
 


### PR DESCRIPTION
This begins to address Issue #1559, solving the problem for two of three warnings in unittests.

The last one comes from the following lines of code: 

https://github.com/biocore/scikit-bio/blob/2bd67352c6e81cad1857a23f03328e18d779887b/skbio/alignment/tests/test_tabular_msa.py#L1138-L1145

But the structure of these tests is super confusing to me, so I haven't been able to track down where in the TablularMSA code the actual problem is arising. 

-------------

Please complete the following checklist:

* [ ] I have read the guidelines in [CONTRIBUTING.md](https://github.com/biocore/scikit-bio/blob/master/CONTRIBUTING.md).

* [ ] I have documented all public-facing changes in [CHANGELOG.md](https://github.com/biocore/scikit-bio/blob/master/CHANGELOG.md).

* [ ] **This pull request includes code, documentation, or other content derived from external source(s).** If this is the case, ensure the external source's license is compatible with scikit-bio's [license](https://github.com/biocore/scikit-bio/blob/master/COPYING.txt). Include the license in the `licenses` directory and add a comment in the code giving proper attribution. Ensure any other requirements set forth by the license and/or author are satisfied. **It is your responsibility to disclose code, documentation, or other content derived from external source(s).** If you have questions about whether something can be included in the project or how to give proper attribution, include those questions in your pull request and a reviewer will assist you.

* [ ] **This pull request does not include code, documentation, or other content derived from external source(s).**

**Note:** [REVIEWING.md](https://github.com/biocore/scikit-bio/blob/master/REVIEWING.md) may also be helpful to see some of the things code reviewers will be verifying when reviewing your pull request.