### PR TITLE
MAINT: fixes many deprecation warnings

### DIFF
--- a/skbio/alignment/_indexing.py
+++ b/skbio/alignment/_indexing.py
@@ -171,7 +171,10 @@ class TabularMSALoc(_Indexing):
             except TypeError:  # Unhashable type, no biggie
                 pass
         if index.has_duplicates:
-            duplicated_key = indexable in index.get_duplicates()
+            # for a given Index object index,
+            # index[index.duplicated()].unique() is pandas' recommended
+            # replacement for index.get_duplicates(), per the pandas 0.23 docs
+            duplicated_key = indexable in index[index.duplicated()].unique()
         return (not duplicated_key and
                 ((np.isscalar(indexable) and not partial_key) or complete_key))
 

--- a/skbio/alignment/_tabular_msa.py
+++ b/skbio/alignment/_tabular_msa.py
@@ -2259,7 +2259,7 @@ class TabularMSA(MetadataMixin, PositionalMetadataMixin, SkbioObject):
         if joined_seqs:
             joined_positional_metadata = pd.concat(
                 [self.positional_metadata, other.positional_metadata],
-                ignore_index=True, **concat_kwargs)
+                ignore_index=True, sort=True, **concat_kwargs)
 
             if not self.has_positional_metadata():
                 del self.positional_metadata

--- a/skbio/alignment/tests/test_tabular_msa.py
+++ b/skbio/alignment/tests/test_tabular_msa.py
@@ -2621,8 +2621,8 @@ class TestJoin(unittest.TestCase):
             TabularMSA([DNA('ACCA'),
                         DNA('G..G'),
                         DNA('C--C')],
-                       positional_metadata={'foo': [1, 2, 3, 4],
-                                            'bar': ['a', 'b', 'c', 'd']}))
+                       positional_metadata={'bar': ['a', 'b', 'c', 'd'],
+                                            'foo': [1, 2, 3, 4]}))
 
     def test_how_strict_failure_index_mismatch(self):
         msa1 = TabularMSA([DNA('AC'),
@@ -3873,17 +3873,19 @@ class TabularMSAReprDoctests:
     ...     # nested quotes
     ...     10: '"\''
     ... }
-    >>> positional_metadata = pd.DataFrame.from_items([
+    >>> positional_metadata = pd.DataFrame({
     ...     # str key, int list value
-    ...     ('foo', [1, 2, 3, 4]),
+    ...     'foo': [1, 2, 3, 4],
     ...     # float key, float list value
-    ...     (42.5, [2.5, 3.0, 4.2, -0.00001]),
+    ...     42.5: [2.5, 3.0, 4.2, -0.00001],
     ...     # int key, object list value
-    ...     (42, [[], 4, 5, {}]),
+    ...     42: [[], 4, 5, {}],
     ...     # truncated key (too long), bool list value
-    ...     ('abc' * 90, [True, False, False, True]),
+    ...     'abc' * 90: [True, False, False, True],
     ...     # None key
-    ...     (None, range(4))])
+    ...     None: range(4)})
+    >>> positional_metadata = positional_metadata.reindex(
+    ...     columns=['foo', 42.5, 42, 'abc' * 90, None])
     >>> TabularMSA([DNA('ACGT')], metadata=metadata,
     ...            positional_metadata=positional_metadata)
     TabularMSA[DNA]

--- a/skbio/diversity/__init__.py
+++ b/skbio/diversity/__init__.py
@@ -281,15 +281,15 @@ Create a matrix containing 6 samples (rows) and 7 OTUs (columns):
    let's define some before we visualize these results.
 
    >>> import pandas as pd
-   >>> sample_md = [
-   ...    ('A', ['gut', 's1']),
-   ...    ('B', ['skin', 's1']),
-   ...    ('C', ['tongue', 's1']),
-   ...    ('D', ['gut', 's2']),
-   ...    ('E', ['tongue', 's2']),
-   ...    ('F', ['skin', 's2'])]
-   >>> sample_md = pd.DataFrame.from_items(
-   ...     sample_md, columns=['body_site', 'subject'], orient='index')
+   >>> sample_md = pd.DataFrame([
+   ...    ['gut', 's1'],
+   ...    ['skin', 's1'],
+   ...    ['tongue', 's1'],
+   ...    ['gut', 's2'],
+   ...    ['tongue', 's2'],
+   ...    ['skin', 's2']],
+   ...    index=['A', 'B', 'C', 'D', 'E', 'F'],
+   ...    columns=['body_site', 'subject'])
    >>> sample_md
      body_site subject
    A       gut      s1

--- a/skbio/io/format/_base.py
+++ b/skbio/io/format/_base.py
@@ -27,7 +27,8 @@ def _decode_qual_to_phred(qual_str, variant=None, phred_offset=None):
          "scikit-bio. Please see the following scikit-bio issue to "
          "track progress on this:\n\t"
          "https://github.com/biocore/scikit-bio/issues/719"])
-    qual = np.fromstring(qual_str, dtype=np.uint8) - phred_offset
+    qual = np.frombuffer(qual_str.encode('ascii'),
+                         dtype=np.uint8) - phred_offset
 
     if np.any((qual > phred_range[1]) | (qual < phred_range[0])):
         raise ValueError("Decoded Phred score is out of range [%d, %d]."

--- a/skbio/io/format/tests/test_stockholm.py
+++ b/skbio/io/format/tests/test_stockholm.py
@@ -800,18 +800,18 @@ class TestStockholmWriter(unittest.TestCase):
             _tabular_msa_to_stockholm(msa, fh)
 
     def test_unoriginal_gr_feature_names_error(self):
-        pos_metadata_dataframe = pd.DataFrame.from_items([('AC',
-                                                           list('GAGCAAGCCACTA'
-                                                                'GA')),
-                                                          ('SS',
-                                                           list('TCCTTGAACTACC'
-                                                                'CG')),
-                                                          ('AS',
-                                                           list('TCAGCTCTGCAGC'
-                                                                'GT')),
-                                                          ('SS',
-                                                           list('GTCAGGCGCTCGG'
-                                                                'TG'))])
+
+        pos_metadata_dataframe = pd.DataFrame(
+            [
+                list('GAGCAAGCCACTAGA'),
+                list('TCCTTGAACTACCCG'),
+                list('TCAGCTCTGCAGCGT'),
+                list('GTCAGGCGCTCGGTG')
+            ],
+            index=['AC', 'SS', 'AS', 'AC']
+
+        ).T
+
         msa = TabularMSA([DNA('CGTCAATCTCGAACT',
                           positional_metadata=pos_metadata_dataframe)],
                          index=['seq1'])
@@ -822,18 +822,17 @@ class TestStockholmWriter(unittest.TestCase):
             _tabular_msa_to_stockholm(msa, fh)
 
     def test_unoriginal_gc_feature_names_error(self):
-        pos_metadata_dataframe = pd.DataFrame.from_items([('AC',
-                                                           list('GAGCAAGCCACTA'
-                                                                'GA')),
-                                                          ('SS',
-                                                           list('TCCTTGAACTACC'
-                                                                'CG')),
-                                                          ('SS',
-                                                           list('TCAGCTCTGCAGC'
-                                                                'GT')),
-                                                          ('AC',
-                                                           list('GTCAGGCGCTCGG'
-                                                                'TG'))])
+        pos_metadata_dataframe = pd.DataFrame(
+            [
+                list('GAGCAAGCCACTAGA'),
+                list('TCCTTGAACTACCCG'),
+                list('TCAGCTCTGCAGCGT'),
+                list('GTCAGGCGCTCGGTG')
+            ],
+            index=['AC', 'SS', 'SS', 'AC']
+
+        ).T
+
         msa = TabularMSA([DNA('CCCCTGCTTTCGTAG')],
                          positional_metadata=pos_metadata_dataframe)
         with self.assertRaisesRegex(StockholmFormatError,

--- a/skbio/sequence/_grammared_sequence.py
+++ b/skbio/sequence/_grammared_sequence.py
@@ -193,8 +193,9 @@ class GrammaredSequence(Sequence, metaclass=GrammaredSequenceMeta):
         # TODO These masks could be defined (as literals) on each concrete
         # object. For now, memoize!
         if cls.__validation_mask is None:
+            as_bytes = ''.join(cls.alphabet).encode('ascii')
             cls.__validation_mask = np.invert(np.bincount(
-                np.fromstring(''.join(cls.alphabet), dtype=np.uint8),
+                np.frombuffer(as_bytes, dtype=np.uint8),
                 minlength=cls._number_of_extended_ascii_codes).astype(bool))
         return cls.__validation_mask
 

--- a/skbio/sequence/_sequence.py
+++ b/skbio/sequence/_sequence.py
@@ -569,7 +569,7 @@ fuzzy=[(True, False)], metadata={'gene': 'foo'})
             if not seq.has_positional_metadata():
                 del seq.positional_metadata
 
-        pm = pd.concat(pm_data, join=how, ignore_index=True)
+        pm = pd.concat(pm_data, join=how, ignore_index=True, sort=True)
         bytes_ = np.concatenate(seq_data)
 
         im = IntervalMetadata.concat(i.interval_metadata for i in seqs)
@@ -628,11 +628,11 @@ fuzzy=[(True, False)], metadata={'gene': 'foo'})
             # Encode as ascii to raise UnicodeEncodeError if necessary.
             if isinstance(sequence, str):
                 sequence = sequence.encode("ascii")
-            s = np.fromstring(sequence, dtype=np.uint8)
+            s = np.frombuffer(sequence, dtype=np.uint8)
 
             # There are two possibilities (to our knowledge) at this point:
             # Either the sequence we were given was something string-like,
-            # (else it would not have made it past fromstring), or it was a
+            # (else it would not have made it past frombuffer), or it was a
             # numpy scalar, and so our length must be 1.
             if isinstance(sequence, np.generic) and len(s) != 1:
                 raise TypeError("Can cannot create a sequence with %r" %
@@ -922,7 +922,8 @@ fuzzy=[(True, False)], metadata={'gene': 'foo'})
                     if self.has_positional_metadata():
                         pos_md_slices = list(_slices_from_iter(
                                              self.positional_metadata, index))
-                        positional_metadata = pd.concat(pos_md_slices)
+                        positional_metadata = pd.concat(pos_md_slices,
+                                                        sort=True)
 
                     metadata = None
                     if self.has_metadata():

--- a/skbio/sequence/tests/test_nucleotide_sequences.py
+++ b/skbio/sequence/tests/test_nucleotide_sequences.py
@@ -26,8 +26,8 @@ class TestNucleotideSequence(unittest.TestCase):
     def setUp(self):
         self.sequence_kinds = frozenset([
             str,
-            lambda s: np.fromstring(s, dtype='|S1'),
-            lambda s: np.fromstring(s, dtype=np.uint8)])
+            lambda s: np.frombuffer(s.encode('ascii'), dtype='|S1'),
+            lambda s: np.frombuffer(s.encode('ascii'), dtype=np.uint8)])
 
         dna_str = 'ACGTMRWSYKVHDBN.-'
         dna_comp_str = 'TGCAKYWSRMBDHVN.-'

--- a/skbio/sequence/tests/test_sequence.py
+++ b/skbio/sequence/tests/test_sequence.py
@@ -69,8 +69,9 @@ class TestSequenceIntervalMetadata(TestCase, ReallyEqualMixin,
 class TestSequenceBase(TestCase):
     def setUp(self):
         self.sequence_kinds = frozenset([
-            str, Sequence, lambda s: np.fromstring(s, dtype='|S1'),
-            lambda s: np.fromstring(s, dtype=np.uint8)])
+            str, Sequence,
+            lambda s: np.frombuffer(s.encode('ascii'), dtype='|S1'),
+            lambda s: np.frombuffer(s.encode('ascii'), dtype=np.uint8)])
 
 
 class TestSequence(TestSequenceBase, ReallyEqualMixin):
@@ -272,7 +273,7 @@ class TestSequence(TestSequenceBase, ReallyEqualMixin):
         for s in (b'',  # bytes
                   '',  # unicode
                   np.array('', dtype='c'),  # char vector
-                  np.fromstring('', dtype=np.uint8),  # byte vec
+                  np.frombuffer(b'', dtype=np.uint8),  # byte vec
                   Sequence('')):  # another Sequence object
             seq = Sequence(s)
 
@@ -296,7 +297,7 @@ class TestSequence(TestSequenceBase, ReallyEqualMixin):
         for s in (b'A',
                   'A',
                   np.array('A', dtype='c'),
-                  np.fromstring('A', dtype=np.uint8),
+                  np.frombuffer(b'A', dtype=np.uint8),
                   Sequence('A')):
             seq = Sequence(s)
 
@@ -319,7 +320,7 @@ class TestSequence(TestSequenceBase, ReallyEqualMixin):
         for s in (b'.ABC\t123  xyz-',
                   '.ABC\t123  xyz-',
                   np.array('.ABC\t123  xyz-', dtype='c'),
-                  np.fromstring('.ABC\t123  xyz-', dtype=np.uint8),
+                  np.frombuffer(b'.ABC\t123  xyz-', dtype=np.uint8),
                   Sequence('.ABC\t123  xyz-')):
             seq = Sequence(s)
 
@@ -460,23 +461,23 @@ class TestSequence(TestSequenceBase, ReallyEqualMixin):
             Sequence(np.array([1, {}, ()]))
 
         # invalid input type (non-numpy.ndarray input)
-        with self.assertRaisesRegex(TypeError, 'tuple'):
+        with self.assertRaisesRegex(AttributeError, 'tuple'):
             Sequence(('a', 'b', 'c'))
-        with self.assertRaisesRegex(TypeError, 'list'):
+        with self.assertRaisesRegex(AttributeError, 'list'):
             Sequence(['a', 'b', 'c'])
-        with self.assertRaisesRegex(TypeError, 'set'):
+        with self.assertRaisesRegex(AttributeError, 'set'):
             Sequence({'a', 'b', 'c'})
-        with self.assertRaisesRegex(TypeError, 'dict'):
+        with self.assertRaisesRegex(AttributeError, 'dict'):
             Sequence({'a': 42, 'b': 43, 'c': 44})
-        with self.assertRaisesRegex(TypeError, 'int'):
+        with self.assertRaisesRegex(AttributeError, 'int'):
             Sequence(42)
-        with self.assertRaisesRegex(TypeError, 'float'):
+        with self.assertRaisesRegex(AttributeError, 'float'):
             Sequence(4.2)
         with self.assertRaisesRegex(TypeError, 'int64'):
             Sequence(np.int_(50))
         with self.assertRaisesRegex(TypeError, 'float64'):
             Sequence(np.float_(50))
-        with self.assertRaisesRegex(TypeError, 'Foo'):
+        with self.assertRaisesRegex(AttributeError, 'Foo'):
             class Foo:
                 pass
             Sequence(Foo())
@@ -1125,10 +1126,10 @@ class TestSequence(TestSequenceBase, ReallyEqualMixin):
 
     def test_count(self):
         def construct_char_array(s):
-            return np.fromstring(s, dtype='|S1')
+            return np.frombuffer(s.encode('ascii'), dtype='|S1')
 
         def construct_uint8_array(s):
-            return np.fromstring(s, dtype=np.uint8)
+            return np.frombuffer(s.encode('ascii'), dtype=np.uint8)
 
         seq = Sequence("1234567899876555")
         tested = 0
@@ -1502,7 +1503,7 @@ class TestSequence(TestSequenceBase, ReallyEqualMixin):
         self.assertEqual(seq.frequencies(chars=chars, relative=True),
                          {'z': 5/11})
 
-        chars = np.fromstring('z', dtype='|S1')[0]
+        chars = np.frombuffer('z'.encode('ascii'), dtype='|S1')[0]
         self.assertEqual(seq.frequencies(chars=chars), {b'z': 5})
         self.assertEqual(seq.frequencies(chars=chars, relative=True),
                          {b'z': 5/11})
@@ -1519,8 +1520,8 @@ class TestSequence(TestSequenceBase, ReallyEqualMixin):
                          {'x': 0.0, 'z': 5/11})
 
         chars = {
-            np.fromstring('x', dtype='|S1')[0],
-            np.fromstring('z', dtype='|S1')[0]
+            np.frombuffer('x'.encode('ascii'), dtype='|S1')[0],
+            np.frombuffer('z'.encode('ascii'), dtype='|S1')[0]
         }
         self.assertEqual(seq.frequencies(chars=chars), {b'x': 0, b'z': 5})
         self.assertEqual(seq.frequencies(chars=chars, relative=True),
@@ -2335,8 +2336,9 @@ class TestDistance(TestSequenceBase):
             return -42.0
 
         sequence_kinds = frozenset([
-            str, SequenceSubclass, lambda s: np.fromstring(s, dtype='|S1'),
-            lambda s: np.fromstring(s, dtype=np.uint8)])
+            str, SequenceSubclass,
+            lambda s: np.frombuffer(s.encode('ascii'), dtype='|S1'),
+            lambda s: np.frombuffer(s.encode('ascii'), dtype=np.uint8)])
 
         for constructor in sequence_kinds:
             seq1 = SequenceSubclass("abcdef")
@@ -2363,7 +2365,7 @@ class TestDistance(TestSequenceBase):
             DNA("ACGT").distance("WXYZ")
 
     def test_munging_invalid_type_to_self_type(self):
-        with self.assertRaises(TypeError):
+        with self.assertRaises(AttributeError):
             Sequence("ACGT").distance(42)
 
     def test_return_type_coercion(self):
@@ -2667,17 +2669,19 @@ class SequenceReprDoctests:
     ...     # nested quotes
     ...     10: '"\''
     ... }
-    >>> positional_metadata = pd.DataFrame.from_items([
+    >>> positional_metadata = pd.DataFrame({
     ...     # str key, int list value
-    ...     ('foo', [1, 2, 3, 4]),
+    ...     'foo': [1, 2, 3, 4],
     ...     # float key, float list value
-    ...     (42.5, [2.5, 3.0, 4.2, -0.00001]),
+    ...     42.5: [2.5, 3.0, 4.2, -0.00001],
     ...     # int key, object list value
-    ...     (42, [[], 4, 5, {}]),
+    ...     42: [[], 4, 5, {}],
     ...     # truncated key (too long), bool list value
-    ...     ('abc' * 90, [True, False, False, True]),
+    ...     'abc' * 90: [True, False, False, True],
     ...     # None key
-    ...     (None, range(4))])
+    ...     None: range(4)})
+    >>> positional_metadata = positional_metadata.reindex(
+    ...     columns=['foo', 42.5, 42, 'abc' * 90, None])
     >>> interval_metadata = IntervalMetadata(4)
     >>> _ = interval_metadata.add([(0, 2), (1, 3)],
     ...                           [(False, True), (False, False)],

--- a/skbio/stats/distance/_mantel.py
+++ b/skbio/stats/distance/_mantel.py
@@ -10,7 +10,7 @@ from itertools import combinations
 
 import numpy as np
 import pandas as pd
-import scipy.misc
+import scipy.special
 from scipy.stats import pearsonr, spearmanr
 
 from skbio.stats.distance import DistanceMatrix
@@ -398,7 +398,7 @@ def pwmantel(dms, labels=None, method='pearson', permutations=999,
         if len(set(labels)) != len(labels):
             raise ValueError("Labels must be unique.")
 
-    num_combs = scipy.misc.comb(num_dms, 2, exact=True)
+    num_combs = scipy.special.comb(num_dms, 2, exact=True)
     results_dtype = [('dm1', object), ('dm2', object), ('statistic', float),
                      ('p-value', float), ('n', int), ('method', object),
                      ('permutations', int), ('alternative', object)]

--- a/skbio/stats/ordination/_canonical_correspondence_analysis.py
+++ b/skbio/stats/ordination/_canonical_correspondence_analysis.py
@@ -100,8 +100,8 @@ def cca(y, x, scaling=1):
        Ecology. Elsevier, Amsterdam.
 
     """
-    Y = y.as_matrix()
-    X = x.as_matrix()
+    Y = y.values
+    X = x.values
 
     # Perform parameter sanity checks
     if X.shape[0] != Y.shape[0]:

--- a/skbio/stats/ordination/_redundancy_analysis.py
+++ b/skbio/stats/ordination/_redundancy_analysis.py
@@ -89,8 +89,8 @@ def rda(y, x, scale_Y=False, scaling=1):
        Ecology. Elsevier, Amsterdam.
 
     """
-    Y = y.as_matrix()
-    X = x.as_matrix()
+    Y = y.values
+    X = x.values
 
     n, p = y.shape
     n_, m = x.shape


### PR DESCRIPTION
- Use scipy.special.comb instead of scipy.misc.comb
- fromstring -> frombuffer + ascii encode
- .as_matrix -> .values
- more dict order sensitivity
- avoid deprecation on pd.concat by using sort=True
- replace TabularMSA use of Index.get_duplicates
- removing pandas from_list everywhere