### PR TITLE
Add numpy as build dependency in pyproject.toml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # scikit-bio changelog
 
+## Version 0.5.7
+
+### Features
+
+### Backward-incompatible changes [stable]
+
+### Backward-incompatible changes [experimental]
+
+### Performance enhancements
+
+### Bug fixes
+
+### Deprecated functionality [stable]
+
+### Deprecated functionality [experimental]
+
+### Miscellaneous
+
+* Specify build dependencies in pyproject.toml. This allows the package to be installed without having to first manually install numpy.
+
 ## Version 0.5.6
 
 ### Features

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,6 +4,7 @@ include CONTRIBUTING.md
 include COPYING.txt
 include Makefile
 include PULL_REQUEST_TEMPLATE.md
+include pyproject.toml
 include README.rst
 include RELEASE.md
 include REVIEWING.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["numpy>=1.9.2", "setuptools", "wheel"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires = ["numpy>=1.9.2", "setuptools", "wheel"]
+requires = ["Cython", "numpy>=1.9.2", "setuptools", "wheel"]


### PR DESCRIPTION
This specifies numpy as a build dependency so that the package can be installed with pip without the user having to first manually install numpy, partially solving https://github.com/biocore/scikit-bio/issues/1671. Unfortunately, hdmedians has the same issue.

Please complete the following checklist:

* [X] I have read the guidelines in [CONTRIBUTING.md](https://github.com/biocore/scikit-bio/blob/master/CONTRIBUTING.md).

* [X] I have documented all public-facing changes in [CHANGELOG.md](https://github.com/biocore/scikit-bio/blob/master/CHANGELOG.md).

* [ ] **This pull request includes code, documentation, or other content derived from external source(s).** If this is the case, ensure the external source's license is compatible with scikit-bio's [license](https://github.com/biocore/scikit-bio/blob/master/COPYING.txt). Include the license in the `licenses` directory and add a comment in the code giving proper attribution. Ensure any other requirements set forth by the license and/or author are satisfied. **It is your responsibility to disclose code, documentation, or other content derived from external source(s).** If you have questions about whether something can be included in the project or how to give proper attribution, include those questions in your pull request and a reviewer will assist you.

* [X] **This pull request does not include code, documentation, or other content derived from external source(s).**

**Note:** [REVIEWING.md](https://github.com/biocore/scikit-bio/blob/master/REVIEWING.md) may also be helpful to see some of the things code reviewers will be verifying when reviewing your pull request.
