### PR TITLE
BUG: fix ownership for byte/string literals

### DIFF
--- a/skbio/sequence/_sequence.py
+++ b/skbio/sequence/_sequence.py
@@ -630,7 +630,7 @@ fuzzy=[(True, False)], metadata={'gene': 'foo'})
                                 type(sequence).__name__)
 
             sequence = s
-            self._owns_bytes = True
+            self._owns_bytes = False
 
             self._set_bytes(sequence)
 


### PR DESCRIPTION
Please complete the following checklist:

* [x] I have read the guidelines in [CONTRIBUTING.md](https://github.com/biocore/scikit-bio/blob/master/CONTRIBUTING.md).

* [ ] I have documented all public-facing changes in [CHANGELOG.md](https://github.com/biocore/scikit-bio/blob/master/CHANGELOG.md).

* [ ] **This pull request includes code, documentation, or other content derived from external source(s).** If this is the case, ensure the external source's license is compatible with scikit-bio's [license](https://github.com/biocore/scikit-bio/blob/master/COPYING.txt). Include the license in the `licenses` directory and add a comment in the code giving proper attribution. Ensure any other requirements set forth by the license and/or author are satisfied. **It is your responsibility to disclose code, documentation, or other content derived from external source(s).** If you have questions about whether something can be included in the project or how to give proper attribution, include those questions in your pull request and a reviewer will assist you.

* [X] **This pull request does not include code, documentation, or other content derived from external source(s).**

**Note:** [REVIEWING.md](https://github.com/biocore/scikit-bio/blob/master/REVIEWING.md) may also be helpful to see some of the things code reviewers will be verifying when reviewing your pull request.


---

fixes #1648 

Turns out the issue was embarrassingly simple: since numpy does not own the backing bytes of string/byte literals, neither do we. This change corrects that in the constructor.

There are very really no situations where skbio will assume byte ownership except for one branch that I don't remember the cause of. We may want to think about either removing these semantics entirely, _or_ add an API to indicate the skbio may mutate the buffer (passing ownership of a numpy array you've created yourself onwards to skbio, assuming the ndarray flag is compatible).
