### PR TITLE
Update documentation building to use napoleon

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,9 @@ os:
   - linux
   - osx
 env:
-  - CONDA_PY=3.7 MAKE_DOC=TRUE
-  - CONDA_PY=3.6 MAKE_DOC=TRUE
-  - CONDA_PY=3.5 MAKE_DOC=TRUE USE_CYTHON=TRUE
+  - CONDA_PY=3.7
+  - CONDA_PY=3.6
+  - CONDA_PY=3.5 USE_CYTHON=TRUE
 
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh; fi
@@ -31,7 +31,7 @@ install:
 
 script:
   - WITH_COVERAGE=TRUE make test
-  - if [ ${MAKE_DOC} ]; then make -C doc clean html; fi
+  - make -C doc clean html
 
 after_success:
   - coveralls

--- a/ci/pip_requirements.txt
+++ b/ci/pip_requirements.txt
@@ -5,6 +5,5 @@ lockfile
 CacheControl
 Sphinx
 sphinx-bootstrap-theme
-numpydoc < 0.8.0
 check-manifest
 hdmedians

--- a/doc/README.md
+++ b/doc/README.md
@@ -11,7 +11,11 @@ Building the documentation
 --------------------------
 
 To build the documentation, you'll need a scikit-bio development environment
-set up. See [CONTRIBUTING.md](../CONTRIBUTING.md) for instructions.
+set up. See [CONTRIBUTING.md](../CONTRIBUTING.md) for instructions. In
+addition, you will also need to install Sphinx and the theme for the
+documentation, you can do that with:
+
+    pip install Sphinx sphinx-bootstrap-theme
 
 **Important:** The documentation will be built for whatever version of
 scikit-bio is *currently installed* on your system (i.e., the version imported

--- a/doc/source/_static/copybutton.js
+++ b/doc/source/_static/copybutton.js
@@ -1,13 +1,11 @@
-// originally taken from scikit-learn's Sphinx theme
 $(document).ready(function() {
     /* Add a [>>>] button on the top-right corner of code samples to hide
      * the >>> and ... prompts and the output and thus make the code
-     * copyable.
-     * Note: This JS snippet was taken from the official python.org
-     * documentation site.*/
+     * copyable. */
     var div = $('.highlight-python .highlight,' +
                 '.highlight-python3 .highlight,' +
-                '.highlight-pycon .highlight')
+                '.highlight-pycon .highlight,' +
+		'.highlight-default .highlight')
     var pre = div.find('pre');
 
     // get the styles from the current theme
@@ -22,7 +20,7 @@ $(document).ready(function() {
         'border-color': border_color, 'border-style': border_style,
         'border-width': border_width, 'color': border_color, 'text-size': '75%',
         'font-family': 'monospace', 'padding-left': '0.2em', 'padding-right': '0.2em',
-        'display': 'inline'
+        'border-radius': '0 3px 0 0'
     }
 
     // create and add the button to all the code blocks that contain >>>
@@ -32,31 +30,34 @@ $(document).ready(function() {
             var button = $('<span class="copybutton">&gt;&gt;&gt;</span>');
             button.css(button_styles)
             button.attr('title', hide_text);
+            button.data('hidden', 'false');
             jthis.prepend(button);
-
-            var show_output = false;
-            button.bind('click', function() {
-                if (show_output) {
-                    var button = $(this);
-                    button.parent().find('.go, .gp, .gt').show();
-                    button.next('pre').find('.gt').nextUntil('.gp, .go').css('visibility', 'visible');
-                    button.css('text-decoration', 'none');
-                    button.attr('title', hide_text);
-                    show_output = false;
-                } else {
-                    var button = $(this);
-                    button.parent().find('.go, .gp, .gt').hide();
-                    button.next('pre').find('.gt').nextUntil('.gp, .go').css('visibility', 'hidden');
-                    button.css('text-decoration', 'line-through');
-                    button.attr('title', show_text);
-                    show_output = true;
-                }
-            });
         }
         // tracebacks (.gt) contain bare text elements that need to be
         // wrapped in a span to work with .nextUntil() (see later)
         jthis.find('pre:has(.gt)').contents().filter(function() {
             return ((this.nodeType == 3) && (this.data.trim().length > 0));
         }).wrap('<span>');
+    });
+
+    // define the behavior of the button when it's clicked
+    $('.copybutton').click(function(e){
+        e.preventDefault();
+        var button = $(this);
+        if (button.data('hidden') === 'false') {
+            // hide the code output
+            button.parent().find('.go, .gp, .gt').hide();
+            button.next('pre').find('.gt').nextUntil('.gp, .go').css('visibility', 'hidden');
+            button.css('text-decoration', 'line-through');
+            button.attr('title', show_text);
+            button.data('hidden', 'true');
+        } else {
+            // show the code output
+            button.parent().find('.go, .gp, .gt').show();
+            button.next('pre').find('.gt').nextUntil('.gp, .go').css('visibility', 'visible');
+            button.css('text-decoration', 'none');
+            button.attr('title', hide_text);
+            button.data('hidden', 'false');
+        }
     });
 });

--- a/doc/source/_templates/autosummary/class.rst
+++ b/doc/source/_templates/autosummary/class.rst
@@ -1,4 +1,7 @@
+{% This template was modified from autosummaries default format %}
 {{ fullname | escape | underline}}
+
+{% We need a list of the built-ins that we implemented, not the default ones %}
 {% set built_in_methods = []  %}
 {% for item in all_methods %}
    {% if (item not in ['__class__',

--- a/doc/source/_templates/autosummary/class.rst
+++ b/doc/source/_templates/autosummary/class.rst
@@ -1,41 +1,50 @@
-{% extends "!autosummary/class.rst" %}
+{{ fullname | escape | underline}}
 
-{# Taken from scipy's sphinx documentation setup (https://github.com/scipy/scipy/blob/master/doc/source/_templates/autosummary/class.rst). #}
+.. currentmodule:: {{ module }}
 
-{% block methods %}
-{% if methods %}
-   .. HACK -- the point here is that we don't want this to appear in the output, but the autosummary should still generate the pages.
-      .. autosummary::
-         :toctree:
-      {% for item in all_methods %}
-         {# We want to build dunder methods if they exist, but not every kind of dunder. These are the dunders provided by default on `object` #}
-         {%- if not item.startswith('_') or (item not in ['__class__',
-                                                          '__delattr__',
-                                                          '__getattribute__',
-                                                          '__init__',
-                                                          '__dir__',
-                                                          '__new__',
-                                                          '__reduce__',
-                                                          '__reduce_ex__',
-                                                          '__repr__',
-                                                          '__setattr__',
-                                                          '__sizeof__',
-                                                          '__subclasshook__'] and item.startswith('__')) %}
-         {{ name }}.{{ item }}
-         {%- endif -%}
-      {%- endfor %}
-{% endif %}
-{% endblock %}
+.. autoclass:: {{ objname }}
 
-{% block attributes %}
-{% if attributes %}
-   .. HACK -- the point here is that we don't want this to appear in the output, but the autosummary should still generate the pages.
-      .. autosummary::
-         :toctree:
-      {% for item in all_attributes %}
-         {%- if not item.startswith('_') %}
-         {{ name }}.{{ item }}
-         {%- endif -%}
-      {%- endfor %}
-{% endif %}
-{% endblock %}
+   .. automethod:: __init__
+
+   {% if attributes %}
+   .. rubric:: Attributes
+
+   .. autosummary::
+   {% for item in attributes %}
+      ~{{ name }}.{{ item }}
+   {%- endfor %}
+
+   {% endif %}
+
+
+   {% if methods %}
+   .. rubric:: Methods
+
+   .. autosummary::
+   {% for item in methods %}
+      ~{{ name }}.{{ item }}
+   {%- endfor %}
+
+   .. rubric:: Built-ins
+
+   .. autosummary::
+      :toctree:
+   {% for item in all_methods %}
+      {# We want to build dunder methods if they exist, but not every kind of dunder. These are the dunders provided by default on `object` #}
+      {%- if (item not in ['__class__',
+                           '__delattr__',
+                           '__getattribute__',
+                           '__init__',
+                           '__dir__',
+                           '__new__',
+                           '__reduce__',
+                           '__reduce_ex__',
+                           '__repr__',
+                           '__setattr__',
+                           '__sizeof__',
+                           '__subclasshook__'] and item.startswith('__')) %}
+      ~{{ name }}.{{ item }}
+      {%- endif -%}
+   {%- endfor %}
+
+   {% endif %}

--- a/doc/source/_templates/autosummary/class.rst
+++ b/doc/source/_templates/autosummary/class.rst
@@ -6,6 +6,7 @@
                         '__getattribute__',
                         '__init__',
                         '__dir__',
+                        '__format__',
                         '__new__',
                         '__reduce__',
                         '__reduce_ex__',
@@ -46,6 +47,8 @@
    .. autosummary::
       :toctree:
    {% for item in methods %}
+      {% if item != '__init__' %}
       ~{{ name }}.{{ item }}
+      {% endif %}
    {%- endfor %}
    {% endif %}

--- a/doc/source/_templates/autosummary/class.rst
+++ b/doc/source/_templates/autosummary/class.rst
@@ -1,7 +1,7 @@
-{% This template was modified from autosummaries default format %}
+{# This template was modified from autosummaries default format #}
 {{ fullname | escape | underline}}
 
-{% We need a list of the built-ins that we implemented, not the default ones %}
+{# We need a list of the built-ins that we implemented, not the default ones #}
 {% set built_in_methods = []  %}
 {% for item in all_methods %}
    {% if (item not in ['__class__',

--- a/doc/source/_templates/autosummary/class.rst
+++ b/doc/source/_templates/autosummary/class.rst
@@ -1,10 +1,25 @@
 {{ fullname | escape | underline}}
+{% set built_in_methods = []  %}
+{% for item in all_methods %}
+   {% if (item not in ['__class__',
+                        '__delattr__',
+                        '__getattribute__',
+                        '__init__',
+                        '__dir__',
+                        '__new__',
+                        '__reduce__',
+                        '__reduce_ex__',
+                        '__repr__',
+                        '__setattr__',
+                        '__sizeof__',
+                        '__subclasshook__'] and item.startswith('__')) %}
+      {{ built_in_methods.append(item) or '' }}
+   {% endif %}
+{% endfor %}
 
 .. currentmodule:: {{ module }}
 
 .. autoclass:: {{ objname }}
-
-   .. automethod:: __init__
 
    {% if attributes %}
    .. rubric:: Attributes
@@ -13,38 +28,24 @@
    {% for item in attributes %}
       ~{{ name }}.{{ item }}
    {%- endfor %}
-
    {% endif %}
 
+   {% if built_in_methods %}
+   .. rubric:: Built-ins
+
+   .. autosummary::
+      :toctree:
+   {% for item in built_in_methods %}
+      ~{{ name }}.{{ item }}
+   {%- endfor %}
+   {% endif %}
 
    {% if methods %}
    .. rubric:: Methods
 
    .. autosummary::
+      :toctree:
    {% for item in methods %}
       ~{{ name }}.{{ item }}
    {%- endfor %}
-
-   .. rubric:: Built-ins
-
-   .. autosummary::
-      :toctree:
-   {% for item in all_methods %}
-      {# We want to build dunder methods if they exist, but not every kind of dunder. These are the dunders provided by default on `object` #}
-      {%- if (item not in ['__class__',
-                           '__delattr__',
-                           '__getattribute__',
-                           '__init__',
-                           '__dir__',
-                           '__new__',
-                           '__reduce__',
-                           '__reduce_ex__',
-                           '__repr__',
-                           '__setattr__',
-                           '__sizeof__',
-                           '__subclasshook__'] and item.startswith('__')) %}
-      ~{{ name }}.{{ item }}
-      {%- endif -%}
-   {%- endfor %}
-
    {% endif %}

--- a/skbio/diversity/alpha/__init__.py
+++ b/skbio/diversity/alpha/__init__.py
@@ -12,7 +12,7 @@ Functions
 ---------
 
 .. autosummary::
-   :toctree: generated/
+   :toctree:
 
    ace
    berger_parker_d

--- a/skbio/diversity/beta/__init__.py
+++ b/skbio/diversity/beta/__init__.py
@@ -13,7 +13,7 @@ Functions
 ---------
 
 .. autosummary::
-   :toctree: generated/
+   :toctree:
 
     unweighted_unifrac
     weighted_unifrac

--- a/skbio/io/__init__.py
+++ b/skbio/io/__init__.py
@@ -13,7 +13,7 @@ see the associated documentation.
 
 .. currentmodule:: skbio.io.format
 .. autosummary::
-   :toctree: generated/
+   :toctree:
 
    blast6
    blast7
@@ -37,7 +37,7 @@ User functions
 --------------
 
 .. autosummary::
-   :toctree: generated/
+   :toctree:
 
    write
    read
@@ -49,7 +49,7 @@ User exceptions and warnings
 ----------------------------
 
 .. autosummary::
-   :toctree: generated/
+   :toctree:
 
    FormatIdentificationWarning
    ArgumentOverrideWarning
@@ -76,7 +76,7 @@ Subpackages
 -----------
 
 .. autosummary::
-   :toctree: generated/
+   :toctree:
 
    registry
    util

--- a/skbio/io/__init__.py
+++ b/skbio/io/__init__.py
@@ -13,7 +13,7 @@ see the associated documentation.
 
 .. currentmodule:: skbio.io.format
 .. autosummary::
-   :toctree:
+   :toctree: generated/
 
    blast6
    blast7
@@ -37,7 +37,7 @@ User functions
 --------------
 
 .. autosummary::
-   :toctree:
+   :toctree: generated/
 
    write
    read
@@ -49,7 +49,7 @@ User exceptions and warnings
 ----------------------------
 
 .. autosummary::
-   :toctree:
+   :toctree: generated/
 
    FormatIdentificationWarning
    ArgumentOverrideWarning
@@ -76,7 +76,7 @@ Subpackages
 -----------
 
 .. autosummary::
-   :toctree:
+   :toctree: generated/
 
    registry
    util

--- a/skbio/io/registry.py
+++ b/skbio/io/registry.py
@@ -8,7 +8,7 @@ Classes
 -------
 
 .. autosummary::
-   :toctree: generated/
+   :toctree:
 
    IORegistry
    Format
@@ -17,7 +17,7 @@ Functions
 ---------
 
 .. autosummary::
-   :toctree: generated/
+   :toctree:
 
    create_format
 
@@ -25,7 +25,7 @@ Exceptions
 ----------
 
 .. autosummary::
-   :toctree: generated/
+   :toctree:
 
    DuplicateRegistrationError
    InvalidRegistrationError

--- a/skbio/sequence/_dna.py
+++ b/skbio/sequence/_dna.py
@@ -51,20 +51,6 @@ class DNA(GrammaredSequence, NucleotideMixin,
         certain that the sequence characters are valid. To store sequence data
         that is not IUPAC-compliant, use ``Sequence``.
 
-    Attributes
-    ----------
-    values
-    metadata
-    positional_metadata
-    interval_metadata
-    alphabet
-    gap_chars
-    default_gap_char
-    definite_chars
-    degenerate_chars
-    degenerate_map
-    complement_map
-
     See Also
     --------
     RNA

--- a/skbio/sequence/_grammared_sequence.py
+++ b/skbio/sequence/_grammared_sequence.py
@@ -101,19 +101,6 @@ class GrammaredSequence(Sequence, metaclass=GrammaredSequenceMeta):
     This class is intended to be inherited from to create grammared sequences
     with custom alphabets.
 
-    Attributes
-    ----------
-    values
-    metadata
-    interval_metadata
-    positional_metadata
-    alphabet
-    gap_chars
-    default_gap_char
-    definite_chars
-    degenerate_chars
-    degenerate_map
-
     Raises
     ------
     ValueError

--- a/skbio/sequence/_nucleotide_mixin.py
+++ b/skbio/sequence/_nucleotide_mixin.py
@@ -19,10 +19,6 @@ class NucleotideMixin(metaclass=ABCMeta):
 
     This is an abstract base class (ABC) that cannot be instantiated.
 
-    Attributes
-    ----------
-    complement_map
-
     See Also
     --------
     DNA

--- a/skbio/sequence/_protein.py
+++ b/skbio/sequence/_protein.py
@@ -50,20 +50,6 @@ class Protein(GrammaredSequence, metaclass=DisableSubclassingMeta):
         certain that the sequence characters are valid. To store sequence data
         that is not IUPAC-compliant, use ``Sequence``.
 
-    Attributes
-    ----------
-    values
-    metadata
-    interval_metadata
-    positional_metadata
-    alphabet
-    gap_chars
-    default_gap_char
-    stop_chars
-    definite_chars
-    degenerate_chars
-    degenerate_map
-
     See Also
     --------
     GrammaredSequence

--- a/skbio/sequence/_rna.py
+++ b/skbio/sequence/_rna.py
@@ -50,20 +50,6 @@ class RNA(GrammaredSequence, NucleotideMixin,
         certain that the sequence characters are valid. To store sequence data
         that is not IUPAC-compliant, use ``Sequence``.
 
-    Attributes
-    ----------
-    values
-    metadata
-    interval_metadata
-    positional_metadata
-    alphabet
-    gap_chars
-    default_gap_char
-    definite_chars
-    degenerate_chars
-    degenerate_map
-    complement_map
-
     See Also
     --------
     DNA

--- a/skbio/sequence/_sequence.py
+++ b/skbio/sequence/_sequence.py
@@ -64,14 +64,6 @@ class Sequence(MetadataMixin, PositionalMetadataMixin, IntervalMetadataMixin,
         and a ``True`` value will be stored in a boolean array in the
         positional metadata under the key.
 
-    Attributes
-    ----------
-    values
-    metadata
-    positional_metadata
-    interval_metadata
-    observed_chars
-
     See Also
     --------
     DNA

--- a/skbio/sequence/distance.py
+++ b/skbio/sequence/distance.py
@@ -14,7 +14,7 @@ Functions
 ---------
 
 .. autosummary::
-   :toctree: generated/
+   :toctree:
 
    hamming
    kmer_distance

--- a/skbio/stats/composition.py
+++ b/skbio/stats/composition.py
@@ -39,7 +39,7 @@ Functions
 ---------
 
 .. autosummary::
-   :toctree: generated/
+   :toctree:
 
    closure
    multiplicative_replacement

--- a/skbio/stats/distance/__init__.py
+++ b/skbio/stats/distance/__init__.py
@@ -40,7 +40,7 @@ Classes
 ^^^^^^^
 
 .. autosummary::
-   :toctree: generated/
+   :toctree:
 
    DissimilarityMatrix
    DistanceMatrix
@@ -49,7 +49,7 @@ Functions
 ^^^^^^^^^
 
 .. autosummary::
-   :toctree: generated/
+   :toctree:
 
    randdm
 
@@ -57,7 +57,7 @@ Exceptions
 ^^^^^^^^^^
 
 .. autosummary::
-   :toctree: generated/
+   :toctree:
 
    DissimilarityMatrixError
    DistanceMatrixError
@@ -150,7 +150,7 @@ Categorical Variable Stats
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. autosummary::
-   :toctree: generated/
+   :toctree:
 
    anosim
    permanova
@@ -160,7 +160,7 @@ Continuous Variable Stats
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. autosummary::
-   :toctree: generated/
+   :toctree:
 
    bioenv
 
@@ -168,7 +168,7 @@ Distance Matrix Comparisons
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. autosummary::
-   :toctree: generated/
+   :toctree:
 
    mantel
    pwmantel

--- a/skbio/stats/distance/_permdisp.py
+++ b/skbio/stats/distance/_permdisp.py
@@ -183,6 +183,7 @@ def permdisp(distance_matrix, grouping, column=None, test='median',
     grouping instead of a grouping vector. The following DataFrame's
     Grouping column specifies the same grouping as the vector we used in the
     previous examples.:
+
     >>> import pandas as pd
     >>> df = pd.DataFrame.from_dict(
     ...      {'Grouping': {'s1': 'G1', 's2': 'G1', 's3': 'G1', 's4': 'G2',

--- a/skbio/stats/evolve/__init__.py
+++ b/skbio/stats/evolve/__init__.py
@@ -16,7 +16,7 @@ Functions
 ^^^^^^^^^
 
 .. autosummary::
-   :toctree: generated/
+   :toctree:
 
    hommola_cospeciation
 

--- a/skbio/stats/gradient.py
+++ b/skbio/stats/gradient.py
@@ -13,7 +13,7 @@ Classes
 -------
 
 .. autosummary::
-   :toctree: generated/
+   :toctree:
 
    GradientANOVA
    AverageGradientANOVA

--- a/skbio/stats/ordination/__init__.py
+++ b/skbio/stats/ordination/__init__.py
@@ -8,32 +8,38 @@ This module contains several ordination methods, including Principal
 Coordinate Analysis, Correspondence Analysis, Redundancy Analysis and
 Canonical Correspondence Analysis.
 
-
-Functions
----------
+Ordination Functions
+--------------------
 
 .. autosummary::
-   :toctree: generated/
+   :toctree:
 
    ca
    pcoa
    pcoa_biplot
    cca
    rda
+
+Classes
+-------
+
+.. autosummary::
+   :toctree:
+
+   OrdinationResults
+
+Utility Functions
+-----------------
+
+.. autosummary::
+   :toctree:
+
    mean_and_std
    corr
    scale
    svd_rank
    e_matrix
    f_matrix
-
-Classes
--------
-
-.. autosummary::
-   :toctree: generated/
-
-   OrdinationResults
 
 Examples
 --------
@@ -83,6 +89,7 @@ observed at different sites.
 We can now perform canonical correspondence analysis. Matrix `X` contains a
 continuous variable (depth) and a categorical one (substrate type) encoded
 using a one-hot encoding.
+
 >>> from skbio.stats.ordination import cca
 
 We explicitly need to avoid perfect collinearity, so we'll drop one of the

--- a/skbio/stats/ordination/_ordination_results.py
+++ b/skbio/stats/ordination/_ordination_results.py
@@ -49,8 +49,6 @@ class OrdinationResults(SkbioObject):
     proportion_explained : pd.Series
         Proportion explained by each of the dimensions in the ordination space.
         The index corresponds to the ordination axis labels
-    png
-    svg
 
     See Also
     --------

--- a/skbio/stats/power.py
+++ b/skbio/stats/power.py
@@ -44,7 +44,7 @@ Functions
 ---------
 
 .. autosummary::
-    :toctree: generated/
+    :toctree:
 
     subsample_power
     subsample_paired_power

--- a/skbio/tree/_tree.py
+++ b/skbio/tree/_tree.py
@@ -66,15 +66,6 @@ class TreeNode(SkbioObject):
         Connect this node to a parent
     children : list of TreeNode or None
         Connect this node to existing children
-
-    Attributes
-    ----------
-    name
-    length
-    parent
-    children
-    id
-
     """
     default_write_format = 'newick'
     _exclude_from_copy = set(['parent', 'children', '_tip_cache',


### PR DESCRIPTION
We did a couple of things here:

- Got rid of numpydoc, we are now using napoleon (shipped with the core sphinx distro).
- Cleaned up the building process (specifically conf.py).
- Cleaned up the generated files to not live under `generated/generated`.
- Fix the copybutton on the code blocks to hide the prompt `>>>`.
- Update the class documentation formatting.

Co-authored with @ebolyen 