### PR TITLE
Within and between distance API methods for the DissimilarityMatrix object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@
 
 * Added option to return a capture group compiled regex pattern to any class inheriting ``GrammaredSequence`` through the ``to_regex`` method. ([#1431](https://github.com/biocore/scikit-bio/issues/1431))
 
+* Added `Dissimilarity.within` and `.between` to obtain the respective distances and express them as a `DataFrame`.
+
 ### Backward-incompatible changes [stable]
 
 ### Backward-incompatible changes [experimental]

--- a/skbio/stats/distance/_base.py
+++ b/skbio/stats/distance/_base.py
@@ -366,6 +366,106 @@ class DissimilarityMatrix(SkbioObject):
         filtered_data = self._data[idxs][:, idxs]
         return self.__class__(filtered_data, ids)
 
+    @experimental(as_of="0.5.4")
+    def within(self, ids):
+        """Obtain all the distances among the set of IDs
+
+        Parameters
+        ----------
+        ids : Iterable of str
+            The IDs to obtain distances for. All pairs of distances are
+            returned such that, if provided ['a', 'b', 'c'], the distances
+            for [('a', 'a'), ('a', 'b'), ('a', 'c'), ('b', 'a'), ('b', 'b'),
+            ('b', 'c'), ('c', 'a'), ('c', 'b'), ('c', 'c')] are gathered.
+
+        Returns
+        -------
+        pd.DataFrame
+            (i, j, value) representing the source ID ("i"), the target ID ("j")
+            and the distance ("value").
+
+        Raises
+        ------
+        MissingIDError
+            If an ID(s) specified is not in the dissimilarity matrix.
+
+        Notes
+        -----
+        Order of the return items is stable, meaning that requesting IDs
+        ['a', 'b'] is equivalent to ['b', 'a'].
+
+        Example
+        -------
+        >>> from skbio.stats.distance import DissimilarityMatrix
+        >>> dm = DissimilarityMatrix([[0, 1, 2, 3, 4], [1, 0, 1, 2, 3],
+        ...                           [2, 1, 0, 1, 2], [3, 2, 1, 0, 1],
+        ...                           [4, 3, 2, 1, 0]],
+        ...                          ['A', 'B', 'C', 'D', 'E'])
+        >>> dm.within(['A', 'B', 'C'])
+             i    j    value
+        0    A    A      0.0
+        1    A    B      1.0
+        2    A    C      2.0
+        3    B    A      1.0
+        4    B    B      0.0
+        5    B    C      1.0
+        6    C    A      2.0
+        7    C    B      1.0
+        8    C    C      0.0
+        """
+        pass
+
+    @experimental(as_of="0.5.4")
+    def between(self, from_, to_, allow_overlap=False):
+        """Obtain all the distances among the set of IDs
+
+        Parameters
+        ----------
+        from_ : Iterable of str
+            The IDs to obtain distances from. Distances from all pairs of IDs
+            in from and to will be obtained.
+        to_ : Iterable of str
+            The IDs to obtain distances to. Distances from all pairs of IDs
+            in to and from will be obtained.
+
+        allow_overlap : bool, optional
+            If True, allow overlap in the IDs of from_ and to_ (which would in
+            effect be collecting the within distances). Default is False.
+
+        Returns
+        -------
+        pd.DataFrame
+            (i, j, value) representing the source ID ("i"), the target ID ("j")
+            and the distance ("value").
+
+        Raises
+        ------
+        MissingIDError
+            If an ID(s) specified is not in the dissimilarity matrix.
+
+        Notes
+        -----
+        Order of the return items is stable, meaning that requesting IDs
+        ['a', 'b'] is equivalent to ['b', 'a'].
+
+        Example
+        -------
+        >>> from skbio.stats.distance import DissimilarityMatrix
+        >>> dm = DissimilarityMatrix([[0, 1, 2, 3, 4], [1, 0, 1, 2, 3],
+        ...                           [2, 1, 0, 1, 2], [3, 2, 1, 0, 1],
+        ...                           [4, 3, 2, 1, 0]],
+        ...                          ['A', 'B', 'C', 'D', 'E'])
+        >>> dm.between(['A', 'B'], ['C', 'D', 'E'])
+             i    j    value
+        0    A    C      2.0
+        1    A    D      3.0
+        2    A    E      4.0
+        3    B    C      1.0
+        4    B    D      2.0
+        5    B    E      3.0
+        """
+        pass
+
     @experimental(as_of="0.4.0")
     def plot(self, cmap=None, title=""):
         """Creates a heatmap of the dissimilarity matrix

--- a/skbio/stats/distance/_base.py
+++ b/skbio/stats/distance/_base.py
@@ -428,16 +428,16 @@ class DissimilarityMatrix(SkbioObject):
         ...                           [4, 3, 2, 1, 0]],
         ...                          ['A', 'B', 'C', 'D', 'E'])
         >>> dm.within(['A', 'B', 'C'])
-             i    j    value
-        0    A    A      0.0
-        1    A    B      1.0
-        2    A    C      2.0
-        3    B    A      1.0
-        4    B    B      0.0
-        5    B    C      1.0
-        6    C    A      2.0
-        7    C    B      1.0
-        8    C    C      0.0
+           i  j  value
+        0  A  A    0.0
+        1  A  B    1.0
+        2  A  C    2.0
+        3  B  A    1.0
+        4  B  B    0.0
+        5  B  C    1.0
+        6  C  A    2.0
+        7  C  B    1.0
+        8  C  C    0.0
         """
         ids = set(ids)
         n_ids = len(ids)
@@ -508,13 +508,13 @@ class DissimilarityMatrix(SkbioObject):
         ...                           [4, 3, 2, 1, 0]],
         ...                          ['A', 'B', 'C', 'D', 'E'])
         >>> dm.between(['A', 'B'], ['C', 'D', 'E'])
-             i    j    value
-        0    A    C      2.0
-        1    A    D      3.0
-        2    A    E      4.0
-        3    B    C      1.0
-        4    B    D      2.0
-        5    B    E      3.0
+           i  j  value
+        0  A  C    2.0
+        1  A  D    3.0
+        2  A  E    4.0
+        3  B  C    1.0
+        4  B  D    2.0
+        5  B  E    3.0
         """
         from_ = set(from_)
         to_ = set(to_)

--- a/skbio/stats/distance/_base.py
+++ b/skbio/stats/distance/_base.py
@@ -452,7 +452,7 @@ class DissimilarityMatrix(SkbioObject):
             in to and from will be obtained.
 
         allow_overlap : bool, optional
-            If True, allow overlap in the IDs of from_ and to_ (which would in
+            If True, allow overlap in the IDs of from and to (which would in
             effect be collecting the within distances). Default is False.
 
         Returns

--- a/skbio/stats/distance/_base.py
+++ b/skbio/stats/distance/_base.py
@@ -498,7 +498,7 @@ class DissimilarityMatrix(SkbioObject):
                                  "found." % not_present.pop())
 
         overlapping = from_ & to_
-        if not allow_overlap and (from_ & to_):
+        if not allow_overlap and overlapping:
             raise KeyError("At least one ID overlaps in from_ and to_ "
                            "(e.g., '%s'). This constraint can removed with "
                            "allow_overlap=True." % overlapping.pop())

--- a/skbio/stats/distance/_base.py
+++ b/skbio/stats/distance/_base.py
@@ -384,7 +384,7 @@ class DissimilarityMatrix(SkbioObject):
         id_order = sorted((self._id_index[i] for i in ids))
         return np.array(id_order, dtype=int)
 
-    @experimental(as_of="0.5.4")
+    @experimental(as_of="0.5.5")
     def within(self, ids):
         """Obtain all the distances among the set of IDs
 
@@ -442,9 +442,9 @@ class DissimilarityMatrix(SkbioObject):
         i_order = self._stable_order(ids)
         return self._subset_to_dataframe(i_order, i_order)
 
-    @experimental(as_of="0.5.4")
+    @experimental(as_of="0.5.5")
     def between(self, from_, to_, allow_overlap=False):
-        """Obtain all the distances among the set of IDs
+        """Obtain the distances between the two groups of IDs
 
         Parameters
         ----------

--- a/skbio/stats/distance/tests/test_base.py
+++ b/skbio/stats/distance/tests/test_base.py
@@ -91,24 +91,24 @@ class DissimilarityMatrixTests(DissimilarityMatrixTestData):
             self.dm_3x3.within(['x', 'a'])
 
     def test_between(self):
-        exp = pd.DataFrame([['b', 'a', 5],
-                            ['b', 'c', 6],
-                            ['b', 'e', 8],
-                            ['d', 'a', 4],
-                            ['d', 'c', 6],
-                            ['d', 'e', 7]],
+        exp = pd.DataFrame([['b', 'a', 5.],
+                            ['b', 'c', 6.],
+                            ['b', 'e', 8.],
+                            ['d', 'a', 4.],
+                            ['d', 'c', 6.],
+                            ['d', 'e', 7.]],
                            columns=['i', 'j', 'value'])
 
         obs = self.dm_5x5.between(['b', 'd'], ['a', 'c', 'e'])
         pdt.assert_frame_equal(obs, exp)
 
     def test_between_order_stability(self):
-        exp = pd.DataFrame([['b', 'a', 5],
-                            ['b', 'c', 6],
-                            ['b', 'e', 8],
-                            ['d', 'a', 4],
-                            ['d', 'c', 6],
-                            ['d', 'e', 7]],
+        exp = pd.DataFrame([['b', 'a', 5.],
+                            ['b', 'c', 6.],
+                            ['b', 'e', 8.],
+                            ['d', 'a', 4.],
+                            ['d', 'c', 6.],
+                            ['d', 'e', 7.]],
                            columns=['i', 'j', 'value'])
 
         # varying the order of the "i" values, result remains consistent
@@ -122,12 +122,12 @@ class DissimilarityMatrixTests(DissimilarityMatrixTestData):
         pdt.assert_frame_equal(obs, exp)
 
     def test_between_overlap(self):
-        exp = pd.DataFrame([['b', 'a', 5],
-                            ['b', 'c', 6],
-                            ['b', 'e', 8],
-                            ['d', 'a', 4],
-                            ['d', 'c', 6],
-                            ['d', 'e', 7]],
+        exp = pd.DataFrame([['b', 'a', 5.],
+                            ['b', 'd', 7.],
+                            ['b', 'e', 8.],
+                            ['d', 'a', 4.],
+                            ['d', 'd', 0.],
+                            ['d', 'e', 7.]],
                            columns=['i', 'j', 'value'])
 
         # 'd' in i and j overlap
@@ -155,7 +155,10 @@ class DissimilarityMatrixTests(DissimilarityMatrixTestData):
                np.array([1, 3, 4], dtype=int),
                ('b', 'd', 'e'))
         obs = self.dm_5x5._stable_order(['d', 'e', 'b'])
-        self.assertEqual(obs, exp)
+
+        self.assertEqual(obs[0], exp[0])
+        self.assertEqual(obs[2], exp[2])
+        npt.assert_equal(obs[1], exp[1])
 
     def test_init_from_dm(self):
         ids = ['foo', 'bar', 'baz']

--- a/skbio/stats/distance/tests/test_base.py
+++ b/skbio/stats/distance/tests/test_base.py
@@ -34,6 +34,11 @@ class DissimilarityMatrixTestData(TestCase):
         self.dm_2x2_asym_data = [[0.0, 1.0], [-2.0, 0.0]]
         self.dm_3x3_data = [[0.0, 0.01, 4.2], [0.01, 0.0, 12.0],
                             [4.2, 12.0, 0.0]]
+        self.dm_5x5_data = [[0, 1, 2, 3, 4],
+                            [5, 0, 6, 7, 8],
+                            [9, 1, 0, 2, 3],
+                            [4, 5, 6, 0, 7],
+                            [8, 9, 1, 2, 0]]
 
 
 class DissimilarityMatrixTests(DissimilarityMatrixTestData):
@@ -45,6 +50,7 @@ class DissimilarityMatrixTests(DissimilarityMatrixTestData):
         self.dm_2x2_asym = DissimilarityMatrix(self.dm_2x2_asym_data,
                                                ['a', 'b'])
         self.dm_3x3 = DissimilarityMatrix(self.dm_3x3_data, ['a', 'b', 'c'])
+        self.dm_5x5 = DissimilarityMatrix(self.dm_5x5_data, list('abcde'))
 
         self.dms = [self.dm_1x1, self.dm_2x2, self.dm_2x2_asym, self.dm_3x3]
         self.dm_shapes = [(1, 1), (2, 2), (2, 2), (3, 3)]
@@ -56,6 +62,92 @@ class DissimilarityMatrixTests(DissimilarityMatrixTestData):
                                    np.array(self.dm_2x2_data),
                                    np.array(self.dm_2x2_asym_data),
                                    np.array(self.dm_3x3_data)]
+
+    def test_within(self):
+        exp = pd.DataFrame([['a', 'a', 0.0],
+                            ['a', 'c', 4.2],
+                            ['c', 'a', 4.2],
+                            ['c', 'c', 0.0]],
+                           columns=['i', 'j', 'value'])
+        obs = self.dm_3x3.within(['a', 'c'])
+        pdt.assert_frame_equal(obs, exp)
+
+    def test_within_order_stability(self):
+        exp = pd.DataFrame([['a', 'a', 0.0],
+                            ['a', 'c', 4.2],
+                            ['c', 'a', 4.2],
+                            ['c', 'c', 0.0]],
+                           columns=['i', 'j', 'value'])
+
+        # NOTE: order was changed from ['a', 'c'] to ['c', 'a']
+        # but the output order in exp is consistent with
+        # test_within
+        obs = self.dm_3x3.within(['c', 'a'])
+        pdt.assert_frame_equal(obs, exp)
+
+    def test_within_missing_id(self):
+        with self.assertRaisesRegex(MissingIDError, "not found."):
+            self.dm_3x3.within(['x', 'a'])
+
+    def test_between(self):
+        exp = pd.DataFrame([['b', 'a', 5],
+                            ['b', 'c', 6],
+                            ['b', 'e', 8],
+                            ['d', 'a', 4],
+                            ['d', 'c', 6],
+                            ['d', 'e', 7]],
+                           columns=['i', 'j', 'value'])
+
+        obs = self.dm_5x5.between(['b', 'd'], ['a', 'c', 'e'])
+        pdt.assert_frame_equal(obs, exp)
+
+    def test_between_order_stability(self):
+        exp = pd.DataFrame([['b', 'a', 5],
+                            ['b', 'c', 6],
+                            ['b', 'e', 8],
+                            ['d', 'a', 4],
+                            ['d', 'c', 6],
+                            ['d', 'e', 7]],
+                           columns=['i', 'j', 'value'])
+
+        # varying the order of the "i" values, result remains consistent
+        # with the test_between result
+        obs = self.dm_5x5.between(['d', 'b'], ['a', 'c', 'e'])
+        pdt.assert_frame_equal(obs, exp)
+
+        # varying the order of the "j" values, result remains consistent
+        # with the test_between result
+        obs = self.dm_5x5.between(['b', 'd'], ['a', 'e', 'c'])
+        pdt.assert_frame_equal(obs, exp)
+
+    def test_between_overlap(self):
+        exp = pd.DataFrame([['b', 'a', 5],
+                            ['b', 'c', 6],
+                            ['b', 'e', 8],
+                            ['d', 'a', 4],
+                            ['d', 'c', 6],
+                            ['d', 'e', 7]],
+                           columns=['i', 'j', 'value'])
+
+        # 'd' in i and j overlap
+        with self.assertRaisesRegex(KeyError, ("overlap. This constraint can "
+                                               "removed with "
+                                               "allow_overlap=True.")):
+            self.dm_5x5.between(['b', 'd'], ['a', 'd', 'e'])
+
+        obs = self.dm_5x5.between(['b', 'd'], ['a', 'd', 'e'],
+                                  allow_overlap=True)
+        pdt.assert_frame_equal(obs, exp)
+
+    def test_between_missing_id(self):
+        with self.assertRaisesRegex(MissingIDError, "not found."):
+            self.dm_3x3.between(['x', 'a'], ['a', 'b', 'c'])
+
+        with self.assertRaisesRegex(MissingIDError, "not found."):
+            self.dm_3x3.between(['a', 'b'], ['a', 'x', 'c'])
+
+        with self.assertRaisesRegex(MissingIDError, "not found."):
+            self.dm_3x3.between(['a', 'y'], ['a', 'x', 'c'])
 
     def test_init_from_dm(self):
         ids = ['foo', 'bar', 'baz']

--- a/skbio/stats/distance/tests/test_base.py
+++ b/skbio/stats/distance/tests/test_base.py
@@ -123,6 +123,11 @@ class DissimilarityMatrixTests(DissimilarityMatrixTestData):
         obs = self.dm_5x5.between(['b', 'd'], ['a', 'e', 'c'])
         pdt.assert_frame_equal(obs, exp)
 
+        # varying the order of the "i" and "j" values, result remains
+        # consistent with the test_between result
+        obs = self.dm_5x5.between(['d', 'b'], ['a', 'e', 'c'])
+        pdt.assert_frame_equal(obs, exp)
+
     def test_between_overlap(self):
         exp = pd.DataFrame([['b', 'a', 5.],
                             ['b', 'd', 7.],
@@ -167,8 +172,20 @@ class DissimilarityMatrixTests(DissimilarityMatrixTestData):
                             ['d', 'e', 7.]],
                            columns=['i', 'j', 'value'])
 
-        obs = self.dm_5x5._subset_to_dataframe([1, 3], [0, 3, 4])
+        obs = self.dm_5x5._subset_to_dataframe(['b', 'd'], ['a', 'd', 'e'])
         pdt.assert_frame_equal(obs, exp)
+
+        # and the empty edge cases
+        exp = pd.DataFrame([],
+                           columns=['i', 'j', 'value'],
+                           index=pd.RangeIndex(start=0, stop=0))
+
+        obs = self.dm_5x5._subset_to_dataframe([], ['a', 'd', 'e'])
+        pdt.assert_frame_equal(obs, exp, check_dtype=False)
+        obs = self.dm_5x5._subset_to_dataframe(['b', 'd'], [])
+        pdt.assert_frame_equal(obs, exp, check_dtype=False)
+        obs = self.dm_5x5._subset_to_dataframe([], [])
+        pdt.assert_frame_equal(obs, exp, check_dtype=False)
 
     def test_init_from_dm(self):
         ids = ['foo', 'bar', 'baz']

--- a/skbio/stats/distance/tests/test_base.py
+++ b/skbio/stats/distance/tests/test_base.py
@@ -13,6 +13,7 @@ import matplotlib as mpl
 import numpy as np
 import numpy.testing as npt
 import pandas as pd
+import pandas.testing as pdt
 import scipy.spatial.distance
 from IPython.core.display import Image, SVG
 
@@ -130,7 +131,7 @@ class DissimilarityMatrixTests(DissimilarityMatrixTestData):
                            columns=['i', 'j', 'value'])
 
         # 'd' in i and j overlap
-        with self.assertRaisesRegex(KeyError, ("overlap. This constraint can "
+        with self.assertRaisesRegex(KeyError, ("This constraint can "
                                                "removed with "
                                                "allow_overlap=True.")):
             self.dm_5x5.between(['b', 'd'], ['a', 'd', 'e'])
@@ -148,6 +149,13 @@ class DissimilarityMatrixTests(DissimilarityMatrixTestData):
 
         with self.assertRaisesRegex(MissingIDError, "not found."):
             self.dm_3x3.between(['a', 'y'], ['a', 'x', 'c'])
+
+    def test_stable_order(self):
+        exp = ([(1, 'b'), (3, 'd'), (4, 'e')],
+               np.array([1, 3, 4], dtype=int),
+               ('b', 'd', 'e'))
+        obs = self.dm_5x5._stable_order(['d', 'e', 'b'])
+        self.assertEqual(obs, exp)
 
     def test_init_from_dm(self):
         ids = ['foo', 'bar', 'baz']

--- a/skbio/stats/distance/tests/test_base.py
+++ b/skbio/stats/distance/tests/test_base.py
@@ -85,6 +85,8 @@ class DissimilarityMatrixTests(DissimilarityMatrixTestData):
         # test_within
         obs = self.dm_3x3.within(['c', 'a'])
         pdt.assert_frame_equal(obs, exp)
+        obs = self.dm_3x3.within(['a', 'c'])
+        pdt.assert_frame_equal(obs, exp)
 
     def test_within_missing_id(self):
         with self.assertRaisesRegex(MissingIDError, "not found."):

--- a/skbio/stats/distance/tests/test_base.py
+++ b/skbio/stats/distance/tests/test_base.py
@@ -151,14 +151,22 @@ class DissimilarityMatrixTests(DissimilarityMatrixTestData):
             self.dm_3x3.between(['a', 'y'], ['a', 'x', 'c'])
 
     def test_stable_order(self):
-        exp = ([(1, 'b'), (3, 'd'), (4, 'e')],
-               np.array([1, 3, 4], dtype=int),
-               ('b', 'd', 'e'))
+        exp = np.array([1, 3, 4], dtype=int)
         obs = self.dm_5x5._stable_order(['d', 'e', 'b'])
 
-        self.assertEqual(obs[0], exp[0])
-        self.assertEqual(obs[2], exp[2])
-        npt.assert_equal(obs[1], exp[1])
+        npt.assert_equal(obs, exp)
+
+    def test_subset_to_dataframe(self):
+        exp = pd.DataFrame([['b', 'a', 5.],
+                            ['b', 'd', 7.],
+                            ['b', 'e', 8.],
+                            ['d', 'a', 4.],
+                            ['d', 'd', 0.],
+                            ['d', 'e', 7.]],
+                           columns=['i', 'j', 'value'])
+
+        obs = self.dm_5x5._subset_to_dataframe([1, 3], [0, 3, 4])
+        pdt.assert_frame_equal(obs, exp)
 
     def test_init_from_dm(self):
         ids = ['foo', 'bar', 'baz']

--- a/skbio/stats/distance/tests/test_mantel.py
+++ b/skbio/stats/distance/tests/test_mantel.py
@@ -239,9 +239,6 @@ class MantelTests(MantelTestData):
         self.assertEqual(obs[2], 24)
 
     def test_no_variation_pearson(self):
-        # Output doesn't match vegan::mantel with method='pearson'. Consider
-        # revising output and this test depending on outcome of
-        # https://github.com/scipy/scipy/issues/3728
         for alt in self.alternatives:
             # test one or both inputs having no variation in their
             # distances

--- a/skbio/stats/evolve/_hommola.py
+++ b/skbio/stats/evolve/_hommola.py
@@ -126,8 +126,8 @@ def hommola_cospeciation(host_dist, par_dist, interaction, permutations=999):
 
     >>> corr_coeff, p_value, perm_stats = hommola_cospeciation(
     ...     hdist, pdist, interaction, permutations=99)
-    >>> round(corr_coeff, 8)
-    0.83171097
+    >>> print("%.3f" % corr_coeff)
+    0.832
 
     In this case, the host distances have a fairly strong positive correlation
     with the symbiont distances. However, this may also reflect structure

--- a/skbio/stats/ordination/_principal_coordinate_analysis.py
+++ b/skbio/stats/ordination/_principal_coordinate_analysis.py
@@ -395,5 +395,6 @@ def pcoa_biplot(ordination, y):
     ordination.features = pd.DataFrame(data=Uproj,
                                        index=y.columns.copy(),
                                        columns=coordinates.columns.copy())
+    ordination.features.fillna(0.0, inplace=True)
 
     return ordination

--- a/skbio/stats/power.py
+++ b/skbio/stats/power.py
@@ -1017,7 +1017,7 @@ def _identify_sample_groups(meta, cat, control_cats, order, strict_match):
         m_ids = meta.loc[ids].groupby(cat).groups
         # Checks if samples from the cat groups are represented in those
         # Samples
-        id_vecs = [m_ids[o] for o in order if o in
+        id_vecs = [sorted(m_ids[o]) for o in order if o in
                    m_ids]
         # If all groups are represented, the index and results are retained
         if len(id_vecs) == len(order):

--- a/skbio/stats/power.py
+++ b/skbio/stats/power.py
@@ -84,8 +84,8 @@ Now, let's use random sampling to estimate the power of our test on
 the first distribution.
 
 >>> samples = [ind, dep]
->>> round(f(samples), 6)
-3.645945e-08
+>>> print("%.3e" % f(samples))
+3.646e-08
 
 In `subsample_power`, we can maintain a paired relationship between samples
 by setting `draw_mode` to "matched". We can also set our critical value, so


### PR DESCRIPTION
This pull request adds in `.within` and `.between` methods to the `DissimilarityMatrix` object, and expressing the data as a `pd.DataFrame`. These methods provide a standard way for obtaining within and between group distances, a common operation for beta-diversity derived distance matrices.

Please complete the following checklist:

* [x] I have read the guidelines in [CONTRIBUTING.md](https://github.com/biocore/scikit-bio/blob/master/CONTRIBUTING.md).

* [x] I have documented all public-facing changes in [CHANGELOG.md](https://github.com/biocore/scikit-bio/blob/master/CHANGELOG.md).

* [ ] **This pull request includes code, documentation, or other content derived from external source(s).** If this is the case, ensure the external source's license is compatible with scikit-bio's [license](https://github.com/biocore/scikit-bio/blob/master/COPYING.txt). Include the license in the `licenses` directory and add a comment in the code giving proper attribution. Ensure any other requirements set forth by the license and/or author are satisfied. **It is your responsibility to disclose code, documentation, or other content derived from external source(s).** If you have questions about whether something can be included in the project or how to give proper attribution, include those questions in your pull request and a reviewer will assist you.

* [x] **This pull request does not include code, documentation, or other content derived from external source(s).**

**Note:** [REVIEWING.md](https://github.com/biocore/scikit-bio/blob/master/REVIEWING.md) may also be helpful to see some of the things code reviewers will be verifying when reviewing your pull request.
