### PR TITLE
WIP: Networkx convertors

### DIFF
--- a/skbio/tree/_tree.py
+++ b/skbio/tree/_tree.py
@@ -3270,15 +3270,14 @@ class TreeNode(SkbioObject):
         for node in nodes_to_unpack:
             node.unpack()
 
-
     @experimental(as_of="0.5.5-dev")
     def to_networkx(self):
         import networkx as nx
 
-        edges = []
         def get_name(x, i):
             return x.name if hasattr(x, 'name') else f"unnamed_{i}"
 
+        edges = []
         for i, n in enumerate(self.postorder(include_self=False)):
             name = get_name(n, i)
             parent_name = get_name(n.parent, i)
@@ -3309,4 +3308,3 @@ class TreeNode(SkbioObject):
             p, c = e
             node_dict[p].append(node_dict[c])
         return node_dict[root]
-

--- a/skbio/tree/tests/test_tree.py
+++ b/skbio/tree/tests/test_tree.py
@@ -19,12 +19,6 @@ from skbio.tree import (DuplicateNodeError, NoLengthError,
                         TreeError, MissingNodeError, NoParentError)
 from skbio.util import RepresentationWarning
 
-try:
-    import networkx as nx
-    has_networkx = True
-except:
-    print('networkx not installed')
-    has_networkx = False
 
 class TreeNodeSubclass(TreeNode):
     pass
@@ -1495,7 +1489,6 @@ class TreeTests(TestCase):
         self.assertEqual(str(tree).rstrip(), exp)
 
     def test_to_networkx(self):
-        if not has_networkx: return
 
         tree = TreeNode.read(['(((a,b,f,g)j,c)i,d)r;'])
         # TODO : account for length
@@ -1515,7 +1508,8 @@ class TreeTests(TestCase):
         self.assertListEqual(exp_edges, res_edges)
 
     def test_from_networkx(self):
-        if not has_networkx: return
+        import networkx as nx
+
         edges = [
             ('a', 'j'),
             ('j', 'b'),

--- a/skbio/tree/tests/test_tree.py
+++ b/skbio/tree/tests/test_tree.py
@@ -19,6 +19,12 @@ from skbio.tree import (DuplicateNodeError, NoLengthError,
                         TreeError, MissingNodeError, NoParentError)
 from skbio.util import RepresentationWarning
 
+try:
+    import networkx as nx
+    has_networkx = True
+except:
+    print('networkx not installed')
+    has_networkx = False
 
 class TreeNodeSubclass(TreeNode):
     pass
@@ -1487,6 +1493,43 @@ class TreeTests(TestCase):
         exp = ('(((a:1.02,b:0.33)85:0.12,c:3.88,d:5.25)75:0.95,'
                '(e:1.43,f:1.89,g:2.12)node:0.35)root;')
         self.assertEqual(str(tree).rstrip(), exp)
+
+    def test_to_networkx(self):
+        if not has_networkx: return
+
+        tree = TreeNode.read(['(((a,b,f,g)j,c)i,d)r;'])
+        # TODO : account for length
+        # TODO : account for nodes with missing names
+        exp_edges = [
+            ('a', 'j'),
+            ('j', 'b'),
+            ('j', 'f'),
+            ('j', 'g'),
+            ('j', 'i'),
+            ('i', 'c'),
+            ('i', 'r'),
+            ('r', 'd')
+        ]
+        G = tree.to_networkx()
+        res_edges = list(G.edges())
+        self.assertListEqual(exp_edges, res_edges)
+
+    def test_from_networkx(self):
+        if not has_networkx: return
+        edges = [
+            ('a', 'j'),
+            ('j', 'b'),
+            ('j', 'f'),
+            ('j', 'g'),
+            ('j', 'i'),
+            ('i', 'c'),
+            ('i', 'r'),
+            ('r', 'd')
+        ]
+        G = nx.Graph()
+        G.add_edges_from(edges)
+        tree = TreeNode.from_networkx(G, root='r')
+        self.assertEqual(str(tree), '(((a,b,f,g)j,c)i,d)r;\n')
 
 
 sample = """


### PR DESCRIPTION
Please complete the following checklist:

* [x] I have read the guidelines in [CONTRIBUTING.md](https://github.com/biocore/scikit-bio/blob/master/CONTRIBUTING.md).

* [x] I have documented all public-facing changes in [CHANGELOG.md](https://github.com/biocore/scikit-bio/blob/master/CHANGELOG.md).

* [ ] **This pull request includes code, documentation, or other content derived from external source(s).** If this is the case, ensure the external source's license is compatible with scikit-bio's [license](https://github.com/biocore/scikit-bio/blob/master/COPYING.txt). Include the license in the `licenses` directory and add a comment in the code giving proper attribution. Ensure any other requirements set forth by the license and/or author are satisfied. **It is your responsibility to disclose code, documentation, or other content derived from external source(s).** If you have questions about whether something can be included in the project or how to give proper attribution, include those questions in your pull request and a reviewer will assist you.

* [x] **This pull request does not include code, documentation, or other content derived from external source(s).**

**Note:** [REVIEWING.md](https://github.com/biocore/scikit-bio/blob/master/REVIEWING.md) may also be helpful to see some of the things code reviewers will be verifying when reviewing your pull request.

This addresses https://github.com/biocore/scikit-bio/issues/809
Here we have both `to_networkx` and `from_networkx` conversion methods implemented, along with bare-bones unittests.

There are a few things that would be need to resolved before merging, namely

- How to handle networkx as an optional dependency
- Should we allow for lengths + other attributes be exchanged between nx.Graph and skbio.TreeNode? For strings / scalars this is totally doable, but could get complicated if we allow lists + dicts to be passed as attributes
- [ ] Missing labels. In theory this `to_networkx` should work with missing node names, but we need additional tests to sanity check this
- [ ] Root node specification.  As the code currently stands, `from_networkx` requires the specification of a root node. If this isn't specified, it just chooses the first node as the root node.

If there are any other outstanding issues, feel free to pile them on the above todo list :)
