### PR TITLE
Replace TabularMSALoc use of Index.get_duplicates

### DIFF
--- a/skbio/alignment/_indexing.py
+++ b/skbio/alignment/_indexing.py
@@ -171,7 +171,10 @@ class TabularMSALoc(_Indexing):
             except TypeError:  # Unhashable type, no biggie
                 pass
         if index.has_duplicates:
-            duplicated_key = indexable in index.get_duplicates()
+            # for a given Index object index,
+            # index[index.duplicated()].unique() is pandas' recommended
+            # replacement for index.get_duplicates(), per the pandas 0.23 docs
+            duplicated_key = indexable in index[index.duplicated()].unique()
         return (not duplicated_key and
                 ((np.isscalar(indexable) and not partial_key) or complete_key))
 


### PR DESCRIPTION
Fixes a few warnings in the test about `Index.get_duplicates()` being deprecated.

This works with pandas 0.23.0, so it should be ok -- the oldest version of pandas that scikit-bio supports is 0.23, per setup.py.

Please complete the following checklist:

* [X] I have read the guidelines in [CONTRIBUTING.md](https://github.com/biocore/scikit-bio/blob/master/CONTRIBUTING.md).

* [X] I have documented all public-facing changes in [CHANGELOG.md](https://github.com/biocore/scikit-bio/blob/master/CHANGELOG.md).

* [ ] **This pull request includes code, documentation, or other content derived from external source(s).** If this is the case, ensure the external source's license is compatible with scikit-bio's [license](https://github.com/biocore/scikit-bio/blob/master/COPYING.txt). Include the license in the `licenses` directory and add a comment in the code giving proper attribution. Ensure any other requirements set forth by the license and/or author are satisfied. **It is your responsibility to disclose code, documentation, or other content derived from external source(s).** If you have questions about whether something can be included in the project or how to give proper attribution, include those questions in your pull request and a reviewer will assist you.

* [X] **This pull request does not include code, documentation, or other content derived from external source(s).**

**Note:** [REVIEWING.md](https://github.com/biocore/scikit-bio/blob/master/REVIEWING.md) may also be helpful to see some of the things code reviewers will be verifying when reviewing your pull request.
