### PR TITLE
Added methods unpack and unpack_by_func to TreeNode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features
 
+* Added `unpack` and `unpack_by_func` to `skbio.tree.TreeNode` to unpack one or multiple internal nodes.
+
 * Added `support` to `skbio.tree.TreeNode` to return the support value of a node.
 
 * Added `permdisp` to `skbio.stats.distance` to test for the homogeniety of groups. ([#1228](https://github.com/biocore/scikit-bio/issues/1228)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features
 
-* Added `unpack` and `unpack_by_func` to `skbio.tree.TreeNode` to unpack one or multiple internal nodes.
+* Added `unpack` and `unpack_by_func` to `skbio.tree.TreeNode` to unpack one or multiple internal nodes. The "unpack" operation removes an internal node and regrafts its children to its parent while retaining the overall length.
 
 * Added `support` to `skbio.tree.TreeNode` to return the support value of a node.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## Version 0.5.2-dev (changes since 0.5.2 go here)
 
 ### Features
+
+* Added `support` to `skbio.tree.TreeNode` to return the support value of a node.
+
 * Added `permdisp` to `skbio.stats.distance` to test for the homogeniety of groups. ([#1228](https://github.com/biocore/scikit-bio/issues/1228)).
 
 ### Backward-incompatible changes [stable]

--- a/skbio/tree/_tree.py
+++ b/skbio/tree/_tree.py
@@ -3113,12 +3113,11 @@ class TreeNode(SkbioObject):
         A "support value" is defined as the numeric form of a whole node label
         without ":", or the part preceding the first ":" in the node label.
 
-        - For examples: "(a,b)1.0", "(a,b)1.0:2.5", and "(a,b)'1.0:species_A'".
+        For examples: "(a,b)1.0", "(a,b)1.0:2.5", and "(a,b)'1.0:species_A'".
         In these cases the support values are all 1.0.
 
-        - For examples: "(a,b):1.0" and "(a,b)species_A". In these cases there
+        For examples: "(a,b):1.0" and "(a,b)species_A". In these cases there
         are no support values.
-
 
         Examples
         --------

--- a/skbio/tree/_tree.py
+++ b/skbio/tree/_tree.py
@@ -3148,6 +3148,8 @@ class TreeNode(SkbioObject):
         parent node, and 3) grafts child nodes to parent node.
 
         Here is an illustration of the `unpack` operation:
+
+        ```
                     /----a
               /c---|
              |      \--b
@@ -3155,8 +3157,11 @@ class TreeNode(SkbioObject):
              |        /---d
               \f-----|
                       \-e
+        ```
 
         Unpack node "c" and the tree becomes:
+
+        ```
               /---------a
              |
         -----|--------b
@@ -3164,6 +3169,7 @@ class TreeNode(SkbioObject):
              |        /---d
               \f-----|
                       \-e
+        ```
 
         Raises
         ------

--- a/skbio/tree/_tree.py
+++ b/skbio/tree/_tree.py
@@ -3098,3 +3098,35 @@ class TreeNode(SkbioObject):
 
             yield self
             counter += 1
+
+    @experimental(as_of="0.5.2-dev")
+    def support(self):
+        """Return support value of a node if available
+
+        Returns
+        -------
+        float or None
+            support value of the node, or None if not available
+
+        Notes
+        -----
+        A "support value" is defined as the numeric form of a whole node label
+        without ":", or the part preceding the first ":" in the node label.
+        - For examples: "(a,b)1.0", "(a,b)1.0:2.5", and "(a,b)'1.0:species_A'".
+        In these cases the support values are all 1.0.
+        - For examples: "(a,b):1.0" and "(a,b)species_A". In these cases there
+        are no support values.
+
+        Examples
+        --------
+        >>> from skbio import TreeNode
+        >>> tree = TreeNode.read(['((a,b)99,(c,d):1.0);'])
+        >>> tree.lca(['a', 'b']).support()
+        99.0
+        >>> tree.lca(['c', 'd']).support() is None
+        True
+        """
+        try:
+            return float(self.name.split(':')[0])
+        except (ValueError, AttributeError):
+            return None

--- a/skbio/tree/_tree.py
+++ b/skbio/tree/_tree.py
@@ -3128,7 +3128,10 @@ class TreeNode(SkbioObject):
         >>> tree.lca(['c', 'd']).support() is None
         True
         """
-        try:
-            return float(self.name.split(':')[0])
-        except (ValueError, AttributeError):
-            return None
+        support = None
+        if self.name is not None:
+            try:
+                support = float(self.name.partition(':')[0])
+            except ValueError:
+                pass
+        return support

--- a/skbio/tree/_tree.py
+++ b/skbio/tree/_tree.py
@@ -3139,7 +3139,7 @@ class TreeNode(SkbioObject):
 
     @experimental(as_of="0.5.2-dev")
     def unpack(self):
-        """Unpack an internal node of a tree.
+        """Unpack an internal node in place.
 
         Notes
         -----
@@ -3151,6 +3151,11 @@ class TreeNode(SkbioObject):
         ------
         ValueError
             if input node is root or tip
+
+        See also
+        --------
+        unpack_by_func
+        prune
 
         Examples
         --------
@@ -3188,6 +3193,11 @@ class TreeNode(SkbioObject):
         skbio.TreeNode
             resulting tree with nodes meeting criteria unpacked
 
+        See also
+        --------
+        unpack
+        prune
+
         Examples
         --------
         >>> from skbio import TreeNode
@@ -3204,7 +3214,7 @@ class TreeNode(SkbioObject):
         """
         tcopy = self.copy()
         nodes_to_unpack = []
-        for node in tcopy.non_tips():
+        for node in tcopy.non_tips(include_self=False):
             if func(node):
                 nodes_to_unpack.append(node)
         for node in nodes_to_unpack:

--- a/skbio/tree/_tree.py
+++ b/skbio/tree/_tree.py
@@ -3147,30 +3147,6 @@ class TreeNode(SkbioObject):
         of self (omit if there is no branch length), 2) removes self from
         parent node, and 3) grafts child nodes to parent node.
 
-        Here is an illustration of the `unpack` operation:
-
-        ```
-                    /----a
-              /c---|
-             |      \--b
-        -----|
-             |        /---d
-              \f-----|
-                      \-e
-        ```
-
-        Unpack node "c" and the tree becomes:
-
-        ```
-              /---------a
-             |
-        -----|--------b
-             |
-             |        /---d
-              \f-----|
-                      \-e
-        ```
-
         Raises
         ------
         ValueError
@@ -3180,7 +3156,7 @@ class TreeNode(SkbioObject):
         --------
         >>> from skbio import TreeNode
         >>> tree = TreeNode.read(['((c:2.0,d:3.0)a:1.0,(e:2.0,f:1.0)b:2.0);'])
-        >>> unpack(tree.find('b'))
+        >>> tree.find('b').unpack()
         >>> print(tree)
         ((c:2.0,d:3.0)a:1.0,e:4.0,f:3.0);
         <BLANKLINE>
@@ -3221,7 +3197,7 @@ class TreeNode(SkbioObject):
         ((e:1.0,f:2.0)b:2.0,c:3.0,d:4.0);
         <BLANKLINE>
         >>> tree = TreeNode.read(['(((a,b)85,(c,d)78)75,(e,(f,g)64)80);'])
-        >>> tree_unpacked = tree.unpack_by_func(lambda x: support(x) < 75)
+        >>> tree_unpacked = tree.unpack_by_func(lambda x: x.support() < 75)
         >>> print(tree_unpacked)
         (((a,b)85,(c,d)78)75,(e,f,g)80);
         <BLANKLINE>

--- a/skbio/tree/_tree.py
+++ b/skbio/tree/_tree.py
@@ -3180,18 +3180,13 @@ class TreeNode(SkbioObject):
 
     @experimental(as_of="0.5.2-dev")
     def unpack_by_func(self, func):
-        """Unpack internal nodes that meet certain criteria.
+        """Unpack internal nodes of a tree that meet certain criteria.
 
         Parameters
         ----------
         func : function
             a function that accepts a TreeNode and returns `True` or `False`,
             where `True` indicates the node is to be unpacked
-
-        Returns
-        -------
-        skbio.TreeNode
-            resulting tree with nodes meeting criteria unpacked
 
         See also
         --------
@@ -3202,21 +3197,19 @@ class TreeNode(SkbioObject):
         --------
         >>> from skbio import TreeNode
         >>> tree = TreeNode.read(['((c:2,d:3)a:1,(e:1,f:2)b:2);'])
-        >>> tree_unpacked = tree.unpack_by_func(lambda x: x.length <= 1)
-        >>> print(tree_unpacked)
+        >>> tree.unpack_by_func(lambda x: x.length <= 1)
+        >>> print(tree)
         ((e:1.0,f:2.0)b:2.0,c:3.0,d:4.0);
         <BLANKLINE>
         >>> tree = TreeNode.read(['(((a,b)85,(c,d)78)75,(e,(f,g)64)80);'])
-        >>> tree_unpacked = tree.unpack_by_func(lambda x: x.support() < 75)
-        >>> print(tree_unpacked)
+        >>> tree.unpack_by_func(lambda x: x.support() < 75)
+        >>> print(tree)
         (((a,b)85,(c,d)78)75,(e,f,g)80);
         <BLANKLINE>
         """
-        tcopy = self.copy()
         nodes_to_unpack = []
-        for node in tcopy.non_tips(include_self=False):
+        for node in self.non_tips(include_self=False):
             if func(node):
                 nodes_to_unpack.append(node)
         for node in nodes_to_unpack:
             node.unpack()
-        return tcopy

--- a/skbio/tree/_tree.py
+++ b/skbio/tree/_tree.py
@@ -3119,6 +3119,7 @@ class TreeNode(SkbioObject):
         - For examples: "(a,b):1.0" and "(a,b)species_A". In these cases there
         are no support values.
 
+
         Examples
         --------
         >>> from skbio import TreeNode

--- a/skbio/tree/_tree.py
+++ b/skbio/tree/_tree.py
@@ -3167,9 +3167,9 @@ class TreeNode(SkbioObject):
         <BLANKLINE>
         """
         if self.is_root():
-            raise ValueError('Cannot unpack root.')
+            raise TreeError('Cannot unpack root.')
         if self.is_tip():
-            raise ValueError('Cannot unpack tip.')
+            raise TreeError('Cannot unpack tip.')
         parent = self.parent
         blen = (self.length or 0.0)
         for child in self.children:

--- a/skbio/tree/_tree.py
+++ b/skbio/tree/_tree.py
@@ -3112,8 +3112,10 @@ class TreeNode(SkbioObject):
         -----
         A "support value" is defined as the numeric form of a whole node label
         without ":", or the part preceding the first ":" in the node label.
+
         - For examples: "(a,b)1.0", "(a,b)1.0:2.5", and "(a,b)'1.0:species_A'".
         In these cases the support values are all 1.0.
+
         - For examples: "(a,b):1.0" and "(a,b)species_A". In these cases there
         are no support values.
 

--- a/skbio/tree/_tree.py
+++ b/skbio/tree/_tree.py
@@ -3130,8 +3130,9 @@ class TreeNode(SkbioObject):
         """
         support = None
         if self.name is not None:
+            left, _, _ = self.name.partition(':')
             try:
-                support = float(self.name.partition(':')[0])
+                support = float(left)
             except ValueError:
                 pass
         return support

--- a/skbio/tree/tests/test_tree.py
+++ b/skbio/tree/tests/test_tree.py
@@ -1317,6 +1317,13 @@ class TreeTests(TestCase):
         self.assertEqual(node1.support(), 0.85)
         self.assertEqual(node2.support(), 0.95)
 
+        # test support values that are negative or scientific notation (not a
+        # common scenario but can happen)
+        tree = TreeNode.read(['((a,b)-1.23,(c,d)1.23e-4);'])
+        node1, node2 = tree.children
+        self.assertEqual(node1.support(), -1.23)
+        self.assertEqual(node2.support(), 0.000123)
+
         # test nodes with support and extra label (not a common scenario but
         # can happen)
         tree = TreeNode.read(['((a,b)\'80:X\',(c,d)\'60:Y\');'])

--- a/skbio/tree/tests/test_tree.py
+++ b/skbio/tree/tests/test_tree.py
@@ -1371,21 +1371,22 @@ class TreeTests(TestCase):
         # will unpack node 'a', but not tip 'e'
         # will add the branch length of 'a' to its child nodes 'c' and 'd'
         tree = TreeNode.read(['((c:2,d:3)a:1,(e:1,f:2)b:2);'])
-        obs = str(tree.unpack_by_func(func)).rstrip()
+        tree.unpack_by_func(func)
         exp = '((e:1.0,f:2.0)b:2.0,c:3.0,d:4.0);'
-        self.assertEqual(obs, exp)
+        self.assertEqual(str(tree).rstrip(), exp)
 
         # unpack internal nodes with branch length < 2.01
         # will unpack both 'a' and 'b'
-        obs = str(tree.unpack_by_func(lambda x: x.length <= 2.0)).rstrip()
+        tree = TreeNode.read(['((c:2,d:3)a:1,(e:1,f:2)b:2);'])
+        tree.unpack_by_func(lambda x: x.length <= 2.0)
         exp = '(c:3.0,d:4.0,e:3.0,f:4.0);'
-        self.assertEqual(obs, exp)
+        self.assertEqual(str(tree).rstrip(), exp)
 
         # unpack two nested nodes 'a' and 'c' simultaneously
         tree = TreeNode.read(['(((e:3,f:2)c:1,d:3)a:1,b:4);'])
-        obs = str(tree.unpack_by_func(lambda x: x.length <= 2.0)).rstrip()
+        tree.unpack_by_func(lambda x: x.length <= 2.0)
         exp = '(b:4.0,d:4.0,e:5.0,f:4.0);'
-        self.assertEqual(obs, exp)
+        self.assertEqual(str(tree).rstrip(), exp)
 
         # test a complicated scenario (unpacking nodes 'g', 'h' and 'm')
         def func(x):
@@ -1393,29 +1394,30 @@ class TreeTests(TestCase):
         tree = TreeNode.read(['(((a:1.04,b:2.32,c:1.44)d:3.20,'
                               '(e:3.91,f:2.47)g:1.21)h:1.75,'
                               '(i:4.14,(j:2.06,k:1.58)l:3.32)m:0.77);'])
-        obs = str(tree.unpack_by_func(func)).rstrip()
+        tree.unpack_by_func(func)
         exp = ('((a:1.04,b:2.32,c:1.44)d:4.95,e:6.87,f:5.43,i:4.91,'
                '(j:2.06,k:1.58)l:4.09);')
-        self.assertEqual(obs, exp)
+        self.assertEqual(str(tree).rstrip(), exp)
 
         # unpack nodes with support < 75
         def func(x):
             return x.support() < 75
         tree = TreeNode.read(['(((a,b)85,(c,d)78)75,(e,(f,g)64)80);'])
-        obs = str(tree.unpack_by_func(func)).rstrip()
+        tree.unpack_by_func(func)
         exp = '(((a,b)85,(c,d)78)75,(e,f,g)80);'
-        self.assertEqual(obs, exp)
+        self.assertEqual(str(tree).rstrip(), exp)
 
         # unpack nodes with support < 85
-        obs = str(tree.unpack_by_func(lambda x: x.support() < 85)).rstrip()
+        tree = TreeNode.read(['(((a,b)85,(c,d)78)75,(e,(f,g)64)80);'])
+        tree.unpack_by_func(lambda x: x.support() < 85)
         exp = '((a,b)85,c,d,e,f,g);'
-        self.assertEqual(obs, exp)
+        self.assertEqual(str(tree).rstrip(), exp)
 
         # unpack nodes with support < 0.95
         tree = TreeNode.read(['(((a,b)0.97,(c,d)0.98)1.0,(e,(f,g)0.88)0.96);'])
-        obs = str(tree.unpack_by_func(lambda x: x.support() < 0.95)).rstrip()
+        tree.unpack_by_func(lambda x: x.support() < 0.95)
         exp = '(((a,b)0.97,(c,d)0.98)1.0,(e,f,g)0.96);'
-        self.assertEqual(obs, exp)
+        self.assertEqual(str(tree).rstrip(), exp)
 
         # test a case where there are branch lengths, none support values and
         # node labels
@@ -1425,10 +1427,10 @@ class TreeTests(TestCase):
         tree = TreeNode.read(['(((a:1.02,b:0.33)85:0.12,(c:0.86,d:2.23)'
                               '70:3.02)75:0.95,(e:1.43,(f:1.69,g:1.92)64:0.20)'
                               'node:0.35)root;'])
-        obs = str(tree.unpack_by_func(func)).rstrip()
+        tree.unpack_by_func(func)
         exp = ('(((a:1.02,b:0.33)85:0.12,c:3.88,d:5.25)75:0.95,'
                '(e:1.43,f:1.89,g:2.12)node:0.35)root;')
-        self.assertEqual(obs, exp)
+        self.assertEqual(str(tree).rstrip(), exp)
 
 
 sample = """

--- a/skbio/tree/tests/test_tree.py
+++ b/skbio/tree/tests/test_tree.py
@@ -1354,12 +1354,12 @@ class TreeTests(TestCase):
         # test attempting to unpack root
         tree = TreeNode.read(['((d,e)b,(f,g)c)a;'])
         msg = 'Cannot unpack root.'
-        with self.assertRaisesRegex(ValueError, msg):
+        with self.assertRaisesRegex(TreeError, msg):
             tree.find('a').unpack()
 
         # test attempting to unpack tip
         msg = 'Cannot unpack tip.'
-        with self.assertRaisesRegex(ValueError, msg):
+        with self.assertRaisesRegex(TreeError, msg):
             tree.find('d').unpack()
 
     def test_unpack_by_func(self):

--- a/skbio/tree/tests/test_tree.py
+++ b/skbio/tree/tests/test_tree.py
@@ -1303,6 +1303,33 @@ class TreeTests(TestCase):
         with self.assertRaises(MissingNodeError):
             next(self.simple_t.shuffle(names=['x', 'y']))
 
+    def test_support(self):
+        """Get support value of a node."""
+        # test nodes with support alone as label
+        tree = TreeNode.read(['((a,b)75,(c,d)90);'])
+        node1, node2 = tree.children
+        self.assertEqual(node1.support(), 75.0)
+        self.assertEqual(node2.support(), 90.0)
+
+        # test nodes with support and branch length
+        tree = TreeNode.read(['((a,b)0.85:1.23,(c,d)0.95:4.56);'])
+        node1, node2 = tree.children
+        self.assertEqual(node1.support(), 0.85)
+        self.assertEqual(node2.support(), 0.95)
+
+        # test nodes with support and extra label (not a common scenario but
+        # can happen)
+        tree = TreeNode.read(['((a,b)\'80:X\',(c,d)\'60:Y\');'])
+        node1, node2 = tree.children
+        self.assertEqual(node1.support(), 80.0)
+        self.assertEqual(node2.support(), 60.0)
+
+        # test nodes without label, with non-numeric label, and with branch
+        # length only
+        tree = TreeNode.read(['((a,b),(c,d)x,(e,f):1.0);'])
+        for node in tree.children:
+            self.assertIsNone(node.support())
+
 
 sample = """
 (

--- a/skbio/tree/tests/test_tree.py
+++ b/skbio/tree/tests/test_tree.py
@@ -1337,6 +1337,99 @@ class TreeTests(TestCase):
         for node in tree.children:
             self.assertIsNone(node.support())
 
+    def test_unpack(self):
+        """Unpack an internal node."""
+        # test unpacking a node without branch length
+        tree = TreeNode.read(['((c,d)a,(e,f)b);'])
+        tree.find('b').unpack()
+        exp = '((c,d)a,e,f);\n'
+        self.assertEqual(str(tree), exp)
+
+        # test unpacking a node with branch length
+        tree = TreeNode.read(['((c:2.0,d:3.0)a:1.0,(e:2.0,f:1.0)b:2.0);'])
+        tree.find('b').unpack()
+        exp = '((c:2.0,d:3.0)a:1.0,e:4.0,f:3.0);'
+        self.assertEqual(str(tree).rstrip(), exp)
+
+        # test attempting to unpack root
+        tree = TreeNode.read(['((d,e)b,(f,g)c)a;'])
+        msg = 'Cannot unpack root.'
+        with self.assertRaisesRegex(ValueError, msg):
+            tree.find('a').unpack()
+
+        # test attempting to unpack tip
+        msg = 'Cannot unpack tip.'
+        with self.assertRaisesRegex(ValueError, msg):
+            tree.find('d').unpack()
+
+    def test_unpack_by_func(self):
+        """Unpack internal nodes of a tree by a function."""
+        # unpack internal nodes with branch length <= 1.0
+        def func(x):
+            return x.length <= 1.0
+
+        # will unpack node 'a', but not tip 'e'
+        # will add the branch length of 'a' to its child nodes 'c' and 'd'
+        tree = TreeNode.read(['((c:2,d:3)a:1,(e:1,f:2)b:2);'])
+        obs = str(tree.unpack_by_func(func)).rstrip()
+        exp = '((e:1.0,f:2.0)b:2.0,c:3.0,d:4.0);'
+        self.assertEqual(obs, exp)
+
+        # unpack internal nodes with branch length < 2.01
+        # will unpack both 'a' and 'b'
+        obs = str(tree.unpack_by_func(lambda x: x.length <= 2.0)).rstrip()
+        exp = '(c:3.0,d:4.0,e:3.0,f:4.0);'
+        self.assertEqual(obs, exp)
+
+        # unpack two nested nodes 'a' and 'c' simultaneously
+        tree = TreeNode.read(['(((e:3,f:2)c:1,d:3)a:1,b:4);'])
+        obs = str(tree.unpack_by_func(lambda x: x.length <= 2.0)).rstrip()
+        exp = '(b:4.0,d:4.0,e:5.0,f:4.0);'
+        self.assertEqual(obs, exp)
+
+        # test a complicated scenario (unpacking nodes 'g', 'h' and 'm')
+        def func(x):
+            return x.length < 2.0
+        tree = TreeNode.read(['(((a:1.04,b:2.32,c:1.44)d:3.20,'
+                              '(e:3.91,f:2.47)g:1.21)h:1.75,'
+                              '(i:4.14,(j:2.06,k:1.58)l:3.32)m:0.77);'])
+        obs = str(tree.unpack_by_func(func)).rstrip()
+        exp = ('((a:1.04,b:2.32,c:1.44)d:4.95,e:6.87,f:5.43,i:4.91,'
+               '(j:2.06,k:1.58)l:4.09);')
+        self.assertEqual(obs, exp)
+
+        # unpack nodes with support < 75
+        def func(x):
+            return x.support() < 75
+        tree = TreeNode.read(['(((a,b)85,(c,d)78)75,(e,(f,g)64)80);'])
+        obs = str(tree.unpack_by_func(func)).rstrip()
+        exp = '(((a,b)85,(c,d)78)75,(e,f,g)80);'
+        self.assertEqual(obs, exp)
+
+        # unpack nodes with support < 85
+        obs = str(tree.unpack_by_func(lambda x: x.support() < 85)).rstrip()
+        exp = '((a,b)85,c,d,e,f,g);'
+        self.assertEqual(obs, exp)
+
+        # unpack nodes with support < 0.95
+        tree = TreeNode.read(['(((a,b)0.97,(c,d)0.98)1.0,(e,(f,g)0.88)0.96);'])
+        obs = str(tree.unpack_by_func(lambda x: x.support() < 0.95)).rstrip()
+        exp = '(((a,b)0.97,(c,d)0.98)1.0,(e,f,g)0.96);'
+        self.assertEqual(obs, exp)
+
+        # test a case where there are branch lengths, none support values and
+        # node labels
+        def func(x):
+            sup = x.support()
+            return sup is not None and sup < 75
+        tree = TreeNode.read(['(((a:1.02,b:0.33)85:0.12,(c:0.86,d:2.23)'
+                              '70:3.02)75:0.95,(e:1.43,(f:1.69,g:1.92)64:0.20)'
+                              'node:0.35)root;'])
+        obs = str(tree.unpack_by_func(func)).rstrip()
+        exp = ('(((a:1.02,b:0.33)85:0.12,c:3.88,d:5.25)75:0.95,'
+               '(e:1.43,f:1.89,g:2.12)node:0.35)root;')
+        self.assertEqual(obs, exp)
+
 
 sample = """
 (


### PR DESCRIPTION
Please complete the following checklist:

* [x] I have read the guidelines in [CONTRIBUTING.md](https://github.com/biocore/scikit-bio/blob/master/CONTRIBUTING.md).

* [x] I have documented all public-facing changes in [CHANGELOG.md](https://github.com/biocore/scikit-bio/blob/master/CHANGELOG.md).

* [ ] **This pull request includes code, documentation, or other content derived from external source(s).** If this is the case, ensure the external source's license is compatible with scikit-bio's [license](https://github.com/biocore/scikit-bio/blob/master/COPYING.txt). Include the license in the `licenses` directory and add a comment in the code giving proper attribution. Ensure any other requirements set forth by the license and/or author are satisfied. **It is your responsibility to disclose code, documentation, or other content derived from external source(s).** If you have questions about whether something can be included in the project or how to give proper attribution, include those questions in your pull request and a reviewer will assist you.

* [x] **This pull request does not include code, documentation, or other content derived from external source(s).**

**Note:** [REVIEWING.md](https://github.com/biocore/scikit-bio/blob/master/REVIEWING.md) may also be helpful to see some of the things code reviewers will be verifying when reviewing your pull request.

***

Hello @wasade @RNAer @mortonjt (and @antgonza ) , thanks for reviewing my first PR to scikit-bio and merged it. Here is my second PR, which is slightly more complex. The `unpack` method removes an internal node and regrafts its children to its parent. The `unpack_by_func` method does this in a batch mode. These functions are useful when the user wants to unpack short and low-support nodes from a tree. The code was also [reviewed](https://github.com/biocore/horizomer/pull/75) by @sjanssen2 , @tanaes and @mortonjt , and was presented and discussed during a Monday code review.
