### PR TITLE
Allow `DissimilarityMatrix` to use `np.float32`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ install:
   - conda info --envs
   - python --version
   - pip install -r ci/pip_requirements.txt
-  - pip install .
+  - pip install . --no-deps
 
 script:
   - WITH_COVERAGE=TRUE make test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # scikit-bio changelog
 
+## Version 0.5.6-dev
+
+### Features
+
+* Added support for `np.float32` with `DissimilarityMatrix` objects.
+
+### Backward-incompatible changes [stable]
+
+### Backward-incompatible changes [experimental]
+
+### Performance enhancements
+
+* Avoid an implicit data copy on construction of `DissimilarityMatrix` objects. 
+
+### Bug fixes
+
+### Deprecated functionality [stable]
+
+### Deprecated functionality [experimental]
+
+### Miscellaneous
+
 ## Version 0.5.6
 
 ### Features

--- a/ci/conda_requirements.txt
+++ b/ci/conda_requirements.txt
@@ -2,7 +2,7 @@ pip
 numpy
 scipy
 matplotlib
-pandas
+pandas < 1.0
 pep8
 ipython
 pyflakes

--- a/ci/conda_requirements.txt
+++ b/ci/conda_requirements.txt
@@ -2,7 +2,7 @@ pip
 numpy
 scipy
 matplotlib
-pandas < 1.0
+pandas
 pep8
 ipython
 pyflakes

--- a/skbio/alignment/_tabular_msa.py
+++ b/skbio/alignment/_tabular_msa.py
@@ -1172,8 +1172,8 @@ class TabularMSA(MetadataMixin, PositionalMetadataMixin, SkbioObject):
             return self._constructor_(new_seqs, positional_metadata=None)
         return self._constructor_(new_seqs)
 
-    def _get_sequence_loc_(self, l):
-        new_seqs = self._seqs.loc[l]
+    def _get_sequence_loc_(self, ids):
+        new_seqs = self._seqs.loc[ids]
         if type(new_seqs) is self.dtype:
             return new_seqs
         else:
@@ -1186,17 +1186,17 @@ class TabularMSA(MetadataMixin, PositionalMetadataMixin, SkbioObject):
                 raise AssertionError(
                     "Something went wrong with the index %r provided to"
                     " `_get_sequence_loc_`, please report this stack trace to"
-                    "\nhttps://github.com/biocore/scikit-bio/issues" % l)
+                    "\nhttps://github.com/biocore/scikit-bio/issues" % ids)
 
-    def _slice_sequences_loc_(self, l):
-        new_seqs = self._seqs.loc[l]
+    def _slice_sequences_loc_(self, ids):
+        new_seqs = self._seqs.loc[ids]
         try:
             # TODO: change for #1198
             if len(new_seqs) == 0:
                 return self._constructor_(new_seqs, positional_metadata=None)
             return self._constructor_(new_seqs)
         except TypeError:  # NaN hit the constructor, key was bad... probably
-            raise KeyError("Part of `%r` was not in the index.")
+            raise KeyError("Part of `%r` was not in the index." % ids)
 
     def _get_position_(self, i, ignore_metadata=False):
         if ignore_metadata:

--- a/skbio/diversity/_util.py
+++ b/skbio/diversity/_util.py
@@ -104,7 +104,7 @@ def _validate_otu_ids_and_tree(counts, otu_ids, tree):
     set_tip_names = set(tip_names)
     if len(tip_names) != len(set_tip_names):
         raise DuplicateNodeError("All tip names must be unique.")
-    if np.array([l is None for l in branch_lengths]).any():
+    if np.array([branch is None for branch in branch_lengths]).any():
         raise ValueError("All non-root nodes in ``tree`` must have a branch "
                          "length.")
     missing_tip_names = set_otu_ids - set_tip_names

--- a/skbio/io/tests/test_registry.py
+++ b/skbio/io/tests/test_registry.py
@@ -27,8 +27,8 @@ from skbio import DNA, read, write
 
 
 class MockClass:
-    def __init__(self, l):
-        self.list = l
+    def __init__(self, list_):
+        self.list = list_
 
     def __eq__(self, other):
         # They are only equal when the class is EXACTLY the same. We don't want
@@ -1692,8 +1692,8 @@ class TestWrite(RegistryTest):
             iterator = iter(obj.list)
             fh.write(next(iterator))
             fh.flush()  # Flush should be a noop for bz2
-            for l in iterator:
-                fh.write(l)
+            for line in iterator:
+                fh.write(line)
 
         self.registry.write(obj, format='format1', into=fp, compression='bz2')
         self.registry.write(obj, format='format1', into=f, compression='bz2')

--- a/skbio/stats/distance/_base.py
+++ b/skbio/stats/distance/_base.py
@@ -881,7 +881,7 @@ class DissimilarityMatrix(SkbioObject):
             raise DissimilarityMatrixError("Data must be square (i.e., have "
                                            "the same number of rows and "
                                            "columns).")
-        if data.dtype != np.double:
+        if data.dtype not in (np.float32, np.float64):
             raise DissimilarityMatrixError("Data must contain only floating "
                                            "point values.")
         duplicates = find_duplicates(ids)

--- a/skbio/stats/distance/_base.py
+++ b/skbio/stats/distance/_base.py
@@ -96,7 +96,28 @@ class DissimilarityMatrix(SkbioObject):
         if isinstance(data, DissimilarityMatrix):
             ids = data.ids if ids is None else ids
             data = data.data
-        data = np.asarray(data, dtype='float')
+
+        # It is necessary to standardize the representation of the .data
+        # attribute of this object. The input types might be list, tuple,
+        # np.array, or possibly some other object type. Generally, this
+        # normalization of type will require a copy of data. For example,
+        # moving from a Python type representation (e.g., [[0, 1], [1, 0]])
+        # requires casting all of the values to numpy types, which is handled
+        # as an implicit copy via np.asarray. However, these copies are
+        # unnecessary if the data object is already a numpy array. np.asarray
+        # is smart enough to not copy the data, however if a dtype change is
+        # requested it will. The following block of code limits the use of
+        # np.asarray to situations where the data are (a) not already a numpy
+        # array or (b) the data are not a single or double precision numpy
+        # data type.
+        _issue_copy = True
+        if isinstance(data, np.ndarray):
+            if data.dtype in (np.float32, np.float64):
+                _issue_copy = False
+
+        if _issue_copy:
+            data = np.asarray(data, dtype='float')
+
         if data.ndim == 1:
             data = squareform(data, force='tomatrix', checks=False)
         if ids is None:

--- a/skbio/stats/distance/tests/test_base.py
+++ b/skbio/stats/distance/tests/test_base.py
@@ -64,6 +64,19 @@ class DissimilarityMatrixTests(DissimilarityMatrixTestData):
                                    np.array(self.dm_2x2_asym_data),
                                    np.array(self.dm_3x3_data)]
 
+    def test_avoid_copy_on_construction(self):
+        # ((data, expect_copy))
+        tests = (([[0, 1], [1, 0]], True),
+                 ([(0, 1), (1, 0)], True),
+                 (((0, 1), (1, 0)), True),
+                 (np.array([[0, 1], [1, 0]], dtype='int'), True),
+                 (np.array([[0, 1], [1, 0]], dtype='float'), False),
+                 (np.array([[0, 1], [1, 0]], dtype='double'), False))
+
+        for data, expect in tests:
+            obj = DissimilarityMatrix(data)
+            self.assertEqual(id(obj.data) != id(data), expect)
+
     def test_within(self):
         exp = pd.DataFrame([['a', 'a', 0.0],
                             ['a', 'c', 4.2],

--- a/skbio/stats/distance/tests/test_base.py
+++ b/skbio/stats/distance/tests/test_base.py
@@ -71,6 +71,8 @@ class DissimilarityMatrixTests(DissimilarityMatrixTestData):
                  (((0, 1), (1, 0)), True),
                  (np.array([[0, 1], [1, 0]], dtype='int'), True),
                  (np.array([[0, 1], [1, 0]], dtype='float'), False),
+                 (np.array([[0, 1], [1, 0]], dtype=np.float32), False),
+                 (np.array([[0, 1], [1, 0]], dtype=np.float64), False),
                  (np.array([[0, 1], [1, 0]], dtype='double'), False))
 
         for data, expect in tests:

--- a/skbio/stats/ordination/tests/test_ordination_results.py
+++ b/skbio/stats/ordination/tests/test_ordination_results.py
@@ -266,7 +266,7 @@ class TestOrdinationResults(unittest.TestCase):
         labels = [t.get_text() for t in legend.get_texts()]
         npt.assert_equal(sorted(labels), ['bar', 'foo'])
 
-        colors = [l.get_color() for l in legend.get_lines()]
+        colors = [line.get_color() for line in legend.get_lines()]
         npt.assert_equal(sorted(colors), ['green', 'red'])
 
     def test_repr_png(self):


### PR DESCRIPTION
We observed a Mantel R^2 of 0.9999 between float32 and float64 results with weighted UniFrac when applied to the EMP dataset (~27k samples). This observation arose from a recent GPU adaption of [UniFrac](https://arxiv.org/abs/2005.05826) when testing for a performance difference when computing float32 and float64. We're now producing float32 matrices from UniFrac as it's appreciably faster, however the `DissimilarityMatrix` object at the moment requires double precision. This PR allows `DissimilarityMatrix` to both support float32, and to avoid an implicit copy that would occur if passing in float32 data. 

The implicit copy is important to avoid for large matrices to keep resident memory low.  
 
Please complete the following checklist:

* [x] I have read the guidelines in [CONTRIBUTING.md](https://github.com/biocore/scikit-bio/blob/master/CONTRIBUTING.md).

* [x] I have documented all public-facing changes in [CHANGELOG.md](https://github.com/biocore/scikit-bio/blob/master/CHANGELOG.md).

* [ ] **This pull request includes code, documentation, or other content derived from external source(s).** If this is the case, ensure the external source's license is compatible with scikit-bio's [license](https://github.com/biocore/scikit-bio/blob/master/COPYING.txt). Include the license in the `licenses` directory and add a comment in the code giving proper attribution. Ensure any other requirements set forth by the license and/or author are satisfied. **It is your responsibility to disclose code, documentation, or other content derived from external source(s).** If you have questions about whether something can be included in the project or how to give proper attribution, include those questions in your pull request and a reviewer will assist you.

* [x] **This pull request does not include code, documentation, or other content derived from external source(s).**

**Note:** [REVIEWING.md](https://github.com/biocore/scikit-bio/blob/master/REVIEWING.md) may also be helpful to see some of the things code reviewers will be verifying when reviewing your pull request.
