### PR TITLE
FIX: removing integer type check in diversity calculations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 
 ### Bug fixes
 
-* Removing type checking in diversity calculations.  ([#1583](https://github.com/biocore/scikit-bio/issues/1583)).
+* Relaxing type checking in diversity calculations.  ([#1583](https://github.com/biocore/scikit-bio/issues/1583)).
 
 ### Deprecated functionality [stable]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
 
 ### Bug fixes
 
+* Removing type checking in diversity calculations.  ([#1583](https://github.com/biocore/scikit-bio/issues/1583)).
+
 ### Deprecated functionality [stable]
 
 ### Deprecated functionality [experimental]

--- a/skbio/diversity/_util.py
+++ b/skbio/diversity/_util.py
@@ -22,9 +22,6 @@ def _validate_counts_vector(counts, suppress_cast=False):
     """
     counts = np.asarray(counts)
 
-    if not suppress_cast:
-        counts = counts.astype(int, casting='safe', copy=False)
-
     if counts.ndim != 1:
         raise ValueError("Only 1-D vectors are supported.")
     elif (counts < 0).any():

--- a/skbio/diversity/_util.py
+++ b/skbio/diversity/_util.py
@@ -21,7 +21,8 @@ def _validate_counts_vector(counts, suppress_cast=False):
 
     """
     counts = np.asarray(counts)
-
+    if not np.all(np.isreal(counts)):
+        raise ValueError("Counts vector must contain real-valued entries.")
     if counts.ndim != 1:
         raise ValueError("Only 1-D vectors are supported.")
     elif (counts < 0).any():

--- a/skbio/diversity/tests/test_util.py
+++ b/skbio/diversity/tests/test_util.py
@@ -57,9 +57,6 @@ class ValidationTests(TestCase):
         self.assertEqual(obs.dtype, int)
 
     def test_validate_counts_vector_invalid_input(self):
-        # wrong dtype
-        with self.assertRaises(TypeError):
-            _validate_counts_vector([0, 2, 1.2, 3])
 
         # wrong number of dimensions (2-D)
         with self.assertRaises(ValueError):
@@ -101,8 +98,6 @@ class ValidationTests(TestCase):
         npt.assert_array_equal(obs[1], np.array([42.2, 42.1, 1.0]))
         self.assertEqual(obs[0].dtype, float)
         self.assertEqual(obs[1].dtype, float)
-        with self.assertRaises(TypeError):
-            _validate_counts_matrix([[0.0], [1]], suppress_cast=False)
 
     def test_validate_counts_matrix_negative_counts(self):
         with self.assertRaises(ValueError):

--- a/skbio/diversity/tests/test_util.py
+++ b/skbio/diversity/tests/test_util.py
@@ -70,6 +70,10 @@ class ValidationTests(TestCase):
         with self.assertRaises(ValueError):
             _validate_counts_vector([0, 0, 2, -1, 3])
 
+        # strings
+        with self.assertRaises(ValueError):
+            _validate_counts_vector([0, 0, 'a', -1, 3])
+
     def test_validate_counts_matrix(self):
         # basic valid input (n=2)
         obs = _validate_counts_matrix([[0, 1, 1, 0, 2],


### PR DESCRIPTION
Please complete the following checklist:

* [x] I have read the guidelines in [CONTRIBUTING.md](https://github.com/biocore/scikit-bio/blob/master/CONTRIBUTING.md).

* [x] I have documented all public-facing changes in [CHANGELOG.md](https://github.com/biocore/scikit-bio/blob/master/CHANGELOG.md).

* [ ] **This pull request includes code, documentation, or other content derived from external source(s).** If this is the case, ensure the external source's license is compatible with scikit-bio's [license](https://github.com/biocore/scikit-bio/blob/master/COPYING.txt). Include the license in the `licenses` directory and add a comment in the code giving proper attribution. Ensure any other requirements set forth by the license and/or author are satisfied. **It is your responsibility to disclose code, documentation, or other content derived from external source(s).** If you have questions about whether something can be included in the project or how to give proper attribution, include those questions in your pull request and a reviewer will assist you.

* [x] **This pull request does not include code, documentation, or other content derived from external source(s).**

**Note:** [REVIEWING.md](https://github.com/biocore/scikit-bio/blob/master/REVIEWING.md) may also be helpful to see some of the things code reviewers will be verifying when reviewing your pull request.

This addresses both #1580 and #1581.  Note that by removing this type check, this will open the doors for other normalization techniques (i.e. total sum scaling) that are floating-point valued.