### PR TITLE
Properly tune the tilling #1762

### DIFF
--- a/skbio/stats/distance/_cutils.c
+++ b/skbio/stats/distance/_cutils.c
@@ -2901,7 +2901,6 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_8is_symmetric_and_hol
   Py_ssize_t __pyx_v_tcol_max;
   Py_ssize_t __pyx_v_row;
   Py_ssize_t __pyx_v_col;
-  float __pyx_v_testval;
   int __pyx_v_is_sym;
   int __pyx_v_is_hollow;
   PyObject *__pyx_r = NULL;
@@ -2920,10 +2919,12 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_8is_symmetric_and_hol
   Py_ssize_t __pyx_t_12;
   Py_ssize_t __pyx_t_13;
   Py_ssize_t __pyx_t_14;
-  int __pyx_t_15;
-  PyObject *__pyx_t_16 = NULL;
-  PyObject *__pyx_t_17 = NULL;
+  Py_ssize_t __pyx_t_15;
+  Py_ssize_t __pyx_t_16;
+  int __pyx_t_17;
   PyObject *__pyx_t_18 = NULL;
+  PyObject *__pyx_t_19 = NULL;
+  PyObject *__pyx_t_20 = NULL;
   int __pyx_lineno = 0;
   const char *__pyx_filename = NULL;
   int __pyx_clineno = 0;
@@ -2984,9 +2985,9 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_8is_symmetric_and_hol
   /* "skbio/stats/distance/_cutils.pyx":55
  * 
  *     # use a tiled approach to maximize memory locality
- *     for trow in prange(0, in_n, 64, nogil=True):             # <<<<<<<<<<<<<<
- *         trow_max = min(trow+64, in_n)
- *         for tcol in range(0, in_n, 64):
+ *     for trow in prange(0, in_n, 24, nogil=True):             # <<<<<<<<<<<<<<
+ *         trow_max = min(trow+24, in_n)
+ *         for tcol in range(0, in_n, 24):
  */
   {
       #ifdef WITH_THREAD
@@ -2996,7 +2997,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_8is_symmetric_and_hol
       #endif
       /*try:*/ {
         __pyx_t_1 = __pyx_v_in_n;
-        if ((64 == 0)) abort();
+        if ((24 == 0)) abort();
         {
             #if ((defined(__APPLE__) || defined(__OSX__)) && (defined(__GNUC__) && (__GNUC__ > 2 || (__GNUC__ == 2 && (__GNUC_MINOR__ > 95)))))
                 #undef likely
@@ -3004,36 +3005,35 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_8is_symmetric_and_hol
                 #define likely(x)   (x)
                 #define unlikely(x) (x)
             #endif
-            __pyx_t_3 = (__pyx_t_1 - 0 + 64 - 64/abs(64)) / 64;
+            __pyx_t_3 = (__pyx_t_1 - 0 + 24 - 24/abs(24)) / 24;
             if (__pyx_t_3 > 0)
             {
                 #ifdef _OPENMP
-                #pragma omp parallel reduction(&:__pyx_v_is_hollow) reduction(&:__pyx_v_is_sym) private(__pyx_t_10, __pyx_t_11, __pyx_t_12, __pyx_t_13, __pyx_t_14, __pyx_t_15, __pyx_t_4, __pyx_t_5, __pyx_t_6, __pyx_t_7, __pyx_t_8, __pyx_t_9)
+                #pragma omp parallel reduction(&:__pyx_v_is_hollow) reduction(&:__pyx_v_is_sym) private(__pyx_t_10, __pyx_t_11, __pyx_t_12, __pyx_t_13, __pyx_t_14, __pyx_t_15, __pyx_t_16, __pyx_t_17, __pyx_t_4, __pyx_t_5, __pyx_t_6, __pyx_t_7, __pyx_t_8, __pyx_t_9)
                 #endif /* _OPENMP */
                 {
                     #ifdef _OPENMP
-                    #pragma omp for lastprivate(__pyx_v_col) lastprivate(__pyx_v_row) lastprivate(__pyx_v_tcol) lastprivate(__pyx_v_tcol_max) lastprivate(__pyx_v_testval) firstprivate(__pyx_v_trow) lastprivate(__pyx_v_trow) lastprivate(__pyx_v_trow_max)
+                    #pragma omp for lastprivate(__pyx_v_col) lastprivate(__pyx_v_row) lastprivate(__pyx_v_tcol) lastprivate(__pyx_v_tcol_max) firstprivate(__pyx_v_trow) lastprivate(__pyx_v_trow) lastprivate(__pyx_v_trow_max)
                     #endif /* _OPENMP */
                     for (__pyx_t_2 = 0; __pyx_t_2 < __pyx_t_3; __pyx_t_2++){
                         {
-                            __pyx_v_trow = (Py_ssize_t)(0 + 64 * __pyx_t_2);
+                            __pyx_v_trow = (Py_ssize_t)(0 + 24 * __pyx_t_2);
                             /* Initialize private variables to invalid values */
                             __pyx_v_col = ((Py_ssize_t)0xbad0bad0);
                             __pyx_v_row = ((Py_ssize_t)0xbad0bad0);
                             __pyx_v_tcol = ((Py_ssize_t)0xbad0bad0);
                             __pyx_v_tcol_max = ((Py_ssize_t)0xbad0bad0);
-                            __pyx_v_testval = ((float)__PYX_NAN());
                             __pyx_v_trow_max = ((Py_ssize_t)0xbad0bad0);
 
                             /* "skbio/stats/distance/_cutils.pyx":56
  *     # use a tiled approach to maximize memory locality
- *     for trow in prange(0, in_n, 64, nogil=True):
- *         trow_max = min(trow+64, in_n)             # <<<<<<<<<<<<<<
- *         for tcol in range(0, in_n, 64):
- *             tcol_max = min(tcol+64, in_n)
+ *     for trow in prange(0, in_n, 24, nogil=True):
+ *         trow_max = min(trow+24, in_n)             # <<<<<<<<<<<<<<
+ *         for tcol in range(0, in_n, 24):
+ *             tcol_max = min(tcol+24, in_n)
  */
                             __pyx_t_4 = __pyx_v_in_n;
-                            __pyx_t_5 = (__pyx_v_trow + 64);
+                            __pyx_t_5 = (__pyx_v_trow + 24);
                             if (((__pyx_t_4 < __pyx_t_5) != 0)) {
                               __pyx_t_6 = __pyx_t_4;
                             } else {
@@ -3042,26 +3042,26 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_8is_symmetric_and_hol
                             __pyx_v_trow_max = __pyx_t_6;
 
                             /* "skbio/stats/distance/_cutils.pyx":57
- *     for trow in prange(0, in_n, 64, nogil=True):
- *         trow_max = min(trow+64, in_n)
- *         for tcol in range(0, in_n, 64):             # <<<<<<<<<<<<<<
- *             tcol_max = min(tcol+64, in_n)
+ *     for trow in prange(0, in_n, 24, nogil=True):
+ *         trow_max = min(trow+24, in_n)
+ *         for tcol in range(0, in_n, 24):             # <<<<<<<<<<<<<<
+ *             tcol_max = min(tcol+24, in_n)
  *             for row in range(trow, trow_max, 1):
  */
                             __pyx_t_6 = __pyx_v_in_n;
                             __pyx_t_4 = __pyx_t_6;
-                            for (__pyx_t_5 = 0; __pyx_t_5 < __pyx_t_4; __pyx_t_5+=64) {
+                            for (__pyx_t_5 = 0; __pyx_t_5 < __pyx_t_4; __pyx_t_5+=24) {
                               __pyx_v_tcol = __pyx_t_5;
 
                               /* "skbio/stats/distance/_cutils.pyx":58
- *         trow_max = min(trow+64, in_n)
- *         for tcol in range(0, in_n, 64):
- *             tcol_max = min(tcol+64, in_n)             # <<<<<<<<<<<<<<
+ *         trow_max = min(trow+24, in_n)
+ *         for tcol in range(0, in_n, 24):
+ *             tcol_max = min(tcol+24, in_n)             # <<<<<<<<<<<<<<
  *             for row in range(trow, trow_max, 1):
  *                 for col in range(tcol, tcol_max, 1):
  */
                               __pyx_t_7 = __pyx_v_in_n;
-                              __pyx_t_8 = (__pyx_v_tcol + 64);
+                              __pyx_t_8 = (__pyx_v_tcol + 24);
                               if (((__pyx_t_7 < __pyx_t_8) != 0)) {
                                 __pyx_t_9 = __pyx_t_7;
                               } else {
@@ -3070,11 +3070,11 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_8is_symmetric_and_hol
                               __pyx_v_tcol_max = __pyx_t_9;
 
                               /* "skbio/stats/distance/_cutils.pyx":59
- *         for tcol in range(0, in_n, 64):
- *             tcol_max = min(tcol+64, in_n)
+ *         for tcol in range(0, in_n, 24):
+ *             tcol_max = min(tcol+24, in_n)
  *             for row in range(trow, trow_max, 1):             # <<<<<<<<<<<<<<
  *                 for col in range(tcol, tcol_max, 1):
- *                    testval = mat[row,col]
+ *                    is_sym &= (mat[row,col]==mat[col,row])
  */
                               __pyx_t_9 = __pyx_v_trow_max;
                               __pyx_t_7 = __pyx_t_9;
@@ -3082,11 +3082,11 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_8is_symmetric_and_hol
                                 __pyx_v_row = __pyx_t_8;
 
                                 /* "skbio/stats/distance/_cutils.pyx":60
- *             tcol_max = min(tcol+64, in_n)
+ *             tcol_max = min(tcol+24, in_n)
  *             for row in range(trow, trow_max, 1):
  *                 for col in range(tcol, tcol_max, 1):             # <<<<<<<<<<<<<<
- *                    testval = mat[row,col]
- *                    if (row==col):
+ *                    is_sym &= (mat[row,col]==mat[col,row])
+ *             if (trow==tcol): # diagonal block, only ones that can have col==row
  */
                                 __pyx_t_10 = __pyx_v_tcol_max;
                                 __pyx_t_11 = __pyx_t_10;
@@ -3096,57 +3096,59 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_8is_symmetric_and_hol
                                   /* "skbio/stats/distance/_cutils.pyx":61
  *             for row in range(trow, trow_max, 1):
  *                 for col in range(tcol, tcol_max, 1):
- *                    testval = mat[row,col]             # <<<<<<<<<<<<<<
- *                    if (row==col):
- *                        # diagonal elements are always symmetric,
+ *                    is_sym &= (mat[row,col]==mat[col,row])             # <<<<<<<<<<<<<<
+ *             if (trow==tcol): # diagonal block, only ones that can have col==row
+ *                 for col in range(tcol, tcol_max, 1):
  */
                                   __pyx_t_13 = __pyx_v_row;
                                   __pyx_t_14 = __pyx_v_col;
-                                  __pyx_v_testval = (*((float *) ( /* dim=1 */ ((char *) (((float *) ( /* dim=0 */ (__pyx_v_mat.data + __pyx_t_13 * __pyx_v_mat.strides[0]) )) + __pyx_t_14)) )));
+                                  __pyx_t_15 = __pyx_v_col;
+                                  __pyx_t_16 = __pyx_v_row;
+                                  __pyx_v_is_sym = (__pyx_v_is_sym & ((*((float *) ( /* dim=1 */ ((char *) (((float *) ( /* dim=0 */ (__pyx_v_mat.data + __pyx_t_13 * __pyx_v_mat.strides[0]) )) + __pyx_t_14)) ))) == (*((float *) ( /* dim=1 */ ((char *) (((float *) ( /* dim=0 */ (__pyx_v_mat.data + __pyx_t_15 * __pyx_v_mat.strides[0]) )) + __pyx_t_16)) )))));
+                                }
+                              }
 
-                                  /* "skbio/stats/distance/_cutils.pyx":62
+                              /* "skbio/stats/distance/_cutils.pyx":62
  *                 for col in range(tcol, tcol_max, 1):
- *                    testval = mat[row,col]
- *                    if (row==col):             # <<<<<<<<<<<<<<
- *                        # diagonal elements are always symmetric,
- *                        # so no need to check
- */
-                                  __pyx_t_15 = ((__pyx_v_row == __pyx_v_col) != 0);
-                                  if (__pyx_t_15) {
-
-                                    /* "skbio/stats/distance/_cutils.pyx":65
- *                        # diagonal elements are always symmetric,
- *                        # so no need to check
- *                        is_hollow &= (testval==0)             # <<<<<<<<<<<<<<
- *                    else:
- *                        is_sym &= (testval==mat[col,row])
- */
-                                    __pyx_v_is_hollow = (__pyx_v_is_hollow & (__pyx_v_testval == 0.0));
-
-                                    /* "skbio/stats/distance/_cutils.pyx":62
+ *                    is_sym &= (mat[row,col]==mat[col,row])
+ *             if (trow==tcol): # diagonal block, only ones that can have col==row             # <<<<<<<<<<<<<<
  *                 for col in range(tcol, tcol_max, 1):
- *                    testval = mat[row,col]
- *                    if (row==col):             # <<<<<<<<<<<<<<
- *                        # diagonal elements are always symmetric,
- *                        # so no need to check
+ *                    is_hollow &= (mat[col,col]==0)
  */
-                                    goto __pyx_L16;
-                                  }
+                              __pyx_t_17 = ((__pyx_v_trow == __pyx_v_tcol) != 0);
+                              if (__pyx_t_17) {
 
-                                  /* "skbio/stats/distance/_cutils.pyx":67
- *                        is_hollow &= (testval==0)
- *                    else:
- *                        is_sym &= (testval==mat[col,row])             # <<<<<<<<<<<<<<
+                                /* "skbio/stats/distance/_cutils.pyx":63
+ *                    is_sym &= (mat[row,col]==mat[col,row])
+ *             if (trow==tcol): # diagonal block, only ones that can have col==row
+ *                 for col in range(tcol, tcol_max, 1):             # <<<<<<<<<<<<<<
+ *                    is_hollow &= (mat[col,col]==0)
+ * 
+ */
+                                __pyx_t_9 = __pyx_v_tcol_max;
+                                __pyx_t_7 = __pyx_t_9;
+                                for (__pyx_t_8 = __pyx_v_tcol; __pyx_t_8 < __pyx_t_7; __pyx_t_8+=1) {
+                                  __pyx_v_col = __pyx_t_8;
+
+                                  /* "skbio/stats/distance/_cutils.pyx":64
+ *             if (trow==tcol): # diagonal block, only ones that can have col==row
+ *                 for col in range(tcol, tcol_max, 1):
+ *                    is_hollow &= (mat[col,col]==0)             # <<<<<<<<<<<<<<
  * 
  *     return [(is_sym==True), (is_hollow==True)]
  */
-                                  /*else*/ {
-                                    __pyx_t_14 = __pyx_v_col;
-                                    __pyx_t_13 = __pyx_v_row;
-                                    __pyx_v_is_sym = (__pyx_v_is_sym & (__pyx_v_testval == (*((float *) ( /* dim=1 */ ((char *) (((float *) ( /* dim=0 */ (__pyx_v_mat.data + __pyx_t_14 * __pyx_v_mat.strides[0]) )) + __pyx_t_13)) )))));
-                                  }
-                                  __pyx_L16:;
+                                  __pyx_t_16 = __pyx_v_col;
+                                  __pyx_t_15 = __pyx_v_col;
+                                  __pyx_v_is_hollow = (__pyx_v_is_hollow & ((*((float *) ( /* dim=1 */ ((char *) (((float *) ( /* dim=0 */ (__pyx_v_mat.data + __pyx_t_16 * __pyx_v_mat.strides[0]) )) + __pyx_t_15)) ))) == 0.0));
                                 }
+
+                                /* "skbio/stats/distance/_cutils.pyx":62
+ *                 for col in range(tcol, tcol_max, 1):
+ *                    is_sym &= (mat[row,col]==mat[col,row])
+ *             if (trow==tcol): # diagonal block, only ones that can have col==row             # <<<<<<<<<<<<<<
+ *                 for col in range(tcol, tcol_max, 1):
+ *                    is_hollow &= (mat[col,col]==0)
+ */
                               }
                             }
                         }
@@ -3165,9 +3167,9 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_8is_symmetric_and_hol
       /* "skbio/stats/distance/_cutils.pyx":55
  * 
  *     # use a tiled approach to maximize memory locality
- *     for trow in prange(0, in_n, 64, nogil=True):             # <<<<<<<<<<<<<<
- *         trow_max = min(trow+64, in_n)
- *         for tcol in range(0, in_n, 64):
+ *     for trow in prange(0, in_n, 24, nogil=True):             # <<<<<<<<<<<<<<
+ *         trow_max = min(trow+24, in_n)
+ *         for tcol in range(0, in_n, 24):
  */
       /*finally:*/ {
         /*normal exit:*/{
@@ -3181,28 +3183,28 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_8is_symmetric_and_hol
       }
   }
 
-  /* "skbio/stats/distance/_cutils.pyx":69
- *                        is_sym &= (testval==mat[col,row])
+  /* "skbio/stats/distance/_cutils.pyx":66
+ *                    is_hollow &= (mat[col,col]==0)
  * 
  *     return [(is_sym==True), (is_hollow==True)]             # <<<<<<<<<<<<<<
  * 
  * 
  */
   __Pyx_XDECREF(__pyx_r);
-  __pyx_t_16 = __Pyx_PyBool_FromLong((__pyx_v_is_sym == 1)); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 69, __pyx_L1_error)
-  __Pyx_GOTREF(__pyx_t_16);
-  __pyx_t_17 = __Pyx_PyBool_FromLong((__pyx_v_is_hollow == 1)); if (unlikely(!__pyx_t_17)) __PYX_ERR(0, 69, __pyx_L1_error)
-  __Pyx_GOTREF(__pyx_t_17);
-  __pyx_t_18 = PyList_New(2); if (unlikely(!__pyx_t_18)) __PYX_ERR(0, 69, __pyx_L1_error)
+  __pyx_t_18 = __Pyx_PyBool_FromLong((__pyx_v_is_sym == 1)); if (unlikely(!__pyx_t_18)) __PYX_ERR(0, 66, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_18);
-  __Pyx_GIVEREF(__pyx_t_16);
-  PyList_SET_ITEM(__pyx_t_18, 0, __pyx_t_16);
-  __Pyx_GIVEREF(__pyx_t_17);
-  PyList_SET_ITEM(__pyx_t_18, 1, __pyx_t_17);
-  __pyx_t_16 = 0;
-  __pyx_t_17 = 0;
-  __pyx_r = __pyx_t_18;
+  __pyx_t_19 = __Pyx_PyBool_FromLong((__pyx_v_is_hollow == 1)); if (unlikely(!__pyx_t_19)) __PYX_ERR(0, 66, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_t_19);
+  __pyx_t_20 = PyList_New(2); if (unlikely(!__pyx_t_20)) __PYX_ERR(0, 66, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_t_20);
+  __Pyx_GIVEREF(__pyx_t_18);
+  PyList_SET_ITEM(__pyx_t_20, 0, __pyx_t_18);
+  __Pyx_GIVEREF(__pyx_t_19);
+  PyList_SET_ITEM(__pyx_t_20, 1, __pyx_t_19);
   __pyx_t_18 = 0;
+  __pyx_t_19 = 0;
+  __pyx_r = __pyx_t_20;
+  __pyx_t_20 = 0;
   goto __pyx_L0;
 
   /* "skbio/stats/distance/_cutils.pyx":22
@@ -3215,9 +3217,9 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_8is_symmetric_and_hol
 
   /* function exit code */
   __pyx_L1_error:;
-  __Pyx_XDECREF(__pyx_t_16);
-  __Pyx_XDECREF(__pyx_t_17);
   __Pyx_XDECREF(__pyx_t_18);
+  __Pyx_XDECREF(__pyx_t_19);
+  __Pyx_XDECREF(__pyx_t_20);
   __Pyx_AddTraceback("skbio.stats.distance._cutils.is_symmetric_and_hollow_cy", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __pyx_r = NULL;
   __pyx_L0:;
@@ -3263,7 +3265,6 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_10is_symmetric_and_ho
   Py_ssize_t __pyx_v_tcol_max;
   Py_ssize_t __pyx_v_row;
   Py_ssize_t __pyx_v_col;
-  double __pyx_v_testval;
   int __pyx_v_is_sym;
   int __pyx_v_is_hollow;
   PyObject *__pyx_r = NULL;
@@ -3282,10 +3283,12 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_10is_symmetric_and_ho
   Py_ssize_t __pyx_t_12;
   Py_ssize_t __pyx_t_13;
   Py_ssize_t __pyx_t_14;
-  int __pyx_t_15;
-  PyObject *__pyx_t_16 = NULL;
-  PyObject *__pyx_t_17 = NULL;
+  Py_ssize_t __pyx_t_15;
+  Py_ssize_t __pyx_t_16;
+  int __pyx_t_17;
   PyObject *__pyx_t_18 = NULL;
+  PyObject *__pyx_t_19 = NULL;
+  PyObject *__pyx_t_20 = NULL;
   int __pyx_lineno = 0;
   const char *__pyx_filename = NULL;
   int __pyx_clineno = 0;
@@ -3346,9 +3349,9 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_10is_symmetric_and_ho
   /* "skbio/stats/distance/_cutils.pyx":55
  * 
  *     # use a tiled approach to maximize memory locality
- *     for trow in prange(0, in_n, 64, nogil=True):             # <<<<<<<<<<<<<<
- *         trow_max = min(trow+64, in_n)
- *         for tcol in range(0, in_n, 64):
+ *     for trow in prange(0, in_n, 24, nogil=True):             # <<<<<<<<<<<<<<
+ *         trow_max = min(trow+24, in_n)
+ *         for tcol in range(0, in_n, 24):
  */
   {
       #ifdef WITH_THREAD
@@ -3358,7 +3361,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_10is_symmetric_and_ho
       #endif
       /*try:*/ {
         __pyx_t_1 = __pyx_v_in_n;
-        if ((64 == 0)) abort();
+        if ((24 == 0)) abort();
         {
             #if ((defined(__APPLE__) || defined(__OSX__)) && (defined(__GNUC__) && (__GNUC__ > 2 || (__GNUC__ == 2 && (__GNUC_MINOR__ > 95)))))
                 #undef likely
@@ -3366,36 +3369,35 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_10is_symmetric_and_ho
                 #define likely(x)   (x)
                 #define unlikely(x) (x)
             #endif
-            __pyx_t_3 = (__pyx_t_1 - 0 + 64 - 64/abs(64)) / 64;
+            __pyx_t_3 = (__pyx_t_1 - 0 + 24 - 24/abs(24)) / 24;
             if (__pyx_t_3 > 0)
             {
                 #ifdef _OPENMP
-                #pragma omp parallel reduction(&:__pyx_v_is_hollow) reduction(&:__pyx_v_is_sym) private(__pyx_t_10, __pyx_t_11, __pyx_t_12, __pyx_t_13, __pyx_t_14, __pyx_t_15, __pyx_t_4, __pyx_t_5, __pyx_t_6, __pyx_t_7, __pyx_t_8, __pyx_t_9)
+                #pragma omp parallel reduction(&:__pyx_v_is_hollow) reduction(&:__pyx_v_is_sym) private(__pyx_t_10, __pyx_t_11, __pyx_t_12, __pyx_t_13, __pyx_t_14, __pyx_t_15, __pyx_t_16, __pyx_t_17, __pyx_t_4, __pyx_t_5, __pyx_t_6, __pyx_t_7, __pyx_t_8, __pyx_t_9)
                 #endif /* _OPENMP */
                 {
                     #ifdef _OPENMP
-                    #pragma omp for lastprivate(__pyx_v_col) lastprivate(__pyx_v_row) lastprivate(__pyx_v_tcol) lastprivate(__pyx_v_tcol_max) lastprivate(__pyx_v_testval) firstprivate(__pyx_v_trow) lastprivate(__pyx_v_trow) lastprivate(__pyx_v_trow_max)
+                    #pragma omp for lastprivate(__pyx_v_col) lastprivate(__pyx_v_row) lastprivate(__pyx_v_tcol) lastprivate(__pyx_v_tcol_max) firstprivate(__pyx_v_trow) lastprivate(__pyx_v_trow) lastprivate(__pyx_v_trow_max)
                     #endif /* _OPENMP */
                     for (__pyx_t_2 = 0; __pyx_t_2 < __pyx_t_3; __pyx_t_2++){
                         {
-                            __pyx_v_trow = (Py_ssize_t)(0 + 64 * __pyx_t_2);
+                            __pyx_v_trow = (Py_ssize_t)(0 + 24 * __pyx_t_2);
                             /* Initialize private variables to invalid values */
                             __pyx_v_col = ((Py_ssize_t)0xbad0bad0);
                             __pyx_v_row = ((Py_ssize_t)0xbad0bad0);
                             __pyx_v_tcol = ((Py_ssize_t)0xbad0bad0);
                             __pyx_v_tcol_max = ((Py_ssize_t)0xbad0bad0);
-                            __pyx_v_testval = ((double)__PYX_NAN());
                             __pyx_v_trow_max = ((Py_ssize_t)0xbad0bad0);
 
                             /* "skbio/stats/distance/_cutils.pyx":56
  *     # use a tiled approach to maximize memory locality
- *     for trow in prange(0, in_n, 64, nogil=True):
- *         trow_max = min(trow+64, in_n)             # <<<<<<<<<<<<<<
- *         for tcol in range(0, in_n, 64):
- *             tcol_max = min(tcol+64, in_n)
+ *     for trow in prange(0, in_n, 24, nogil=True):
+ *         trow_max = min(trow+24, in_n)             # <<<<<<<<<<<<<<
+ *         for tcol in range(0, in_n, 24):
+ *             tcol_max = min(tcol+24, in_n)
  */
                             __pyx_t_4 = __pyx_v_in_n;
-                            __pyx_t_5 = (__pyx_v_trow + 64);
+                            __pyx_t_5 = (__pyx_v_trow + 24);
                             if (((__pyx_t_4 < __pyx_t_5) != 0)) {
                               __pyx_t_6 = __pyx_t_4;
                             } else {
@@ -3404,26 +3406,26 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_10is_symmetric_and_ho
                             __pyx_v_trow_max = __pyx_t_6;
 
                             /* "skbio/stats/distance/_cutils.pyx":57
- *     for trow in prange(0, in_n, 64, nogil=True):
- *         trow_max = min(trow+64, in_n)
- *         for tcol in range(0, in_n, 64):             # <<<<<<<<<<<<<<
- *             tcol_max = min(tcol+64, in_n)
+ *     for trow in prange(0, in_n, 24, nogil=True):
+ *         trow_max = min(trow+24, in_n)
+ *         for tcol in range(0, in_n, 24):             # <<<<<<<<<<<<<<
+ *             tcol_max = min(tcol+24, in_n)
  *             for row in range(trow, trow_max, 1):
  */
                             __pyx_t_6 = __pyx_v_in_n;
                             __pyx_t_4 = __pyx_t_6;
-                            for (__pyx_t_5 = 0; __pyx_t_5 < __pyx_t_4; __pyx_t_5+=64) {
+                            for (__pyx_t_5 = 0; __pyx_t_5 < __pyx_t_4; __pyx_t_5+=24) {
                               __pyx_v_tcol = __pyx_t_5;
 
                               /* "skbio/stats/distance/_cutils.pyx":58
- *         trow_max = min(trow+64, in_n)
- *         for tcol in range(0, in_n, 64):
- *             tcol_max = min(tcol+64, in_n)             # <<<<<<<<<<<<<<
+ *         trow_max = min(trow+24, in_n)
+ *         for tcol in range(0, in_n, 24):
+ *             tcol_max = min(tcol+24, in_n)             # <<<<<<<<<<<<<<
  *             for row in range(trow, trow_max, 1):
  *                 for col in range(tcol, tcol_max, 1):
  */
                               __pyx_t_7 = __pyx_v_in_n;
-                              __pyx_t_8 = (__pyx_v_tcol + 64);
+                              __pyx_t_8 = (__pyx_v_tcol + 24);
                               if (((__pyx_t_7 < __pyx_t_8) != 0)) {
                                 __pyx_t_9 = __pyx_t_7;
                               } else {
@@ -3432,11 +3434,11 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_10is_symmetric_and_ho
                               __pyx_v_tcol_max = __pyx_t_9;
 
                               /* "skbio/stats/distance/_cutils.pyx":59
- *         for tcol in range(0, in_n, 64):
- *             tcol_max = min(tcol+64, in_n)
+ *         for tcol in range(0, in_n, 24):
+ *             tcol_max = min(tcol+24, in_n)
  *             for row in range(trow, trow_max, 1):             # <<<<<<<<<<<<<<
  *                 for col in range(tcol, tcol_max, 1):
- *                    testval = mat[row,col]
+ *                    is_sym &= (mat[row,col]==mat[col,row])
  */
                               __pyx_t_9 = __pyx_v_trow_max;
                               __pyx_t_7 = __pyx_t_9;
@@ -3444,11 +3446,11 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_10is_symmetric_and_ho
                                 __pyx_v_row = __pyx_t_8;
 
                                 /* "skbio/stats/distance/_cutils.pyx":60
- *             tcol_max = min(tcol+64, in_n)
+ *             tcol_max = min(tcol+24, in_n)
  *             for row in range(trow, trow_max, 1):
  *                 for col in range(tcol, tcol_max, 1):             # <<<<<<<<<<<<<<
- *                    testval = mat[row,col]
- *                    if (row==col):
+ *                    is_sym &= (mat[row,col]==mat[col,row])
+ *             if (trow==tcol): # diagonal block, only ones that can have col==row
  */
                                 __pyx_t_10 = __pyx_v_tcol_max;
                                 __pyx_t_11 = __pyx_t_10;
@@ -3458,57 +3460,59 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_10is_symmetric_and_ho
                                   /* "skbio/stats/distance/_cutils.pyx":61
  *             for row in range(trow, trow_max, 1):
  *                 for col in range(tcol, tcol_max, 1):
- *                    testval = mat[row,col]             # <<<<<<<<<<<<<<
- *                    if (row==col):
- *                        # diagonal elements are always symmetric,
+ *                    is_sym &= (mat[row,col]==mat[col,row])             # <<<<<<<<<<<<<<
+ *             if (trow==tcol): # diagonal block, only ones that can have col==row
+ *                 for col in range(tcol, tcol_max, 1):
  */
                                   __pyx_t_13 = __pyx_v_row;
                                   __pyx_t_14 = __pyx_v_col;
-                                  __pyx_v_testval = (*((double *) ( /* dim=1 */ ((char *) (((double *) ( /* dim=0 */ (__pyx_v_mat.data + __pyx_t_13 * __pyx_v_mat.strides[0]) )) + __pyx_t_14)) )));
+                                  __pyx_t_15 = __pyx_v_col;
+                                  __pyx_t_16 = __pyx_v_row;
+                                  __pyx_v_is_sym = (__pyx_v_is_sym & ((*((double *) ( /* dim=1 */ ((char *) (((double *) ( /* dim=0 */ (__pyx_v_mat.data + __pyx_t_13 * __pyx_v_mat.strides[0]) )) + __pyx_t_14)) ))) == (*((double *) ( /* dim=1 */ ((char *) (((double *) ( /* dim=0 */ (__pyx_v_mat.data + __pyx_t_15 * __pyx_v_mat.strides[0]) )) + __pyx_t_16)) )))));
+                                }
+                              }
 
-                                  /* "skbio/stats/distance/_cutils.pyx":62
+                              /* "skbio/stats/distance/_cutils.pyx":62
  *                 for col in range(tcol, tcol_max, 1):
- *                    testval = mat[row,col]
- *                    if (row==col):             # <<<<<<<<<<<<<<
- *                        # diagonal elements are always symmetric,
- *                        # so no need to check
- */
-                                  __pyx_t_15 = ((__pyx_v_row == __pyx_v_col) != 0);
-                                  if (__pyx_t_15) {
-
-                                    /* "skbio/stats/distance/_cutils.pyx":65
- *                        # diagonal elements are always symmetric,
- *                        # so no need to check
- *                        is_hollow &= (testval==0)             # <<<<<<<<<<<<<<
- *                    else:
- *                        is_sym &= (testval==mat[col,row])
- */
-                                    __pyx_v_is_hollow = (__pyx_v_is_hollow & (__pyx_v_testval == 0.0));
-
-                                    /* "skbio/stats/distance/_cutils.pyx":62
+ *                    is_sym &= (mat[row,col]==mat[col,row])
+ *             if (trow==tcol): # diagonal block, only ones that can have col==row             # <<<<<<<<<<<<<<
  *                 for col in range(tcol, tcol_max, 1):
- *                    testval = mat[row,col]
- *                    if (row==col):             # <<<<<<<<<<<<<<
- *                        # diagonal elements are always symmetric,
- *                        # so no need to check
+ *                    is_hollow &= (mat[col,col]==0)
  */
-                                    goto __pyx_L16;
-                                  }
+                              __pyx_t_17 = ((__pyx_v_trow == __pyx_v_tcol) != 0);
+                              if (__pyx_t_17) {
 
-                                  /* "skbio/stats/distance/_cutils.pyx":67
- *                        is_hollow &= (testval==0)
- *                    else:
- *                        is_sym &= (testval==mat[col,row])             # <<<<<<<<<<<<<<
+                                /* "skbio/stats/distance/_cutils.pyx":63
+ *                    is_sym &= (mat[row,col]==mat[col,row])
+ *             if (trow==tcol): # diagonal block, only ones that can have col==row
+ *                 for col in range(tcol, tcol_max, 1):             # <<<<<<<<<<<<<<
+ *                    is_hollow &= (mat[col,col]==0)
+ * 
+ */
+                                __pyx_t_9 = __pyx_v_tcol_max;
+                                __pyx_t_7 = __pyx_t_9;
+                                for (__pyx_t_8 = __pyx_v_tcol; __pyx_t_8 < __pyx_t_7; __pyx_t_8+=1) {
+                                  __pyx_v_col = __pyx_t_8;
+
+                                  /* "skbio/stats/distance/_cutils.pyx":64
+ *             if (trow==tcol): # diagonal block, only ones that can have col==row
+ *                 for col in range(tcol, tcol_max, 1):
+ *                    is_hollow &= (mat[col,col]==0)             # <<<<<<<<<<<<<<
  * 
  *     return [(is_sym==True), (is_hollow==True)]
  */
-                                  /*else*/ {
-                                    __pyx_t_14 = __pyx_v_col;
-                                    __pyx_t_13 = __pyx_v_row;
-                                    __pyx_v_is_sym = (__pyx_v_is_sym & (__pyx_v_testval == (*((double *) ( /* dim=1 */ ((char *) (((double *) ( /* dim=0 */ (__pyx_v_mat.data + __pyx_t_14 * __pyx_v_mat.strides[0]) )) + __pyx_t_13)) )))));
-                                  }
-                                  __pyx_L16:;
+                                  __pyx_t_16 = __pyx_v_col;
+                                  __pyx_t_15 = __pyx_v_col;
+                                  __pyx_v_is_hollow = (__pyx_v_is_hollow & ((*((double *) ( /* dim=1 */ ((char *) (((double *) ( /* dim=0 */ (__pyx_v_mat.data + __pyx_t_16 * __pyx_v_mat.strides[0]) )) + __pyx_t_15)) ))) == 0.0));
                                 }
+
+                                /* "skbio/stats/distance/_cutils.pyx":62
+ *                 for col in range(tcol, tcol_max, 1):
+ *                    is_sym &= (mat[row,col]==mat[col,row])
+ *             if (trow==tcol): # diagonal block, only ones that can have col==row             # <<<<<<<<<<<<<<
+ *                 for col in range(tcol, tcol_max, 1):
+ *                    is_hollow &= (mat[col,col]==0)
+ */
                               }
                             }
                         }
@@ -3527,9 +3531,9 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_10is_symmetric_and_ho
       /* "skbio/stats/distance/_cutils.pyx":55
  * 
  *     # use a tiled approach to maximize memory locality
- *     for trow in prange(0, in_n, 64, nogil=True):             # <<<<<<<<<<<<<<
- *         trow_max = min(trow+64, in_n)
- *         for tcol in range(0, in_n, 64):
+ *     for trow in prange(0, in_n, 24, nogil=True):             # <<<<<<<<<<<<<<
+ *         trow_max = min(trow+24, in_n)
+ *         for tcol in range(0, in_n, 24):
  */
       /*finally:*/ {
         /*normal exit:*/{
@@ -3543,28 +3547,28 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_10is_symmetric_and_ho
       }
   }
 
-  /* "skbio/stats/distance/_cutils.pyx":69
- *                        is_sym &= (testval==mat[col,row])
+  /* "skbio/stats/distance/_cutils.pyx":66
+ *                    is_hollow &= (mat[col,col]==0)
  * 
  *     return [(is_sym==True), (is_hollow==True)]             # <<<<<<<<<<<<<<
  * 
  * 
  */
   __Pyx_XDECREF(__pyx_r);
-  __pyx_t_16 = __Pyx_PyBool_FromLong((__pyx_v_is_sym == 1)); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 69, __pyx_L1_error)
-  __Pyx_GOTREF(__pyx_t_16);
-  __pyx_t_17 = __Pyx_PyBool_FromLong((__pyx_v_is_hollow == 1)); if (unlikely(!__pyx_t_17)) __PYX_ERR(0, 69, __pyx_L1_error)
-  __Pyx_GOTREF(__pyx_t_17);
-  __pyx_t_18 = PyList_New(2); if (unlikely(!__pyx_t_18)) __PYX_ERR(0, 69, __pyx_L1_error)
+  __pyx_t_18 = __Pyx_PyBool_FromLong((__pyx_v_is_sym == 1)); if (unlikely(!__pyx_t_18)) __PYX_ERR(0, 66, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_18);
-  __Pyx_GIVEREF(__pyx_t_16);
-  PyList_SET_ITEM(__pyx_t_18, 0, __pyx_t_16);
-  __Pyx_GIVEREF(__pyx_t_17);
-  PyList_SET_ITEM(__pyx_t_18, 1, __pyx_t_17);
-  __pyx_t_16 = 0;
-  __pyx_t_17 = 0;
-  __pyx_r = __pyx_t_18;
+  __pyx_t_19 = __Pyx_PyBool_FromLong((__pyx_v_is_hollow == 1)); if (unlikely(!__pyx_t_19)) __PYX_ERR(0, 66, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_t_19);
+  __pyx_t_20 = PyList_New(2); if (unlikely(!__pyx_t_20)) __PYX_ERR(0, 66, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_t_20);
+  __Pyx_GIVEREF(__pyx_t_18);
+  PyList_SET_ITEM(__pyx_t_20, 0, __pyx_t_18);
+  __Pyx_GIVEREF(__pyx_t_19);
+  PyList_SET_ITEM(__pyx_t_20, 1, __pyx_t_19);
   __pyx_t_18 = 0;
+  __pyx_t_19 = 0;
+  __pyx_r = __pyx_t_20;
+  __pyx_t_20 = 0;
   goto __pyx_L0;
 
   /* "skbio/stats/distance/_cutils.pyx":22
@@ -3577,9 +3581,9 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_10is_symmetric_and_ho
 
   /* function exit code */
   __pyx_L1_error:;
-  __Pyx_XDECREF(__pyx_t_16);
-  __Pyx_XDECREF(__pyx_t_17);
   __Pyx_XDECREF(__pyx_t_18);
+  __Pyx_XDECREF(__pyx_t_19);
+  __Pyx_XDECREF(__pyx_t_20);
   __Pyx_AddTraceback("skbio.stats.distance._cutils.is_symmetric_and_hollow_cy", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __pyx_r = NULL;
   __pyx_L0:;
@@ -3589,7 +3593,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_10is_symmetric_and_ho
   return __pyx_r;
 }
 
-/* "skbio/stats/distance/_cutils.pyx":74
+/* "skbio/stats/distance/_cutils.pyx":71
  * @cython.boundscheck(False)
  * @cython.wraparound(False)
  * def distmat_reorder_cy(TReal[:, ::1] in_mat, long[::1] reorder_vec,             # <<<<<<<<<<<<<<
@@ -3639,23 +3643,23 @@ static PyObject *__pyx_pw_5skbio_5stats_8distance_7_cutils_3distmat_reorder_cy(P
         case  1:
         if (likely((values[1] = __Pyx_PyDict_GetItemStr(__pyx_kwds, __pyx_n_s_args)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("__pyx_fused_cpdef", 1, 4, 4, 1); __PYX_ERR(0, 74, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("__pyx_fused_cpdef", 1, 4, 4, 1); __PYX_ERR(0, 71, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  2:
         if (likely((values[2] = __Pyx_PyDict_GetItemStr(__pyx_kwds, __pyx_n_s_kwargs)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("__pyx_fused_cpdef", 1, 4, 4, 2); __PYX_ERR(0, 74, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("__pyx_fused_cpdef", 1, 4, 4, 2); __PYX_ERR(0, 71, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  3:
         if (likely((values[3] = __Pyx_PyDict_GetItemStr(__pyx_kwds, __pyx_n_s_defaults)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("__pyx_fused_cpdef", 1, 4, 4, 3); __PYX_ERR(0, 74, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("__pyx_fused_cpdef", 1, 4, 4, 3); __PYX_ERR(0, 71, __pyx_L3_error)
         }
       }
       if (unlikely(kw_args > 0)) {
-        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "__pyx_fused_cpdef") < 0)) __PYX_ERR(0, 74, __pyx_L3_error)
+        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "__pyx_fused_cpdef") < 0)) __PYX_ERR(0, 71, __pyx_L3_error)
       }
     } else if (PyTuple_GET_SIZE(__pyx_args) != 4) {
       goto __pyx_L5_argtuple_error;
@@ -3672,7 +3676,7 @@ static PyObject *__pyx_pw_5skbio_5stats_8distance_7_cutils_3distmat_reorder_cy(P
   }
   goto __pyx_L4_argument_unpacking_done;
   __pyx_L5_argtuple_error:;
-  __Pyx_RaiseArgtupleInvalid("__pyx_fused_cpdef", 1, 4, 4, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 74, __pyx_L3_error)
+  __Pyx_RaiseArgtupleInvalid("__pyx_fused_cpdef", 1, 4, 4, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 71, __pyx_L3_error)
   __pyx_L3_error:;
   __Pyx_AddTraceback("skbio.stats.distance._cutils.__pyx_fused_cpdef", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __Pyx_RefNannyFinishContext();
@@ -3726,7 +3730,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_2distmat_reorder_cy(C
   int __pyx_clineno = 0;
   __Pyx_RefNannySetupContext("distmat_reorder_cy", 0);
   __Pyx_INCREF(__pyx_v_kwargs);
-  __pyx_t_1 = PyList_New(1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 74, __pyx_L1_error)
+  __pyx_t_1 = PyList_New(1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 71, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __Pyx_INCREF(Py_None);
   __Pyx_GIVEREF(Py_None);
@@ -3740,7 +3744,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_2distmat_reorder_cy(C
     __pyx_t_2 = __pyx_t_4;
     goto __pyx_L4_bool_binop_done;
   }
-  __pyx_t_4 = __Pyx_PyObject_IsTrue(__pyx_v_kwargs); if (unlikely(__pyx_t_4 < 0)) __PYX_ERR(0, 74, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_PyObject_IsTrue(__pyx_v_kwargs); if (unlikely(__pyx_t_4 < 0)) __PYX_ERR(0, 71, __pyx_L1_error)
   __pyx_t_3 = ((!__pyx_t_4) != 0);
   __pyx_t_2 = __pyx_t_3;
   __pyx_L4_bool_binop_done:;
@@ -3748,21 +3752,21 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_2distmat_reorder_cy(C
     __Pyx_INCREF(Py_None);
     __Pyx_DECREF_SET(__pyx_v_kwargs, Py_None);
   }
-  __pyx_t_1 = ((PyObject *)__Pyx_ImportNumPyArrayTypeIfAvailable()); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 74, __pyx_L1_error)
+  __pyx_t_1 = ((PyObject *)__Pyx_ImportNumPyArrayTypeIfAvailable()); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 71, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __pyx_v_ndarray = ((PyTypeObject*)__pyx_t_1);
   __pyx_t_1 = 0;
   __pyx_v_itemsize = -1L;
   if (unlikely(__pyx_v_args == Py_None)) {
     PyErr_SetString(PyExc_TypeError, "object of type 'NoneType' has no len()");
-    __PYX_ERR(0, 74, __pyx_L1_error)
+    __PYX_ERR(0, 71, __pyx_L1_error)
   }
-  __pyx_t_5 = PyTuple_GET_SIZE(((PyObject*)__pyx_v_args)); if (unlikely(__pyx_t_5 == ((Py_ssize_t)-1))) __PYX_ERR(0, 74, __pyx_L1_error)
+  __pyx_t_5 = PyTuple_GET_SIZE(((PyObject*)__pyx_v_args)); if (unlikely(__pyx_t_5 == ((Py_ssize_t)-1))) __PYX_ERR(0, 71, __pyx_L1_error)
   __pyx_t_2 = ((0 < __pyx_t_5) != 0);
   if (__pyx_t_2) {
     if (unlikely(__pyx_v_args == Py_None)) {
       PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-      __PYX_ERR(0, 74, __pyx_L1_error)
+      __PYX_ERR(0, 71, __pyx_L1_error)
     }
     __pyx_t_1 = PyTuple_GET_ITEM(((PyObject*)__pyx_v_args), 0);
     __Pyx_INCREF(__pyx_t_1);
@@ -3779,18 +3783,18 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_2distmat_reorder_cy(C
   }
   if (unlikely(__pyx_v_kwargs == Py_None)) {
     PyErr_SetString(PyExc_TypeError, "'NoneType' object is not iterable");
-    __PYX_ERR(0, 74, __pyx_L1_error)
+    __PYX_ERR(0, 71, __pyx_L1_error)
   }
-  __pyx_t_4 = (__Pyx_PyDict_ContainsTF(__pyx_n_s_in_mat, ((PyObject*)__pyx_v_kwargs), Py_EQ)); if (unlikely(__pyx_t_4 < 0)) __PYX_ERR(0, 74, __pyx_L1_error)
+  __pyx_t_4 = (__Pyx_PyDict_ContainsTF(__pyx_n_s_in_mat, ((PyObject*)__pyx_v_kwargs), Py_EQ)); if (unlikely(__pyx_t_4 < 0)) __PYX_ERR(0, 71, __pyx_L1_error)
   __pyx_t_3 = (__pyx_t_4 != 0);
   __pyx_t_2 = __pyx_t_3;
   __pyx_L7_bool_binop_done:;
   if (__pyx_t_2) {
     if (unlikely(__pyx_v_kwargs == Py_None)) {
       PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-      __PYX_ERR(0, 74, __pyx_L1_error)
+      __PYX_ERR(0, 71, __pyx_L1_error)
     }
-    __pyx_t_1 = __Pyx_PyDict_GetItem(((PyObject*)__pyx_v_kwargs), __pyx_n_s_in_mat); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 74, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_PyDict_GetItem(((PyObject*)__pyx_v_kwargs), __pyx_n_s_in_mat); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 71, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
     __pyx_v_arg = __pyx_t_1;
     __pyx_t_1 = 0;
@@ -3799,12 +3803,12 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_2distmat_reorder_cy(C
   /*else*/ {
     if (unlikely(__pyx_v_args == Py_None)) {
       PyErr_SetString(PyExc_TypeError, "object of type 'NoneType' has no len()");
-      __PYX_ERR(0, 74, __pyx_L1_error)
+      __PYX_ERR(0, 71, __pyx_L1_error)
     }
-    __pyx_t_5 = PyTuple_GET_SIZE(((PyObject*)__pyx_v_args)); if (unlikely(__pyx_t_5 == ((Py_ssize_t)-1))) __PYX_ERR(0, 74, __pyx_L1_error)
-    __pyx_t_1 = PyInt_FromSsize_t(__pyx_t_5); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 74, __pyx_L1_error)
+    __pyx_t_5 = PyTuple_GET_SIZE(((PyObject*)__pyx_v_args)); if (unlikely(__pyx_t_5 == ((Py_ssize_t)-1))) __PYX_ERR(0, 71, __pyx_L1_error)
+    __pyx_t_1 = PyInt_FromSsize_t(__pyx_t_5); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 71, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
-    __pyx_t_6 = PyTuple_New(3); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 74, __pyx_L1_error)
+    __pyx_t_6 = PyTuple_New(3); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 71, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_6);
     __Pyx_INCREF(__pyx_int_3);
     __Pyx_GIVEREF(__pyx_int_3);
@@ -3815,15 +3819,15 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_2distmat_reorder_cy(C
     __Pyx_GIVEREF(__pyx_t_1);
     PyTuple_SET_ITEM(__pyx_t_6, 2, __pyx_t_1);
     __pyx_t_1 = 0;
-    __pyx_t_1 = __Pyx_PyString_Format(__pyx_kp_s_Expected_at_least_d_argument_s_g, __pyx_t_6); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 74, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_PyString_Format(__pyx_kp_s_Expected_at_least_d_argument_s_g, __pyx_t_6); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 71, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
-    __pyx_t_6 = __Pyx_PyObject_CallOneArg(__pyx_builtin_TypeError, __pyx_t_1); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 74, __pyx_L1_error)
+    __pyx_t_6 = __Pyx_PyObject_CallOneArg(__pyx_builtin_TypeError, __pyx_t_1); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 71, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_6);
     __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
     __Pyx_Raise(__pyx_t_6, 0, 0, 0);
     __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
-    __PYX_ERR(0, 74, __pyx_L1_error)
+    __PYX_ERR(0, 71, __pyx_L1_error)
   }
   __pyx_L6:;
   while (1) {
@@ -3833,7 +3837,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_2distmat_reorder_cy(C
       __pyx_t_3 = __Pyx_TypeCheck(__pyx_v_arg, __pyx_v_ndarray); 
       __pyx_t_2 = (__pyx_t_3 != 0);
       if (__pyx_t_2) {
-        __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_dtype); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 74, __pyx_L1_error)
+        __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_dtype); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 71, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_6);
         __pyx_v_dtype = __pyx_t_6;
         __pyx_t_6 = 0;
@@ -3842,14 +3846,14 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_2distmat_reorder_cy(C
       __pyx_t_2 = __pyx_memoryview_check(__pyx_v_arg); 
       __pyx_t_3 = (__pyx_t_2 != 0);
       if (__pyx_t_3) {
-        __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_base); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 74, __pyx_L1_error)
+        __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_base); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 71, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_6);
         __pyx_v_arg_base = __pyx_t_6;
         __pyx_t_6 = 0;
         __pyx_t_3 = __Pyx_TypeCheck(__pyx_v_arg_base, __pyx_v_ndarray); 
         __pyx_t_2 = (__pyx_t_3 != 0);
         if (__pyx_t_2) {
-          __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg_base, __pyx_n_s_dtype); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 74, __pyx_L1_error)
+          __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg_base, __pyx_n_s_dtype); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 71, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_6);
           __pyx_v_dtype = __pyx_t_6;
           __pyx_t_6 = 0;
@@ -3871,14 +3875,14 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_2distmat_reorder_cy(C
       __pyx_t_2 = (__pyx_v_dtype != Py_None);
       __pyx_t_3 = (__pyx_t_2 != 0);
       if (__pyx_t_3) {
-        __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_v_dtype, __pyx_n_s_itemsize); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 74, __pyx_L1_error)
+        __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_v_dtype, __pyx_n_s_itemsize); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 71, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_6);
-        __pyx_t_5 = __Pyx_PyIndex_AsSsize_t(__pyx_t_6); if (unlikely((__pyx_t_5 == (Py_ssize_t)-1) && PyErr_Occurred())) __PYX_ERR(0, 74, __pyx_L1_error)
+        __pyx_t_5 = __Pyx_PyIndex_AsSsize_t(__pyx_t_6); if (unlikely((__pyx_t_5 == (Py_ssize_t)-1) && PyErr_Occurred())) __PYX_ERR(0, 71, __pyx_L1_error)
         __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
         __pyx_v_itemsize = __pyx_t_5;
-        __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_v_dtype, __pyx_n_s_kind); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 74, __pyx_L1_error)
+        __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_v_dtype, __pyx_n_s_kind); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 71, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_6);
-        __pyx_t_7 = __Pyx_PyObject_Ord(__pyx_t_6); if (unlikely(__pyx_t_7 == ((long)(long)(Py_UCS4)-1))) __PYX_ERR(0, 74, __pyx_L1_error)
+        __pyx_t_7 = __Pyx_PyObject_Ord(__pyx_t_6); if (unlikely(__pyx_t_7 == ((long)(long)(Py_UCS4)-1))) __PYX_ERR(0, 71, __pyx_L1_error)
         __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
         __pyx_v_kind = __pyx_t_7;
         __pyx_v_dtype_signed = (__pyx_v_kind == 'i');
@@ -3893,15 +3897,15 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_2distmat_reorder_cy(C
             __pyx_t_3 = __pyx_t_2;
             goto __pyx_L16_bool_binop_done;
           }
-          __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_ndim); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 74, __pyx_L1_error)
+          __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_ndim); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 71, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_6);
-          __pyx_t_5 = __Pyx_PyIndex_AsSsize_t(__pyx_t_6); if (unlikely((__pyx_t_5 == (Py_ssize_t)-1) && PyErr_Occurred())) __PYX_ERR(0, 74, __pyx_L1_error)
+          __pyx_t_5 = __Pyx_PyIndex_AsSsize_t(__pyx_t_6); if (unlikely((__pyx_t_5 == (Py_ssize_t)-1) && PyErr_Occurred())) __PYX_ERR(0, 71, __pyx_L1_error)
           __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
           __pyx_t_2 = ((((Py_ssize_t)__pyx_t_5) == 2) != 0);
           __pyx_t_3 = __pyx_t_2;
           __pyx_L16_bool_binop_done:;
           if (__pyx_t_3) {
-            if (unlikely(__Pyx_SetItemInt(__pyx_v_dest_sig, 0, __pyx_n_s_float, long, 1, __Pyx_PyInt_From_long, 1, 0, 0) < 0)) __PYX_ERR(0, 74, __pyx_L1_error)
+            if (unlikely(__Pyx_SetItemInt(__pyx_v_dest_sig, 0, __pyx_n_s_float, long, 1, __Pyx_PyInt_From_long, 1, 0, 0) < 0)) __PYX_ERR(0, 71, __pyx_L1_error)
             goto __pyx_L10_break;
           }
           __pyx_t_2 = (((sizeof(double)) == __pyx_v_itemsize) != 0);
@@ -3910,15 +3914,15 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_2distmat_reorder_cy(C
             __pyx_t_3 = __pyx_t_2;
             goto __pyx_L19_bool_binop_done;
           }
-          __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_ndim); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 74, __pyx_L1_error)
+          __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_ndim); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 71, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_6);
-          __pyx_t_5 = __Pyx_PyIndex_AsSsize_t(__pyx_t_6); if (unlikely((__pyx_t_5 == (Py_ssize_t)-1) && PyErr_Occurred())) __PYX_ERR(0, 74, __pyx_L1_error)
+          __pyx_t_5 = __Pyx_PyIndex_AsSsize_t(__pyx_t_6); if (unlikely((__pyx_t_5 == (Py_ssize_t)-1) && PyErr_Occurred())) __PYX_ERR(0, 71, __pyx_L1_error)
           __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
           __pyx_t_2 = ((((Py_ssize_t)__pyx_t_5) == 2) != 0);
           __pyx_t_3 = __pyx_t_2;
           __pyx_L19_bool_binop_done:;
           if (__pyx_t_3) {
-            if (unlikely(__Pyx_SetItemInt(__pyx_v_dest_sig, 0, __pyx_n_s_double, long, 1, __Pyx_PyInt_From_long, 1, 0, 0) < 0)) __PYX_ERR(0, 74, __pyx_L1_error)
+            if (unlikely(__Pyx_SetItemInt(__pyx_v_dest_sig, 0, __pyx_n_s_double, long, 1, __Pyx_PyInt_From_long, 1, 0, 0) < 0)) __PYX_ERR(0, 71, __pyx_L1_error)
             goto __pyx_L10_break;
           }
           break;
@@ -3945,7 +3949,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_2distmat_reorder_cy(C
       __pyx_t_3 = (__pyx_v_memslice.memview != 0);
       if (__pyx_t_3) {
         __PYX_XDEC_MEMVIEW((&__pyx_v_memslice), 1); 
-        if (unlikely(__Pyx_SetItemInt(__pyx_v_dest_sig, 0, __pyx_n_s_float, long, 1, __Pyx_PyInt_From_long, 1, 0, 0) < 0)) __PYX_ERR(0, 74, __pyx_L1_error)
+        if (unlikely(__Pyx_SetItemInt(__pyx_v_dest_sig, 0, __pyx_n_s_float, long, 1, __Pyx_PyInt_From_long, 1, 0, 0) < 0)) __PYX_ERR(0, 71, __pyx_L1_error)
         goto __pyx_L10_break;
       }
       /*else*/ {
@@ -3967,27 +3971,27 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_2distmat_reorder_cy(C
       __pyx_t_3 = (__pyx_v_memslice.memview != 0);
       if (__pyx_t_3) {
         __PYX_XDEC_MEMVIEW((&__pyx_v_memslice), 1); 
-        if (unlikely(__Pyx_SetItemInt(__pyx_v_dest_sig, 0, __pyx_n_s_double, long, 1, __Pyx_PyInt_From_long, 1, 0, 0) < 0)) __PYX_ERR(0, 74, __pyx_L1_error)
+        if (unlikely(__Pyx_SetItemInt(__pyx_v_dest_sig, 0, __pyx_n_s_double, long, 1, __Pyx_PyInt_From_long, 1, 0, 0) < 0)) __PYX_ERR(0, 71, __pyx_L1_error)
         goto __pyx_L10_break;
       }
       /*else*/ {
         PyErr_Clear(); 
       }
     }
-    if (unlikely(__Pyx_SetItemInt(__pyx_v_dest_sig, 0, Py_None, long, 1, __Pyx_PyInt_From_long, 1, 0, 0) < 0)) __PYX_ERR(0, 74, __pyx_L1_error)
+    if (unlikely(__Pyx_SetItemInt(__pyx_v_dest_sig, 0, Py_None, long, 1, __Pyx_PyInt_From_long, 1, 0, 0) < 0)) __PYX_ERR(0, 71, __pyx_L1_error)
     goto __pyx_L10_break;
   }
   __pyx_L10_break:;
-  __pyx_t_6 = PyList_New(0); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 74, __pyx_L1_error)
+  __pyx_t_6 = PyList_New(0); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 71, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_6);
   __pyx_v_candidates = ((PyObject*)__pyx_t_6);
   __pyx_t_6 = 0;
   __pyx_t_5 = 0;
   if (unlikely(__pyx_v_signatures == Py_None)) {
     PyErr_SetString(PyExc_TypeError, "'NoneType' object is not iterable");
-    __PYX_ERR(0, 74, __pyx_L1_error)
+    __PYX_ERR(0, 71, __pyx_L1_error)
   }
-  __pyx_t_1 = __Pyx_dict_iterator(((PyObject*)__pyx_v_signatures), 1, ((PyObject *)NULL), (&__pyx_t_9), (&__pyx_t_10)); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 74, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_dict_iterator(((PyObject*)__pyx_v_signatures), 1, ((PyObject *)NULL), (&__pyx_t_9), (&__pyx_t_10)); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 71, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __Pyx_XDECREF(__pyx_t_6);
   __pyx_t_6 = __pyx_t_1;
@@ -3995,12 +3999,12 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_2distmat_reorder_cy(C
   while (1) {
     __pyx_t_11 = __Pyx_dict_iter_next(__pyx_t_6, __pyx_t_9, &__pyx_t_5, &__pyx_t_1, NULL, NULL, __pyx_t_10);
     if (unlikely(__pyx_t_11 == 0)) break;
-    if (unlikely(__pyx_t_11 == -1)) __PYX_ERR(0, 74, __pyx_L1_error)
+    if (unlikely(__pyx_t_11 == -1)) __PYX_ERR(0, 71, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_XDECREF_SET(__pyx_v_sig, __pyx_t_1);
     __pyx_t_1 = 0;
     __pyx_v_match_found = 0;
-    __pyx_t_13 = __Pyx_PyObject_GetAttrStr(__pyx_v_sig, __pyx_n_s_strip); if (unlikely(!__pyx_t_13)) __PYX_ERR(0, 74, __pyx_L1_error)
+    __pyx_t_13 = __Pyx_PyObject_GetAttrStr(__pyx_v_sig, __pyx_n_s_strip); if (unlikely(!__pyx_t_13)) __PYX_ERR(0, 71, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_13);
     __pyx_t_14 = NULL;
     if (CYTHON_UNPACK_METHODS && likely(PyMethod_Check(__pyx_t_13))) {
@@ -4014,10 +4018,10 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_2distmat_reorder_cy(C
     }
     __pyx_t_12 = (__pyx_t_14) ? __Pyx_PyObject_Call2Args(__pyx_t_13, __pyx_t_14, __pyx_kp_s__2) : __Pyx_PyObject_CallOneArg(__pyx_t_13, __pyx_kp_s__2);
     __Pyx_XDECREF(__pyx_t_14); __pyx_t_14 = 0;
-    if (unlikely(!__pyx_t_12)) __PYX_ERR(0, 74, __pyx_L1_error)
+    if (unlikely(!__pyx_t_12)) __PYX_ERR(0, 71, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_12);
     __Pyx_DECREF(__pyx_t_13); __pyx_t_13 = 0;
-    __pyx_t_13 = __Pyx_PyObject_GetAttrStr(__pyx_t_12, __pyx_n_s_split); if (unlikely(!__pyx_t_13)) __PYX_ERR(0, 74, __pyx_L1_error)
+    __pyx_t_13 = __Pyx_PyObject_GetAttrStr(__pyx_t_12, __pyx_n_s_split); if (unlikely(!__pyx_t_13)) __PYX_ERR(0, 71, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_13);
     __Pyx_DECREF(__pyx_t_12); __pyx_t_12 = 0;
     __pyx_t_12 = NULL;
@@ -4032,12 +4036,12 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_2distmat_reorder_cy(C
     }
     __pyx_t_1 = (__pyx_t_12) ? __Pyx_PyObject_Call2Args(__pyx_t_13, __pyx_t_12, __pyx_kp_s__3) : __Pyx_PyObject_CallOneArg(__pyx_t_13, __pyx_kp_s__3);
     __Pyx_XDECREF(__pyx_t_12); __pyx_t_12 = 0;
-    if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 74, __pyx_L1_error)
+    if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 71, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF(__pyx_t_13); __pyx_t_13 = 0;
     __Pyx_XDECREF_SET(__pyx_v_src_sig, __pyx_t_1);
     __pyx_t_1 = 0;
-    __pyx_t_15 = PyList_GET_SIZE(__pyx_v_dest_sig); if (unlikely(__pyx_t_15 == ((Py_ssize_t)-1))) __PYX_ERR(0, 74, __pyx_L1_error)
+    __pyx_t_15 = PyList_GET_SIZE(__pyx_v_dest_sig); if (unlikely(__pyx_t_15 == ((Py_ssize_t)-1))) __PYX_ERR(0, 71, __pyx_L1_error)
     __pyx_t_16 = __pyx_t_15;
     for (__pyx_t_17 = 0; __pyx_t_17 < __pyx_t_16; __pyx_t_17+=1) {
       __pyx_v_i = __pyx_t_17;
@@ -4048,11 +4052,11 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_2distmat_reorder_cy(C
       __pyx_t_3 = (__pyx_v_dst_type != Py_None);
       __pyx_t_2 = (__pyx_t_3 != 0);
       if (__pyx_t_2) {
-        __pyx_t_1 = __Pyx_GetItemInt(__pyx_v_src_sig, __pyx_v_i, Py_ssize_t, 1, PyInt_FromSsize_t, 0, 0, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 74, __pyx_L1_error)
+        __pyx_t_1 = __Pyx_GetItemInt(__pyx_v_src_sig, __pyx_v_i, Py_ssize_t, 1, PyInt_FromSsize_t, 0, 0, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 71, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_1);
-        __pyx_t_13 = PyObject_RichCompare(__pyx_t_1, __pyx_v_dst_type, Py_EQ); __Pyx_XGOTREF(__pyx_t_13); if (unlikely(!__pyx_t_13)) __PYX_ERR(0, 74, __pyx_L1_error)
+        __pyx_t_13 = PyObject_RichCompare(__pyx_t_1, __pyx_v_dst_type, Py_EQ); __Pyx_XGOTREF(__pyx_t_13); if (unlikely(!__pyx_t_13)) __PYX_ERR(0, 71, __pyx_L1_error)
         __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
-        __pyx_t_2 = __Pyx_PyObject_IsTrue(__pyx_t_13); if (unlikely(__pyx_t_2 < 0)) __PYX_ERR(0, 74, __pyx_L1_error)
+        __pyx_t_2 = __Pyx_PyObject_IsTrue(__pyx_t_13); if (unlikely(__pyx_t_2 < 0)) __PYX_ERR(0, 71, __pyx_L1_error)
         __Pyx_DECREF(__pyx_t_13); __pyx_t_13 = 0;
         if (__pyx_t_2) {
           __pyx_v_match_found = 1;
@@ -4068,35 +4072,35 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_2distmat_reorder_cy(C
     __pyx_L32_break:;
     __pyx_t_2 = (__pyx_v_match_found != 0);
     if (__pyx_t_2) {
-      __pyx_t_18 = __Pyx_PyList_Append(__pyx_v_candidates, __pyx_v_sig); if (unlikely(__pyx_t_18 == ((int)-1))) __PYX_ERR(0, 74, __pyx_L1_error)
+      __pyx_t_18 = __Pyx_PyList_Append(__pyx_v_candidates, __pyx_v_sig); if (unlikely(__pyx_t_18 == ((int)-1))) __PYX_ERR(0, 71, __pyx_L1_error)
     }
   }
   __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
   __pyx_t_2 = (PyList_GET_SIZE(__pyx_v_candidates) != 0);
   __pyx_t_3 = ((!__pyx_t_2) != 0);
   if (__pyx_t_3) {
-    __pyx_t_6 = __Pyx_PyObject_Call(__pyx_builtin_TypeError, __pyx_tuple__4, NULL); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 74, __pyx_L1_error)
+    __pyx_t_6 = __Pyx_PyObject_Call(__pyx_builtin_TypeError, __pyx_tuple__4, NULL); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 71, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_6);
     __Pyx_Raise(__pyx_t_6, 0, 0, 0);
     __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
-    __PYX_ERR(0, 74, __pyx_L1_error)
+    __PYX_ERR(0, 71, __pyx_L1_error)
   }
-  __pyx_t_9 = PyList_GET_SIZE(__pyx_v_candidates); if (unlikely(__pyx_t_9 == ((Py_ssize_t)-1))) __PYX_ERR(0, 74, __pyx_L1_error)
+  __pyx_t_9 = PyList_GET_SIZE(__pyx_v_candidates); if (unlikely(__pyx_t_9 == ((Py_ssize_t)-1))) __PYX_ERR(0, 71, __pyx_L1_error)
   __pyx_t_3 = ((__pyx_t_9 > 1) != 0);
   if (__pyx_t_3) {
-    __pyx_t_6 = __Pyx_PyObject_Call(__pyx_builtin_TypeError, __pyx_tuple__5, NULL); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 74, __pyx_L1_error)
+    __pyx_t_6 = __Pyx_PyObject_Call(__pyx_builtin_TypeError, __pyx_tuple__5, NULL); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 71, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_6);
     __Pyx_Raise(__pyx_t_6, 0, 0, 0);
     __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
-    __PYX_ERR(0, 74, __pyx_L1_error)
+    __PYX_ERR(0, 71, __pyx_L1_error)
   }
   /*else*/ {
     __Pyx_XDECREF(__pyx_r);
     if (unlikely(__pyx_v_signatures == Py_None)) {
       PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-      __PYX_ERR(0, 74, __pyx_L1_error)
+      __PYX_ERR(0, 71, __pyx_L1_error)
     }
-    __pyx_t_6 = __Pyx_PyDict_GetItem(((PyObject*)__pyx_v_signatures), PyList_GET_ITEM(__pyx_v_candidates, 0)); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 74, __pyx_L1_error)
+    __pyx_t_6 = __Pyx_PyDict_GetItem(((PyObject*)__pyx_v_signatures), PyList_GET_ITEM(__pyx_v_candidates, 0)); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 71, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_6);
     __pyx_r = __pyx_t_6;
     __pyx_t_6 = 0;
@@ -4166,17 +4170,17 @@ static PyObject *__pyx_fuse_0__pyx_pw_5skbio_5stats_8distance_7_cutils_15distmat
         case  1:
         if (likely((values[1] = __Pyx_PyDict_GetItemStr(__pyx_kwds, __pyx_n_s_reorder_vec)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("distmat_reorder_cy", 1, 3, 3, 1); __PYX_ERR(0, 74, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("distmat_reorder_cy", 1, 3, 3, 1); __PYX_ERR(0, 71, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  2:
         if (likely((values[2] = __Pyx_PyDict_GetItemStr(__pyx_kwds, __pyx_n_s_out_mat)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("distmat_reorder_cy", 1, 3, 3, 2); __PYX_ERR(0, 74, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("distmat_reorder_cy", 1, 3, 3, 2); __PYX_ERR(0, 71, __pyx_L3_error)
         }
       }
       if (unlikely(kw_args > 0)) {
-        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "distmat_reorder_cy") < 0)) __PYX_ERR(0, 74, __pyx_L3_error)
+        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "distmat_reorder_cy") < 0)) __PYX_ERR(0, 71, __pyx_L3_error)
       }
     } else if (PyTuple_GET_SIZE(__pyx_args) != 3) {
       goto __pyx_L5_argtuple_error;
@@ -4185,13 +4189,13 @@ static PyObject *__pyx_fuse_0__pyx_pw_5skbio_5stats_8distance_7_cutils_15distmat
       values[1] = PyTuple_GET_ITEM(__pyx_args, 1);
       values[2] = PyTuple_GET_ITEM(__pyx_args, 2);
     }
-    __pyx_v_in_mat = __Pyx_PyObject_to_MemoryviewSlice_d_dc_float(values[0], PyBUF_WRITABLE); if (unlikely(!__pyx_v_in_mat.memview)) __PYX_ERR(0, 74, __pyx_L3_error)
-    __pyx_v_reorder_vec = __Pyx_PyObject_to_MemoryviewSlice_dc_long(values[1], PyBUF_WRITABLE); if (unlikely(!__pyx_v_reorder_vec.memview)) __PYX_ERR(0, 74, __pyx_L3_error)
-    __pyx_v_out_mat = __Pyx_PyObject_to_MemoryviewSlice_d_dc_float(values[2], PyBUF_WRITABLE); if (unlikely(!__pyx_v_out_mat.memview)) __PYX_ERR(0, 75, __pyx_L3_error)
+    __pyx_v_in_mat = __Pyx_PyObject_to_MemoryviewSlice_d_dc_float(values[0], PyBUF_WRITABLE); if (unlikely(!__pyx_v_in_mat.memview)) __PYX_ERR(0, 71, __pyx_L3_error)
+    __pyx_v_reorder_vec = __Pyx_PyObject_to_MemoryviewSlice_dc_long(values[1], PyBUF_WRITABLE); if (unlikely(!__pyx_v_reorder_vec.memview)) __PYX_ERR(0, 71, __pyx_L3_error)
+    __pyx_v_out_mat = __Pyx_PyObject_to_MemoryviewSlice_d_dc_float(values[2], PyBUF_WRITABLE); if (unlikely(!__pyx_v_out_mat.memview)) __PYX_ERR(0, 72, __pyx_L3_error)
   }
   goto __pyx_L4_argument_unpacking_done;
   __pyx_L5_argtuple_error:;
-  __Pyx_RaiseArgtupleInvalid("distmat_reorder_cy", 1, 3, 3, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 74, __pyx_L3_error)
+  __Pyx_RaiseArgtupleInvalid("distmat_reorder_cy", 1, 3, 3, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 71, __pyx_L3_error)
   __pyx_L3_error:;
   __Pyx_AddTraceback("skbio.stats.distance._cutils.distmat_reorder_cy", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __Pyx_RefNannyFinishContext();
@@ -4231,7 +4235,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_14distmat_reorder_cy(
   int __pyx_clineno = 0;
   __Pyx_RefNannySetupContext("__pyx_fuse_0distmat_reorder_cy", 0);
 
-  /* "skbio/stats/distance/_cutils.pyx":106
+  /* "skbio/stats/distance/_cutils.pyx":103
  *         Output, Distance matrix, must be same size as reorder_vec
  *     """
  *     cdef Py_ssize_t in_n = in_mat.shape[0]             # <<<<<<<<<<<<<<
@@ -4240,7 +4244,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_14distmat_reorder_cy(
  */
   __pyx_v_in_n = (__pyx_v_in_mat.shape[0]);
 
-  /* "skbio/stats/distance/_cutils.pyx":107
+  /* "skbio/stats/distance/_cutils.pyx":104
  *     """
  *     cdef Py_ssize_t in_n = in_mat.shape[0]
  *     cdef Py_ssize_t in2 = in_mat.shape[1]             # <<<<<<<<<<<<<<
@@ -4249,7 +4253,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_14distmat_reorder_cy(
  */
   __pyx_v_in2 = (__pyx_v_in_mat.shape[1]);
 
-  /* "skbio/stats/distance/_cutils.pyx":108
+  /* "skbio/stats/distance/_cutils.pyx":105
  *     cdef Py_ssize_t in_n = in_mat.shape[0]
  *     cdef Py_ssize_t in2 = in_mat.shape[1]
  *     cdef Py_ssize_t out_n = reorder_vec.shape[0]             # <<<<<<<<<<<<<<
@@ -4258,7 +4262,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_14distmat_reorder_cy(
  */
   __pyx_v_out_n = (__pyx_v_reorder_vec.shape[0]);
 
-  /* "skbio/stats/distance/_cutils.pyx":109
+  /* "skbio/stats/distance/_cutils.pyx":106
  *     cdef Py_ssize_t in2 = in_mat.shape[1]
  *     cdef Py_ssize_t out_n = reorder_vec.shape[0]
  *     cdef Py_ssize_t on2 = out_mat.shape[0]             # <<<<<<<<<<<<<<
@@ -4267,7 +4271,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_14distmat_reorder_cy(
  */
   __pyx_v_on2 = (__pyx_v_out_mat.shape[0]);
 
-  /* "skbio/stats/distance/_cutils.pyx":110
+  /* "skbio/stats/distance/_cutils.pyx":107
  *     cdef Py_ssize_t out_n = reorder_vec.shape[0]
  *     cdef Py_ssize_t on2 = out_mat.shape[0]
  *     cdef Py_ssize_t on3 = out_mat.shape[1]             # <<<<<<<<<<<<<<
@@ -4276,7 +4280,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_14distmat_reorder_cy(
  */
   __pyx_v_on3 = (__pyx_v_out_mat.shape[1]);
 
-  /* "skbio/stats/distance/_cutils.pyx":112
+  /* "skbio/stats/distance/_cutils.pyx":109
  *     cdef Py_ssize_t on3 = out_mat.shape[1]
  * 
  *     assert in_n == in2             # <<<<<<<<<<<<<<
@@ -4287,12 +4291,12 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_14distmat_reorder_cy(
   if (unlikely(!Py_OptimizeFlag)) {
     if (unlikely(!((__pyx_v_in_n == __pyx_v_in2) != 0))) {
       PyErr_SetNone(PyExc_AssertionError);
-      __PYX_ERR(0, 112, __pyx_L1_error)
+      __PYX_ERR(0, 109, __pyx_L1_error)
     }
   }
   #endif
 
-  /* "skbio/stats/distance/_cutils.pyx":113
+  /* "skbio/stats/distance/_cutils.pyx":110
  * 
  *     assert in_n == in2
  *     assert out_n == on2             # <<<<<<<<<<<<<<
@@ -4303,12 +4307,12 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_14distmat_reorder_cy(
   if (unlikely(!Py_OptimizeFlag)) {
     if (unlikely(!((__pyx_v_out_n == __pyx_v_on2) != 0))) {
       PyErr_SetNone(PyExc_AssertionError);
-      __PYX_ERR(0, 113, __pyx_L1_error)
+      __PYX_ERR(0, 110, __pyx_L1_error)
     }
   }
   #endif
 
-  /* "skbio/stats/distance/_cutils.pyx":114
+  /* "skbio/stats/distance/_cutils.pyx":111
  *     assert in_n == in2
  *     assert out_n == on2
  *     assert out_n == on3             # <<<<<<<<<<<<<<
@@ -4319,12 +4323,12 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_14distmat_reorder_cy(
   if (unlikely(!Py_OptimizeFlag)) {
     if (unlikely(!((__pyx_v_out_n == __pyx_v_on3) != 0))) {
       PyErr_SetNone(PyExc_AssertionError);
-      __PYX_ERR(0, 114, __pyx_L1_error)
+      __PYX_ERR(0, 111, __pyx_L1_error)
     }
   }
   #endif
 
-  /* "skbio/stats/distance/_cutils.pyx":119
+  /* "skbio/stats/distance/_cutils.pyx":116
  *     cdef Py_ssize_t vrow
  * 
  *     for row in prange(out_n, nogil=True):             # <<<<<<<<<<<<<<
@@ -4364,7 +4368,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_14distmat_reorder_cy(
                             __pyx_v_col = ((Py_ssize_t)0xbad0bad0);
                             __pyx_v_vrow = ((Py_ssize_t)0xbad0bad0);
 
-                            /* "skbio/stats/distance/_cutils.pyx":120
+                            /* "skbio/stats/distance/_cutils.pyx":117
  * 
  *     for row in prange(out_n, nogil=True):
  *         vrow = reorder_vec[row]             # <<<<<<<<<<<<<<
@@ -4374,7 +4378,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_14distmat_reorder_cy(
                             __pyx_t_4 = __pyx_v_row;
                             __pyx_v_vrow = (*((long *) ( /* dim=0 */ ((char *) (((long *) __pyx_v_reorder_vec.data) + __pyx_t_4)) )));
 
-                            /* "skbio/stats/distance/_cutils.pyx":121
+                            /* "skbio/stats/distance/_cutils.pyx":118
  *     for row in prange(out_n, nogil=True):
  *         vrow = reorder_vec[row]
  *         for col in range(out_n):             # <<<<<<<<<<<<<<
@@ -4386,7 +4390,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_14distmat_reorder_cy(
                             for (__pyx_t_7 = 0; __pyx_t_7 < __pyx_t_6; __pyx_t_7+=1) {
                               __pyx_v_col = __pyx_t_7;
 
-                              /* "skbio/stats/distance/_cutils.pyx":122
+                              /* "skbio/stats/distance/_cutils.pyx":119
  *         vrow = reorder_vec[row]
  *         for col in range(out_n):
  *            out_mat[row,col] = in_mat[vrow, reorder_vec[col]]             # <<<<<<<<<<<<<<
@@ -4413,7 +4417,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_14distmat_reorder_cy(
         #endif
       }
 
-      /* "skbio/stats/distance/_cutils.pyx":119
+      /* "skbio/stats/distance/_cutils.pyx":116
  *     cdef Py_ssize_t vrow
  * 
  *     for row in prange(out_n, nogil=True):             # <<<<<<<<<<<<<<
@@ -4432,7 +4436,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_14distmat_reorder_cy(
       }
   }
 
-  /* "skbio/stats/distance/_cutils.pyx":74
+  /* "skbio/stats/distance/_cutils.pyx":71
  * @cython.boundscheck(False)
  * @cython.wraparound(False)
  * def distmat_reorder_cy(TReal[:, ::1] in_mat, long[::1] reorder_vec,             # <<<<<<<<<<<<<<
@@ -4493,17 +4497,17 @@ static PyObject *__pyx_fuse_1__pyx_pw_5skbio_5stats_8distance_7_cutils_17distmat
         case  1:
         if (likely((values[1] = __Pyx_PyDict_GetItemStr(__pyx_kwds, __pyx_n_s_reorder_vec)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("distmat_reorder_cy", 1, 3, 3, 1); __PYX_ERR(0, 74, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("distmat_reorder_cy", 1, 3, 3, 1); __PYX_ERR(0, 71, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  2:
         if (likely((values[2] = __Pyx_PyDict_GetItemStr(__pyx_kwds, __pyx_n_s_out_mat)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("distmat_reorder_cy", 1, 3, 3, 2); __PYX_ERR(0, 74, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("distmat_reorder_cy", 1, 3, 3, 2); __PYX_ERR(0, 71, __pyx_L3_error)
         }
       }
       if (unlikely(kw_args > 0)) {
-        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "distmat_reorder_cy") < 0)) __PYX_ERR(0, 74, __pyx_L3_error)
+        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "distmat_reorder_cy") < 0)) __PYX_ERR(0, 71, __pyx_L3_error)
       }
     } else if (PyTuple_GET_SIZE(__pyx_args) != 3) {
       goto __pyx_L5_argtuple_error;
@@ -4512,13 +4516,13 @@ static PyObject *__pyx_fuse_1__pyx_pw_5skbio_5stats_8distance_7_cutils_17distmat
       values[1] = PyTuple_GET_ITEM(__pyx_args, 1);
       values[2] = PyTuple_GET_ITEM(__pyx_args, 2);
     }
-    __pyx_v_in_mat = __Pyx_PyObject_to_MemoryviewSlice_d_dc_double(values[0], PyBUF_WRITABLE); if (unlikely(!__pyx_v_in_mat.memview)) __PYX_ERR(0, 74, __pyx_L3_error)
-    __pyx_v_reorder_vec = __Pyx_PyObject_to_MemoryviewSlice_dc_long(values[1], PyBUF_WRITABLE); if (unlikely(!__pyx_v_reorder_vec.memview)) __PYX_ERR(0, 74, __pyx_L3_error)
-    __pyx_v_out_mat = __Pyx_PyObject_to_MemoryviewSlice_d_dc_double(values[2], PyBUF_WRITABLE); if (unlikely(!__pyx_v_out_mat.memview)) __PYX_ERR(0, 75, __pyx_L3_error)
+    __pyx_v_in_mat = __Pyx_PyObject_to_MemoryviewSlice_d_dc_double(values[0], PyBUF_WRITABLE); if (unlikely(!__pyx_v_in_mat.memview)) __PYX_ERR(0, 71, __pyx_L3_error)
+    __pyx_v_reorder_vec = __Pyx_PyObject_to_MemoryviewSlice_dc_long(values[1], PyBUF_WRITABLE); if (unlikely(!__pyx_v_reorder_vec.memview)) __PYX_ERR(0, 71, __pyx_L3_error)
+    __pyx_v_out_mat = __Pyx_PyObject_to_MemoryviewSlice_d_dc_double(values[2], PyBUF_WRITABLE); if (unlikely(!__pyx_v_out_mat.memview)) __PYX_ERR(0, 72, __pyx_L3_error)
   }
   goto __pyx_L4_argument_unpacking_done;
   __pyx_L5_argtuple_error:;
-  __Pyx_RaiseArgtupleInvalid("distmat_reorder_cy", 1, 3, 3, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 74, __pyx_L3_error)
+  __Pyx_RaiseArgtupleInvalid("distmat_reorder_cy", 1, 3, 3, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 71, __pyx_L3_error)
   __pyx_L3_error:;
   __Pyx_AddTraceback("skbio.stats.distance._cutils.distmat_reorder_cy", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __Pyx_RefNannyFinishContext();
@@ -4558,7 +4562,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_16distmat_reorder_cy(
   int __pyx_clineno = 0;
   __Pyx_RefNannySetupContext("__pyx_fuse_1distmat_reorder_cy", 0);
 
-  /* "skbio/stats/distance/_cutils.pyx":106
+  /* "skbio/stats/distance/_cutils.pyx":103
  *         Output, Distance matrix, must be same size as reorder_vec
  *     """
  *     cdef Py_ssize_t in_n = in_mat.shape[0]             # <<<<<<<<<<<<<<
@@ -4567,7 +4571,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_16distmat_reorder_cy(
  */
   __pyx_v_in_n = (__pyx_v_in_mat.shape[0]);
 
-  /* "skbio/stats/distance/_cutils.pyx":107
+  /* "skbio/stats/distance/_cutils.pyx":104
  *     """
  *     cdef Py_ssize_t in_n = in_mat.shape[0]
  *     cdef Py_ssize_t in2 = in_mat.shape[1]             # <<<<<<<<<<<<<<
@@ -4576,7 +4580,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_16distmat_reorder_cy(
  */
   __pyx_v_in2 = (__pyx_v_in_mat.shape[1]);
 
-  /* "skbio/stats/distance/_cutils.pyx":108
+  /* "skbio/stats/distance/_cutils.pyx":105
  *     cdef Py_ssize_t in_n = in_mat.shape[0]
  *     cdef Py_ssize_t in2 = in_mat.shape[1]
  *     cdef Py_ssize_t out_n = reorder_vec.shape[0]             # <<<<<<<<<<<<<<
@@ -4585,7 +4589,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_16distmat_reorder_cy(
  */
   __pyx_v_out_n = (__pyx_v_reorder_vec.shape[0]);
 
-  /* "skbio/stats/distance/_cutils.pyx":109
+  /* "skbio/stats/distance/_cutils.pyx":106
  *     cdef Py_ssize_t in2 = in_mat.shape[1]
  *     cdef Py_ssize_t out_n = reorder_vec.shape[0]
  *     cdef Py_ssize_t on2 = out_mat.shape[0]             # <<<<<<<<<<<<<<
@@ -4594,7 +4598,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_16distmat_reorder_cy(
  */
   __pyx_v_on2 = (__pyx_v_out_mat.shape[0]);
 
-  /* "skbio/stats/distance/_cutils.pyx":110
+  /* "skbio/stats/distance/_cutils.pyx":107
  *     cdef Py_ssize_t out_n = reorder_vec.shape[0]
  *     cdef Py_ssize_t on2 = out_mat.shape[0]
  *     cdef Py_ssize_t on3 = out_mat.shape[1]             # <<<<<<<<<<<<<<
@@ -4603,7 +4607,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_16distmat_reorder_cy(
  */
   __pyx_v_on3 = (__pyx_v_out_mat.shape[1]);
 
-  /* "skbio/stats/distance/_cutils.pyx":112
+  /* "skbio/stats/distance/_cutils.pyx":109
  *     cdef Py_ssize_t on3 = out_mat.shape[1]
  * 
  *     assert in_n == in2             # <<<<<<<<<<<<<<
@@ -4614,12 +4618,12 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_16distmat_reorder_cy(
   if (unlikely(!Py_OptimizeFlag)) {
     if (unlikely(!((__pyx_v_in_n == __pyx_v_in2) != 0))) {
       PyErr_SetNone(PyExc_AssertionError);
-      __PYX_ERR(0, 112, __pyx_L1_error)
+      __PYX_ERR(0, 109, __pyx_L1_error)
     }
   }
   #endif
 
-  /* "skbio/stats/distance/_cutils.pyx":113
+  /* "skbio/stats/distance/_cutils.pyx":110
  * 
  *     assert in_n == in2
  *     assert out_n == on2             # <<<<<<<<<<<<<<
@@ -4630,12 +4634,12 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_16distmat_reorder_cy(
   if (unlikely(!Py_OptimizeFlag)) {
     if (unlikely(!((__pyx_v_out_n == __pyx_v_on2) != 0))) {
       PyErr_SetNone(PyExc_AssertionError);
-      __PYX_ERR(0, 113, __pyx_L1_error)
+      __PYX_ERR(0, 110, __pyx_L1_error)
     }
   }
   #endif
 
-  /* "skbio/stats/distance/_cutils.pyx":114
+  /* "skbio/stats/distance/_cutils.pyx":111
  *     assert in_n == in2
  *     assert out_n == on2
  *     assert out_n == on3             # <<<<<<<<<<<<<<
@@ -4646,12 +4650,12 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_16distmat_reorder_cy(
   if (unlikely(!Py_OptimizeFlag)) {
     if (unlikely(!((__pyx_v_out_n == __pyx_v_on3) != 0))) {
       PyErr_SetNone(PyExc_AssertionError);
-      __PYX_ERR(0, 114, __pyx_L1_error)
+      __PYX_ERR(0, 111, __pyx_L1_error)
     }
   }
   #endif
 
-  /* "skbio/stats/distance/_cutils.pyx":119
+  /* "skbio/stats/distance/_cutils.pyx":116
  *     cdef Py_ssize_t vrow
  * 
  *     for row in prange(out_n, nogil=True):             # <<<<<<<<<<<<<<
@@ -4691,7 +4695,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_16distmat_reorder_cy(
                             __pyx_v_col = ((Py_ssize_t)0xbad0bad0);
                             __pyx_v_vrow = ((Py_ssize_t)0xbad0bad0);
 
-                            /* "skbio/stats/distance/_cutils.pyx":120
+                            /* "skbio/stats/distance/_cutils.pyx":117
  * 
  *     for row in prange(out_n, nogil=True):
  *         vrow = reorder_vec[row]             # <<<<<<<<<<<<<<
@@ -4701,7 +4705,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_16distmat_reorder_cy(
                             __pyx_t_4 = __pyx_v_row;
                             __pyx_v_vrow = (*((long *) ( /* dim=0 */ ((char *) (((long *) __pyx_v_reorder_vec.data) + __pyx_t_4)) )));
 
-                            /* "skbio/stats/distance/_cutils.pyx":121
+                            /* "skbio/stats/distance/_cutils.pyx":118
  *     for row in prange(out_n, nogil=True):
  *         vrow = reorder_vec[row]
  *         for col in range(out_n):             # <<<<<<<<<<<<<<
@@ -4713,7 +4717,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_16distmat_reorder_cy(
                             for (__pyx_t_7 = 0; __pyx_t_7 < __pyx_t_6; __pyx_t_7+=1) {
                               __pyx_v_col = __pyx_t_7;
 
-                              /* "skbio/stats/distance/_cutils.pyx":122
+                              /* "skbio/stats/distance/_cutils.pyx":119
  *         vrow = reorder_vec[row]
  *         for col in range(out_n):
  *            out_mat[row,col] = in_mat[vrow, reorder_vec[col]]             # <<<<<<<<<<<<<<
@@ -4740,7 +4744,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_16distmat_reorder_cy(
         #endif
       }
 
-      /* "skbio/stats/distance/_cutils.pyx":119
+      /* "skbio/stats/distance/_cutils.pyx":116
  *     cdef Py_ssize_t vrow
  * 
  *     for row in prange(out_n, nogil=True):             # <<<<<<<<<<<<<<
@@ -4759,7 +4763,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_16distmat_reorder_cy(
       }
   }
 
-  /* "skbio/stats/distance/_cutils.pyx":74
+  /* "skbio/stats/distance/_cutils.pyx":71
  * @cython.boundscheck(False)
  * @cython.wraparound(False)
  * def distmat_reorder_cy(TReal[:, ::1] in_mat, long[::1] reorder_vec,             # <<<<<<<<<<<<<<
@@ -4782,7 +4786,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_16distmat_reorder_cy(
   return __pyx_r;
 }
 
-/* "skbio/stats/distance/_cutils.pyx":126
+/* "skbio/stats/distance/_cutils.pyx":123
  * @cython.boundscheck(False)
  * @cython.wraparound(False)
  * def distmat_reorder_condensed_cy(TReal[:, ::1] in_mat, long[::1] reorder_vec,             # <<<<<<<<<<<<<<
@@ -4832,23 +4836,23 @@ static PyObject *__pyx_pw_5skbio_5stats_8distance_7_cutils_5distmat_reorder_cond
         case  1:
         if (likely((values[1] = __Pyx_PyDict_GetItemStr(__pyx_kwds, __pyx_n_s_args)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("__pyx_fused_cpdef", 1, 4, 4, 1); __PYX_ERR(0, 126, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("__pyx_fused_cpdef", 1, 4, 4, 1); __PYX_ERR(0, 123, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  2:
         if (likely((values[2] = __Pyx_PyDict_GetItemStr(__pyx_kwds, __pyx_n_s_kwargs)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("__pyx_fused_cpdef", 1, 4, 4, 2); __PYX_ERR(0, 126, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("__pyx_fused_cpdef", 1, 4, 4, 2); __PYX_ERR(0, 123, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  3:
         if (likely((values[3] = __Pyx_PyDict_GetItemStr(__pyx_kwds, __pyx_n_s_defaults)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("__pyx_fused_cpdef", 1, 4, 4, 3); __PYX_ERR(0, 126, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("__pyx_fused_cpdef", 1, 4, 4, 3); __PYX_ERR(0, 123, __pyx_L3_error)
         }
       }
       if (unlikely(kw_args > 0)) {
-        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "__pyx_fused_cpdef") < 0)) __PYX_ERR(0, 126, __pyx_L3_error)
+        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "__pyx_fused_cpdef") < 0)) __PYX_ERR(0, 123, __pyx_L3_error)
       }
     } else if (PyTuple_GET_SIZE(__pyx_args) != 4) {
       goto __pyx_L5_argtuple_error;
@@ -4865,7 +4869,7 @@ static PyObject *__pyx_pw_5skbio_5stats_8distance_7_cutils_5distmat_reorder_cond
   }
   goto __pyx_L4_argument_unpacking_done;
   __pyx_L5_argtuple_error:;
-  __Pyx_RaiseArgtupleInvalid("__pyx_fused_cpdef", 1, 4, 4, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 126, __pyx_L3_error)
+  __Pyx_RaiseArgtupleInvalid("__pyx_fused_cpdef", 1, 4, 4, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 123, __pyx_L3_error)
   __pyx_L3_error:;
   __Pyx_AddTraceback("skbio.stats.distance._cutils.__pyx_fused_cpdef", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __Pyx_RefNannyFinishContext();
@@ -4919,7 +4923,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_4distmat_reorder_cond
   int __pyx_clineno = 0;
   __Pyx_RefNannySetupContext("distmat_reorder_condensed_cy", 0);
   __Pyx_INCREF(__pyx_v_kwargs);
-  __pyx_t_1 = PyList_New(1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 126, __pyx_L1_error)
+  __pyx_t_1 = PyList_New(1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 123, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __Pyx_INCREF(Py_None);
   __Pyx_GIVEREF(Py_None);
@@ -4933,7 +4937,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_4distmat_reorder_cond
     __pyx_t_2 = __pyx_t_4;
     goto __pyx_L4_bool_binop_done;
   }
-  __pyx_t_4 = __Pyx_PyObject_IsTrue(__pyx_v_kwargs); if (unlikely(__pyx_t_4 < 0)) __PYX_ERR(0, 126, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_PyObject_IsTrue(__pyx_v_kwargs); if (unlikely(__pyx_t_4 < 0)) __PYX_ERR(0, 123, __pyx_L1_error)
   __pyx_t_3 = ((!__pyx_t_4) != 0);
   __pyx_t_2 = __pyx_t_3;
   __pyx_L4_bool_binop_done:;
@@ -4941,21 +4945,21 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_4distmat_reorder_cond
     __Pyx_INCREF(Py_None);
     __Pyx_DECREF_SET(__pyx_v_kwargs, Py_None);
   }
-  __pyx_t_1 = ((PyObject *)__Pyx_ImportNumPyArrayTypeIfAvailable()); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 126, __pyx_L1_error)
+  __pyx_t_1 = ((PyObject *)__Pyx_ImportNumPyArrayTypeIfAvailable()); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 123, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __pyx_v_ndarray = ((PyTypeObject*)__pyx_t_1);
   __pyx_t_1 = 0;
   __pyx_v_itemsize = -1L;
   if (unlikely(__pyx_v_args == Py_None)) {
     PyErr_SetString(PyExc_TypeError, "object of type 'NoneType' has no len()");
-    __PYX_ERR(0, 126, __pyx_L1_error)
+    __PYX_ERR(0, 123, __pyx_L1_error)
   }
-  __pyx_t_5 = PyTuple_GET_SIZE(((PyObject*)__pyx_v_args)); if (unlikely(__pyx_t_5 == ((Py_ssize_t)-1))) __PYX_ERR(0, 126, __pyx_L1_error)
+  __pyx_t_5 = PyTuple_GET_SIZE(((PyObject*)__pyx_v_args)); if (unlikely(__pyx_t_5 == ((Py_ssize_t)-1))) __PYX_ERR(0, 123, __pyx_L1_error)
   __pyx_t_2 = ((0 < __pyx_t_5) != 0);
   if (__pyx_t_2) {
     if (unlikely(__pyx_v_args == Py_None)) {
       PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-      __PYX_ERR(0, 126, __pyx_L1_error)
+      __PYX_ERR(0, 123, __pyx_L1_error)
     }
     __pyx_t_1 = PyTuple_GET_ITEM(((PyObject*)__pyx_v_args), 0);
     __Pyx_INCREF(__pyx_t_1);
@@ -4972,18 +4976,18 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_4distmat_reorder_cond
   }
   if (unlikely(__pyx_v_kwargs == Py_None)) {
     PyErr_SetString(PyExc_TypeError, "'NoneType' object is not iterable");
-    __PYX_ERR(0, 126, __pyx_L1_error)
+    __PYX_ERR(0, 123, __pyx_L1_error)
   }
-  __pyx_t_4 = (__Pyx_PyDict_ContainsTF(__pyx_n_s_in_mat, ((PyObject*)__pyx_v_kwargs), Py_EQ)); if (unlikely(__pyx_t_4 < 0)) __PYX_ERR(0, 126, __pyx_L1_error)
+  __pyx_t_4 = (__Pyx_PyDict_ContainsTF(__pyx_n_s_in_mat, ((PyObject*)__pyx_v_kwargs), Py_EQ)); if (unlikely(__pyx_t_4 < 0)) __PYX_ERR(0, 123, __pyx_L1_error)
   __pyx_t_3 = (__pyx_t_4 != 0);
   __pyx_t_2 = __pyx_t_3;
   __pyx_L7_bool_binop_done:;
   if (__pyx_t_2) {
     if (unlikely(__pyx_v_kwargs == Py_None)) {
       PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-      __PYX_ERR(0, 126, __pyx_L1_error)
+      __PYX_ERR(0, 123, __pyx_L1_error)
     }
-    __pyx_t_1 = __Pyx_PyDict_GetItem(((PyObject*)__pyx_v_kwargs), __pyx_n_s_in_mat); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 126, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_PyDict_GetItem(((PyObject*)__pyx_v_kwargs), __pyx_n_s_in_mat); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 123, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
     __pyx_v_arg = __pyx_t_1;
     __pyx_t_1 = 0;
@@ -4992,12 +4996,12 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_4distmat_reorder_cond
   /*else*/ {
     if (unlikely(__pyx_v_args == Py_None)) {
       PyErr_SetString(PyExc_TypeError, "object of type 'NoneType' has no len()");
-      __PYX_ERR(0, 126, __pyx_L1_error)
+      __PYX_ERR(0, 123, __pyx_L1_error)
     }
-    __pyx_t_5 = PyTuple_GET_SIZE(((PyObject*)__pyx_v_args)); if (unlikely(__pyx_t_5 == ((Py_ssize_t)-1))) __PYX_ERR(0, 126, __pyx_L1_error)
-    __pyx_t_1 = PyInt_FromSsize_t(__pyx_t_5); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 126, __pyx_L1_error)
+    __pyx_t_5 = PyTuple_GET_SIZE(((PyObject*)__pyx_v_args)); if (unlikely(__pyx_t_5 == ((Py_ssize_t)-1))) __PYX_ERR(0, 123, __pyx_L1_error)
+    __pyx_t_1 = PyInt_FromSsize_t(__pyx_t_5); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 123, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
-    __pyx_t_6 = PyTuple_New(3); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 126, __pyx_L1_error)
+    __pyx_t_6 = PyTuple_New(3); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 123, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_6);
     __Pyx_INCREF(__pyx_int_3);
     __Pyx_GIVEREF(__pyx_int_3);
@@ -5008,15 +5012,15 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_4distmat_reorder_cond
     __Pyx_GIVEREF(__pyx_t_1);
     PyTuple_SET_ITEM(__pyx_t_6, 2, __pyx_t_1);
     __pyx_t_1 = 0;
-    __pyx_t_1 = __Pyx_PyString_Format(__pyx_kp_s_Expected_at_least_d_argument_s_g, __pyx_t_6); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 126, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_PyString_Format(__pyx_kp_s_Expected_at_least_d_argument_s_g, __pyx_t_6); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 123, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
-    __pyx_t_6 = __Pyx_PyObject_CallOneArg(__pyx_builtin_TypeError, __pyx_t_1); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 126, __pyx_L1_error)
+    __pyx_t_6 = __Pyx_PyObject_CallOneArg(__pyx_builtin_TypeError, __pyx_t_1); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 123, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_6);
     __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
     __Pyx_Raise(__pyx_t_6, 0, 0, 0);
     __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
-    __PYX_ERR(0, 126, __pyx_L1_error)
+    __PYX_ERR(0, 123, __pyx_L1_error)
   }
   __pyx_L6:;
   while (1) {
@@ -5026,7 +5030,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_4distmat_reorder_cond
       __pyx_t_3 = __Pyx_TypeCheck(__pyx_v_arg, __pyx_v_ndarray); 
       __pyx_t_2 = (__pyx_t_3 != 0);
       if (__pyx_t_2) {
-        __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_dtype); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 126, __pyx_L1_error)
+        __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_dtype); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 123, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_6);
         __pyx_v_dtype = __pyx_t_6;
         __pyx_t_6 = 0;
@@ -5035,14 +5039,14 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_4distmat_reorder_cond
       __pyx_t_2 = __pyx_memoryview_check(__pyx_v_arg); 
       __pyx_t_3 = (__pyx_t_2 != 0);
       if (__pyx_t_3) {
-        __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_base); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 126, __pyx_L1_error)
+        __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_base); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 123, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_6);
         __pyx_v_arg_base = __pyx_t_6;
         __pyx_t_6 = 0;
         __pyx_t_3 = __Pyx_TypeCheck(__pyx_v_arg_base, __pyx_v_ndarray); 
         __pyx_t_2 = (__pyx_t_3 != 0);
         if (__pyx_t_2) {
-          __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg_base, __pyx_n_s_dtype); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 126, __pyx_L1_error)
+          __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg_base, __pyx_n_s_dtype); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 123, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_6);
           __pyx_v_dtype = __pyx_t_6;
           __pyx_t_6 = 0;
@@ -5064,14 +5068,14 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_4distmat_reorder_cond
       __pyx_t_2 = (__pyx_v_dtype != Py_None);
       __pyx_t_3 = (__pyx_t_2 != 0);
       if (__pyx_t_3) {
-        __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_v_dtype, __pyx_n_s_itemsize); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 126, __pyx_L1_error)
+        __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_v_dtype, __pyx_n_s_itemsize); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 123, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_6);
-        __pyx_t_5 = __Pyx_PyIndex_AsSsize_t(__pyx_t_6); if (unlikely((__pyx_t_5 == (Py_ssize_t)-1) && PyErr_Occurred())) __PYX_ERR(0, 126, __pyx_L1_error)
+        __pyx_t_5 = __Pyx_PyIndex_AsSsize_t(__pyx_t_6); if (unlikely((__pyx_t_5 == (Py_ssize_t)-1) && PyErr_Occurred())) __PYX_ERR(0, 123, __pyx_L1_error)
         __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
         __pyx_v_itemsize = __pyx_t_5;
-        __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_v_dtype, __pyx_n_s_kind); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 126, __pyx_L1_error)
+        __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_v_dtype, __pyx_n_s_kind); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 123, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_6);
-        __pyx_t_7 = __Pyx_PyObject_Ord(__pyx_t_6); if (unlikely(__pyx_t_7 == ((long)(long)(Py_UCS4)-1))) __PYX_ERR(0, 126, __pyx_L1_error)
+        __pyx_t_7 = __Pyx_PyObject_Ord(__pyx_t_6); if (unlikely(__pyx_t_7 == ((long)(long)(Py_UCS4)-1))) __PYX_ERR(0, 123, __pyx_L1_error)
         __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
         __pyx_v_kind = __pyx_t_7;
         __pyx_v_dtype_signed = (__pyx_v_kind == 'i');
@@ -5086,15 +5090,15 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_4distmat_reorder_cond
             __pyx_t_3 = __pyx_t_2;
             goto __pyx_L16_bool_binop_done;
           }
-          __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_ndim); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 126, __pyx_L1_error)
+          __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_ndim); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 123, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_6);
-          __pyx_t_5 = __Pyx_PyIndex_AsSsize_t(__pyx_t_6); if (unlikely((__pyx_t_5 == (Py_ssize_t)-1) && PyErr_Occurred())) __PYX_ERR(0, 126, __pyx_L1_error)
+          __pyx_t_5 = __Pyx_PyIndex_AsSsize_t(__pyx_t_6); if (unlikely((__pyx_t_5 == (Py_ssize_t)-1) && PyErr_Occurred())) __PYX_ERR(0, 123, __pyx_L1_error)
           __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
           __pyx_t_2 = ((((Py_ssize_t)__pyx_t_5) == 2) != 0);
           __pyx_t_3 = __pyx_t_2;
           __pyx_L16_bool_binop_done:;
           if (__pyx_t_3) {
-            if (unlikely(__Pyx_SetItemInt(__pyx_v_dest_sig, 0, __pyx_n_s_float, long, 1, __Pyx_PyInt_From_long, 1, 0, 0) < 0)) __PYX_ERR(0, 126, __pyx_L1_error)
+            if (unlikely(__Pyx_SetItemInt(__pyx_v_dest_sig, 0, __pyx_n_s_float, long, 1, __Pyx_PyInt_From_long, 1, 0, 0) < 0)) __PYX_ERR(0, 123, __pyx_L1_error)
             goto __pyx_L10_break;
           }
           __pyx_t_2 = (((sizeof(double)) == __pyx_v_itemsize) != 0);
@@ -5103,15 +5107,15 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_4distmat_reorder_cond
             __pyx_t_3 = __pyx_t_2;
             goto __pyx_L19_bool_binop_done;
           }
-          __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_ndim); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 126, __pyx_L1_error)
+          __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_ndim); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 123, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_6);
-          __pyx_t_5 = __Pyx_PyIndex_AsSsize_t(__pyx_t_6); if (unlikely((__pyx_t_5 == (Py_ssize_t)-1) && PyErr_Occurred())) __PYX_ERR(0, 126, __pyx_L1_error)
+          __pyx_t_5 = __Pyx_PyIndex_AsSsize_t(__pyx_t_6); if (unlikely((__pyx_t_5 == (Py_ssize_t)-1) && PyErr_Occurred())) __PYX_ERR(0, 123, __pyx_L1_error)
           __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
           __pyx_t_2 = ((((Py_ssize_t)__pyx_t_5) == 2) != 0);
           __pyx_t_3 = __pyx_t_2;
           __pyx_L19_bool_binop_done:;
           if (__pyx_t_3) {
-            if (unlikely(__Pyx_SetItemInt(__pyx_v_dest_sig, 0, __pyx_n_s_double, long, 1, __Pyx_PyInt_From_long, 1, 0, 0) < 0)) __PYX_ERR(0, 126, __pyx_L1_error)
+            if (unlikely(__Pyx_SetItemInt(__pyx_v_dest_sig, 0, __pyx_n_s_double, long, 1, __Pyx_PyInt_From_long, 1, 0, 0) < 0)) __PYX_ERR(0, 123, __pyx_L1_error)
             goto __pyx_L10_break;
           }
           break;
@@ -5138,7 +5142,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_4distmat_reorder_cond
       __pyx_t_3 = (__pyx_v_memslice.memview != 0);
       if (__pyx_t_3) {
         __PYX_XDEC_MEMVIEW((&__pyx_v_memslice), 1); 
-        if (unlikely(__Pyx_SetItemInt(__pyx_v_dest_sig, 0, __pyx_n_s_float, long, 1, __Pyx_PyInt_From_long, 1, 0, 0) < 0)) __PYX_ERR(0, 126, __pyx_L1_error)
+        if (unlikely(__Pyx_SetItemInt(__pyx_v_dest_sig, 0, __pyx_n_s_float, long, 1, __Pyx_PyInt_From_long, 1, 0, 0) < 0)) __PYX_ERR(0, 123, __pyx_L1_error)
         goto __pyx_L10_break;
       }
       /*else*/ {
@@ -5160,27 +5164,27 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_4distmat_reorder_cond
       __pyx_t_3 = (__pyx_v_memslice.memview != 0);
       if (__pyx_t_3) {
         __PYX_XDEC_MEMVIEW((&__pyx_v_memslice), 1); 
-        if (unlikely(__Pyx_SetItemInt(__pyx_v_dest_sig, 0, __pyx_n_s_double, long, 1, __Pyx_PyInt_From_long, 1, 0, 0) < 0)) __PYX_ERR(0, 126, __pyx_L1_error)
+        if (unlikely(__Pyx_SetItemInt(__pyx_v_dest_sig, 0, __pyx_n_s_double, long, 1, __Pyx_PyInt_From_long, 1, 0, 0) < 0)) __PYX_ERR(0, 123, __pyx_L1_error)
         goto __pyx_L10_break;
       }
       /*else*/ {
         PyErr_Clear(); 
       }
     }
-    if (unlikely(__Pyx_SetItemInt(__pyx_v_dest_sig, 0, Py_None, long, 1, __Pyx_PyInt_From_long, 1, 0, 0) < 0)) __PYX_ERR(0, 126, __pyx_L1_error)
+    if (unlikely(__Pyx_SetItemInt(__pyx_v_dest_sig, 0, Py_None, long, 1, __Pyx_PyInt_From_long, 1, 0, 0) < 0)) __PYX_ERR(0, 123, __pyx_L1_error)
     goto __pyx_L10_break;
   }
   __pyx_L10_break:;
-  __pyx_t_6 = PyList_New(0); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 126, __pyx_L1_error)
+  __pyx_t_6 = PyList_New(0); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 123, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_6);
   __pyx_v_candidates = ((PyObject*)__pyx_t_6);
   __pyx_t_6 = 0;
   __pyx_t_5 = 0;
   if (unlikely(__pyx_v_signatures == Py_None)) {
     PyErr_SetString(PyExc_TypeError, "'NoneType' object is not iterable");
-    __PYX_ERR(0, 126, __pyx_L1_error)
+    __PYX_ERR(0, 123, __pyx_L1_error)
   }
-  __pyx_t_1 = __Pyx_dict_iterator(((PyObject*)__pyx_v_signatures), 1, ((PyObject *)NULL), (&__pyx_t_9), (&__pyx_t_10)); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 126, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_dict_iterator(((PyObject*)__pyx_v_signatures), 1, ((PyObject *)NULL), (&__pyx_t_9), (&__pyx_t_10)); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 123, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __Pyx_XDECREF(__pyx_t_6);
   __pyx_t_6 = __pyx_t_1;
@@ -5188,12 +5192,12 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_4distmat_reorder_cond
   while (1) {
     __pyx_t_11 = __Pyx_dict_iter_next(__pyx_t_6, __pyx_t_9, &__pyx_t_5, &__pyx_t_1, NULL, NULL, __pyx_t_10);
     if (unlikely(__pyx_t_11 == 0)) break;
-    if (unlikely(__pyx_t_11 == -1)) __PYX_ERR(0, 126, __pyx_L1_error)
+    if (unlikely(__pyx_t_11 == -1)) __PYX_ERR(0, 123, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_XDECREF_SET(__pyx_v_sig, __pyx_t_1);
     __pyx_t_1 = 0;
     __pyx_v_match_found = 0;
-    __pyx_t_13 = __Pyx_PyObject_GetAttrStr(__pyx_v_sig, __pyx_n_s_strip); if (unlikely(!__pyx_t_13)) __PYX_ERR(0, 126, __pyx_L1_error)
+    __pyx_t_13 = __Pyx_PyObject_GetAttrStr(__pyx_v_sig, __pyx_n_s_strip); if (unlikely(!__pyx_t_13)) __PYX_ERR(0, 123, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_13);
     __pyx_t_14 = NULL;
     if (CYTHON_UNPACK_METHODS && likely(PyMethod_Check(__pyx_t_13))) {
@@ -5207,10 +5211,10 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_4distmat_reorder_cond
     }
     __pyx_t_12 = (__pyx_t_14) ? __Pyx_PyObject_Call2Args(__pyx_t_13, __pyx_t_14, __pyx_kp_s__2) : __Pyx_PyObject_CallOneArg(__pyx_t_13, __pyx_kp_s__2);
     __Pyx_XDECREF(__pyx_t_14); __pyx_t_14 = 0;
-    if (unlikely(!__pyx_t_12)) __PYX_ERR(0, 126, __pyx_L1_error)
+    if (unlikely(!__pyx_t_12)) __PYX_ERR(0, 123, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_12);
     __Pyx_DECREF(__pyx_t_13); __pyx_t_13 = 0;
-    __pyx_t_13 = __Pyx_PyObject_GetAttrStr(__pyx_t_12, __pyx_n_s_split); if (unlikely(!__pyx_t_13)) __PYX_ERR(0, 126, __pyx_L1_error)
+    __pyx_t_13 = __Pyx_PyObject_GetAttrStr(__pyx_t_12, __pyx_n_s_split); if (unlikely(!__pyx_t_13)) __PYX_ERR(0, 123, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_13);
     __Pyx_DECREF(__pyx_t_12); __pyx_t_12 = 0;
     __pyx_t_12 = NULL;
@@ -5225,12 +5229,12 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_4distmat_reorder_cond
     }
     __pyx_t_1 = (__pyx_t_12) ? __Pyx_PyObject_Call2Args(__pyx_t_13, __pyx_t_12, __pyx_kp_s__3) : __Pyx_PyObject_CallOneArg(__pyx_t_13, __pyx_kp_s__3);
     __Pyx_XDECREF(__pyx_t_12); __pyx_t_12 = 0;
-    if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 126, __pyx_L1_error)
+    if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 123, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF(__pyx_t_13); __pyx_t_13 = 0;
     __Pyx_XDECREF_SET(__pyx_v_src_sig, __pyx_t_1);
     __pyx_t_1 = 0;
-    __pyx_t_15 = PyList_GET_SIZE(__pyx_v_dest_sig); if (unlikely(__pyx_t_15 == ((Py_ssize_t)-1))) __PYX_ERR(0, 126, __pyx_L1_error)
+    __pyx_t_15 = PyList_GET_SIZE(__pyx_v_dest_sig); if (unlikely(__pyx_t_15 == ((Py_ssize_t)-1))) __PYX_ERR(0, 123, __pyx_L1_error)
     __pyx_t_16 = __pyx_t_15;
     for (__pyx_t_17 = 0; __pyx_t_17 < __pyx_t_16; __pyx_t_17+=1) {
       __pyx_v_i = __pyx_t_17;
@@ -5241,11 +5245,11 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_4distmat_reorder_cond
       __pyx_t_3 = (__pyx_v_dst_type != Py_None);
       __pyx_t_2 = (__pyx_t_3 != 0);
       if (__pyx_t_2) {
-        __pyx_t_1 = __Pyx_GetItemInt(__pyx_v_src_sig, __pyx_v_i, Py_ssize_t, 1, PyInt_FromSsize_t, 0, 0, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 126, __pyx_L1_error)
+        __pyx_t_1 = __Pyx_GetItemInt(__pyx_v_src_sig, __pyx_v_i, Py_ssize_t, 1, PyInt_FromSsize_t, 0, 0, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 123, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_1);
-        __pyx_t_13 = PyObject_RichCompare(__pyx_t_1, __pyx_v_dst_type, Py_EQ); __Pyx_XGOTREF(__pyx_t_13); if (unlikely(!__pyx_t_13)) __PYX_ERR(0, 126, __pyx_L1_error)
+        __pyx_t_13 = PyObject_RichCompare(__pyx_t_1, __pyx_v_dst_type, Py_EQ); __Pyx_XGOTREF(__pyx_t_13); if (unlikely(!__pyx_t_13)) __PYX_ERR(0, 123, __pyx_L1_error)
         __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
-        __pyx_t_2 = __Pyx_PyObject_IsTrue(__pyx_t_13); if (unlikely(__pyx_t_2 < 0)) __PYX_ERR(0, 126, __pyx_L1_error)
+        __pyx_t_2 = __Pyx_PyObject_IsTrue(__pyx_t_13); if (unlikely(__pyx_t_2 < 0)) __PYX_ERR(0, 123, __pyx_L1_error)
         __Pyx_DECREF(__pyx_t_13); __pyx_t_13 = 0;
         if (__pyx_t_2) {
           __pyx_v_match_found = 1;
@@ -5261,35 +5265,35 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_4distmat_reorder_cond
     __pyx_L32_break:;
     __pyx_t_2 = (__pyx_v_match_found != 0);
     if (__pyx_t_2) {
-      __pyx_t_18 = __Pyx_PyList_Append(__pyx_v_candidates, __pyx_v_sig); if (unlikely(__pyx_t_18 == ((int)-1))) __PYX_ERR(0, 126, __pyx_L1_error)
+      __pyx_t_18 = __Pyx_PyList_Append(__pyx_v_candidates, __pyx_v_sig); if (unlikely(__pyx_t_18 == ((int)-1))) __PYX_ERR(0, 123, __pyx_L1_error)
     }
   }
   __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
   __pyx_t_2 = (PyList_GET_SIZE(__pyx_v_candidates) != 0);
   __pyx_t_3 = ((!__pyx_t_2) != 0);
   if (__pyx_t_3) {
-    __pyx_t_6 = __Pyx_PyObject_Call(__pyx_builtin_TypeError, __pyx_tuple__4, NULL); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 126, __pyx_L1_error)
+    __pyx_t_6 = __Pyx_PyObject_Call(__pyx_builtin_TypeError, __pyx_tuple__4, NULL); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 123, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_6);
     __Pyx_Raise(__pyx_t_6, 0, 0, 0);
     __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
-    __PYX_ERR(0, 126, __pyx_L1_error)
+    __PYX_ERR(0, 123, __pyx_L1_error)
   }
-  __pyx_t_9 = PyList_GET_SIZE(__pyx_v_candidates); if (unlikely(__pyx_t_9 == ((Py_ssize_t)-1))) __PYX_ERR(0, 126, __pyx_L1_error)
+  __pyx_t_9 = PyList_GET_SIZE(__pyx_v_candidates); if (unlikely(__pyx_t_9 == ((Py_ssize_t)-1))) __PYX_ERR(0, 123, __pyx_L1_error)
   __pyx_t_3 = ((__pyx_t_9 > 1) != 0);
   if (__pyx_t_3) {
-    __pyx_t_6 = __Pyx_PyObject_Call(__pyx_builtin_TypeError, __pyx_tuple__5, NULL); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 126, __pyx_L1_error)
+    __pyx_t_6 = __Pyx_PyObject_Call(__pyx_builtin_TypeError, __pyx_tuple__5, NULL); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 123, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_6);
     __Pyx_Raise(__pyx_t_6, 0, 0, 0);
     __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
-    __PYX_ERR(0, 126, __pyx_L1_error)
+    __PYX_ERR(0, 123, __pyx_L1_error)
   }
   /*else*/ {
     __Pyx_XDECREF(__pyx_r);
     if (unlikely(__pyx_v_signatures == Py_None)) {
       PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-      __PYX_ERR(0, 126, __pyx_L1_error)
+      __PYX_ERR(0, 123, __pyx_L1_error)
     }
-    __pyx_t_6 = __Pyx_PyDict_GetItem(((PyObject*)__pyx_v_signatures), PyList_GET_ITEM(__pyx_v_candidates, 0)); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 126, __pyx_L1_error)
+    __pyx_t_6 = __Pyx_PyDict_GetItem(((PyObject*)__pyx_v_signatures), PyList_GET_ITEM(__pyx_v_candidates, 0)); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 123, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_6);
     __pyx_r = __pyx_t_6;
     __pyx_t_6 = 0;
@@ -5359,17 +5363,17 @@ static PyObject *__pyx_fuse_0__pyx_pw_5skbio_5stats_8distance_7_cutils_21distmat
         case  1:
         if (likely((values[1] = __Pyx_PyDict_GetItemStr(__pyx_kwds, __pyx_n_s_reorder_vec)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("distmat_reorder_condensed_cy", 1, 3, 3, 1); __PYX_ERR(0, 126, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("distmat_reorder_condensed_cy", 1, 3, 3, 1); __PYX_ERR(0, 123, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  2:
         if (likely((values[2] = __Pyx_PyDict_GetItemStr(__pyx_kwds, __pyx_n_s_out_mat_condensed)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("distmat_reorder_condensed_cy", 1, 3, 3, 2); __PYX_ERR(0, 126, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("distmat_reorder_condensed_cy", 1, 3, 3, 2); __PYX_ERR(0, 123, __pyx_L3_error)
         }
       }
       if (unlikely(kw_args > 0)) {
-        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "distmat_reorder_condensed_cy") < 0)) __PYX_ERR(0, 126, __pyx_L3_error)
+        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "distmat_reorder_condensed_cy") < 0)) __PYX_ERR(0, 123, __pyx_L3_error)
       }
     } else if (PyTuple_GET_SIZE(__pyx_args) != 3) {
       goto __pyx_L5_argtuple_error;
@@ -5378,13 +5382,13 @@ static PyObject *__pyx_fuse_0__pyx_pw_5skbio_5stats_8distance_7_cutils_21distmat
       values[1] = PyTuple_GET_ITEM(__pyx_args, 1);
       values[2] = PyTuple_GET_ITEM(__pyx_args, 2);
     }
-    __pyx_v_in_mat = __Pyx_PyObject_to_MemoryviewSlice_d_dc_float(values[0], PyBUF_WRITABLE); if (unlikely(!__pyx_v_in_mat.memview)) __PYX_ERR(0, 126, __pyx_L3_error)
-    __pyx_v_reorder_vec = __Pyx_PyObject_to_MemoryviewSlice_dc_long(values[1], PyBUF_WRITABLE); if (unlikely(!__pyx_v_reorder_vec.memview)) __PYX_ERR(0, 126, __pyx_L3_error)
-    __pyx_v_out_mat_condensed = __Pyx_PyObject_to_MemoryviewSlice_dc_float(values[2], PyBUF_WRITABLE); if (unlikely(!__pyx_v_out_mat_condensed.memview)) __PYX_ERR(0, 127, __pyx_L3_error)
+    __pyx_v_in_mat = __Pyx_PyObject_to_MemoryviewSlice_d_dc_float(values[0], PyBUF_WRITABLE); if (unlikely(!__pyx_v_in_mat.memview)) __PYX_ERR(0, 123, __pyx_L3_error)
+    __pyx_v_reorder_vec = __Pyx_PyObject_to_MemoryviewSlice_dc_long(values[1], PyBUF_WRITABLE); if (unlikely(!__pyx_v_reorder_vec.memview)) __PYX_ERR(0, 123, __pyx_L3_error)
+    __pyx_v_out_mat_condensed = __Pyx_PyObject_to_MemoryviewSlice_dc_float(values[2], PyBUF_WRITABLE); if (unlikely(!__pyx_v_out_mat_condensed.memview)) __PYX_ERR(0, 124, __pyx_L3_error)
   }
   goto __pyx_L4_argument_unpacking_done;
   __pyx_L5_argtuple_error:;
-  __Pyx_RaiseArgtupleInvalid("distmat_reorder_condensed_cy", 1, 3, 3, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 126, __pyx_L3_error)
+  __Pyx_RaiseArgtupleInvalid("distmat_reorder_condensed_cy", 1, 3, 3, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 123, __pyx_L3_error)
   __pyx_L3_error:;
   __Pyx_AddTraceback("skbio.stats.distance._cutils.distmat_reorder_condensed_cy", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __Pyx_RefNannyFinishContext();
@@ -5423,7 +5427,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_20distmat_reorder_con
   int __pyx_clineno = 0;
   __Pyx_RefNannySetupContext("__pyx_fuse_0distmat_reorder_condensed_cy", 0);
 
-  /* "skbio/stats/distance/_cutils.pyx":155
+  /* "skbio/stats/distance/_cutils.pyx":152
  *         Output, condensed distance matrix
  *     """
  *     cdef Py_ssize_t in_n = in_mat.shape[0]             # <<<<<<<<<<<<<<
@@ -5432,7 +5436,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_20distmat_reorder_con
  */
   __pyx_v_in_n = (__pyx_v_in_mat.shape[0]);
 
-  /* "skbio/stats/distance/_cutils.pyx":156
+  /* "skbio/stats/distance/_cutils.pyx":153
  *     """
  *     cdef Py_ssize_t in_n = in_mat.shape[0]
  *     cdef Py_ssize_t in2 = in_mat.shape[1]             # <<<<<<<<<<<<<<
@@ -5441,7 +5445,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_20distmat_reorder_con
  */
   __pyx_v_in2 = (__pyx_v_in_mat.shape[1]);
 
-  /* "skbio/stats/distance/_cutils.pyx":157
+  /* "skbio/stats/distance/_cutils.pyx":154
  *     cdef Py_ssize_t in_n = in_mat.shape[0]
  *     cdef Py_ssize_t in2 = in_mat.shape[1]
  *     cdef Py_ssize_t out_n = reorder_vec.shape[0]             # <<<<<<<<<<<<<<
@@ -5450,7 +5454,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_20distmat_reorder_con
  */
   __pyx_v_out_n = (__pyx_v_reorder_vec.shape[0]);
 
-  /* "skbio/stats/distance/_cutils.pyx":158
+  /* "skbio/stats/distance/_cutils.pyx":155
  *     cdef Py_ssize_t in2 = in_mat.shape[1]
  *     cdef Py_ssize_t out_n = reorder_vec.shape[0]
  *     cdef Py_ssize_t on2 = out_mat_condensed.shape[0]             # <<<<<<<<<<<<<<
@@ -5459,7 +5463,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_20distmat_reorder_con
  */
   __pyx_v_on2 = (__pyx_v_out_mat_condensed.shape[0]);
 
-  /* "skbio/stats/distance/_cutils.pyx":160
+  /* "skbio/stats/distance/_cutils.pyx":157
  *     cdef Py_ssize_t on2 = out_mat_condensed.shape[0]
  * 
  *     assert in_n == in2             # <<<<<<<<<<<<<<
@@ -5470,12 +5474,12 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_20distmat_reorder_con
   if (unlikely(!Py_OptimizeFlag)) {
     if (unlikely(!((__pyx_v_in_n == __pyx_v_in2) != 0))) {
       PyErr_SetNone(PyExc_AssertionError);
-      __PYX_ERR(0, 160, __pyx_L1_error)
+      __PYX_ERR(0, 157, __pyx_L1_error)
     }
   }
   #endif
 
-  /* "skbio/stats/distance/_cutils.pyx":161
+  /* "skbio/stats/distance/_cutils.pyx":158
  * 
  *     assert in_n == in2
  *     assert on2 == ((out_n-1)*out_n)/2             # <<<<<<<<<<<<<<
@@ -5486,12 +5490,12 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_20distmat_reorder_con
   if (unlikely(!Py_OptimizeFlag)) {
     if (unlikely(!((__pyx_v_on2 == __Pyx_div_Py_ssize_t(((__pyx_v_out_n - 1) * __pyx_v_out_n), 2)) != 0))) {
       PyErr_SetNone(PyExc_AssertionError);
-      __PYX_ERR(0, 161, __pyx_L1_error)
+      __PYX_ERR(0, 158, __pyx_L1_error)
     }
   }
   #endif
 
-  /* "skbio/stats/distance/_cutils.pyx":167
+  /* "skbio/stats/distance/_cutils.pyx":164
  *     cdef Py_ssize_t idx
  * 
  *     for row in prange(out_n-1, nogil=True):             # <<<<<<<<<<<<<<
@@ -5532,7 +5536,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_20distmat_reorder_con
                             __pyx_v_idx = ((Py_ssize_t)0xbad0bad0);
                             __pyx_v_vrow = ((Py_ssize_t)0xbad0bad0);
 
-                            /* "skbio/stats/distance/_cutils.pyx":168
+                            /* "skbio/stats/distance/_cutils.pyx":165
  * 
  *     for row in prange(out_n-1, nogil=True):
  *         vrow = reorder_vec[row]             # <<<<<<<<<<<<<<
@@ -5542,7 +5546,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_20distmat_reorder_con
                             __pyx_t_4 = __pyx_v_row;
                             __pyx_v_vrow = (*((long *) ( /* dim=0 */ ((char *) (((long *) __pyx_v_reorder_vec.data) + __pyx_t_4)) )));
 
-                            /* "skbio/stats/distance/_cutils.pyx":169
+                            /* "skbio/stats/distance/_cutils.pyx":166
  *     for row in prange(out_n-1, nogil=True):
  *         vrow = reorder_vec[row]
  *         idx = row*(out_n-1) - ((row-1)*row)/2             # <<<<<<<<<<<<<<
@@ -5551,7 +5555,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_20distmat_reorder_con
  */
                             __pyx_v_idx = ((__pyx_v_row * (__pyx_v_out_n - 1)) - __Pyx_div_Py_ssize_t(((__pyx_v_row - 1) * __pyx_v_row), 2));
 
-                            /* "skbio/stats/distance/_cutils.pyx":170
+                            /* "skbio/stats/distance/_cutils.pyx":167
  *         vrow = reorder_vec[row]
  *         idx = row*(out_n-1) - ((row-1)*row)/2
  *         for col in range(out_n-row-1):             # <<<<<<<<<<<<<<
@@ -5563,7 +5567,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_20distmat_reorder_con
                             for (__pyx_t_7 = 0; __pyx_t_7 < __pyx_t_6; __pyx_t_7+=1) {
                               __pyx_v_col = __pyx_t_7;
 
-                              /* "skbio/stats/distance/_cutils.pyx":171
+                              /* "skbio/stats/distance/_cutils.pyx":168
  *         idx = row*(out_n-1) - ((row-1)*row)/2
  *         for col in range(out_n-row-1):
  *            out_mat_condensed[idx+col] = in_mat[vrow, reorder_vec[col+row+1]]             # <<<<<<<<<<<<<<
@@ -5589,7 +5593,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_20distmat_reorder_con
         #endif
       }
 
-      /* "skbio/stats/distance/_cutils.pyx":167
+      /* "skbio/stats/distance/_cutils.pyx":164
  *     cdef Py_ssize_t idx
  * 
  *     for row in prange(out_n-1, nogil=True):             # <<<<<<<<<<<<<<
@@ -5608,7 +5612,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_20distmat_reorder_con
       }
   }
 
-  /* "skbio/stats/distance/_cutils.pyx":126
+  /* "skbio/stats/distance/_cutils.pyx":123
  * @cython.boundscheck(False)
  * @cython.wraparound(False)
  * def distmat_reorder_condensed_cy(TReal[:, ::1] in_mat, long[::1] reorder_vec,             # <<<<<<<<<<<<<<
@@ -5669,17 +5673,17 @@ static PyObject *__pyx_fuse_1__pyx_pw_5skbio_5stats_8distance_7_cutils_23distmat
         case  1:
         if (likely((values[1] = __Pyx_PyDict_GetItemStr(__pyx_kwds, __pyx_n_s_reorder_vec)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("distmat_reorder_condensed_cy", 1, 3, 3, 1); __PYX_ERR(0, 126, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("distmat_reorder_condensed_cy", 1, 3, 3, 1); __PYX_ERR(0, 123, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  2:
         if (likely((values[2] = __Pyx_PyDict_GetItemStr(__pyx_kwds, __pyx_n_s_out_mat_condensed)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("distmat_reorder_condensed_cy", 1, 3, 3, 2); __PYX_ERR(0, 126, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("distmat_reorder_condensed_cy", 1, 3, 3, 2); __PYX_ERR(0, 123, __pyx_L3_error)
         }
       }
       if (unlikely(kw_args > 0)) {
-        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "distmat_reorder_condensed_cy") < 0)) __PYX_ERR(0, 126, __pyx_L3_error)
+        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "distmat_reorder_condensed_cy") < 0)) __PYX_ERR(0, 123, __pyx_L3_error)
       }
     } else if (PyTuple_GET_SIZE(__pyx_args) != 3) {
       goto __pyx_L5_argtuple_error;
@@ -5688,13 +5692,13 @@ static PyObject *__pyx_fuse_1__pyx_pw_5skbio_5stats_8distance_7_cutils_23distmat
       values[1] = PyTuple_GET_ITEM(__pyx_args, 1);
       values[2] = PyTuple_GET_ITEM(__pyx_args, 2);
     }
-    __pyx_v_in_mat = __Pyx_PyObject_to_MemoryviewSlice_d_dc_double(values[0], PyBUF_WRITABLE); if (unlikely(!__pyx_v_in_mat.memview)) __PYX_ERR(0, 126, __pyx_L3_error)
-    __pyx_v_reorder_vec = __Pyx_PyObject_to_MemoryviewSlice_dc_long(values[1], PyBUF_WRITABLE); if (unlikely(!__pyx_v_reorder_vec.memview)) __PYX_ERR(0, 126, __pyx_L3_error)
-    __pyx_v_out_mat_condensed = __Pyx_PyObject_to_MemoryviewSlice_dc_double(values[2], PyBUF_WRITABLE); if (unlikely(!__pyx_v_out_mat_condensed.memview)) __PYX_ERR(0, 127, __pyx_L3_error)
+    __pyx_v_in_mat = __Pyx_PyObject_to_MemoryviewSlice_d_dc_double(values[0], PyBUF_WRITABLE); if (unlikely(!__pyx_v_in_mat.memview)) __PYX_ERR(0, 123, __pyx_L3_error)
+    __pyx_v_reorder_vec = __Pyx_PyObject_to_MemoryviewSlice_dc_long(values[1], PyBUF_WRITABLE); if (unlikely(!__pyx_v_reorder_vec.memview)) __PYX_ERR(0, 123, __pyx_L3_error)
+    __pyx_v_out_mat_condensed = __Pyx_PyObject_to_MemoryviewSlice_dc_double(values[2], PyBUF_WRITABLE); if (unlikely(!__pyx_v_out_mat_condensed.memview)) __PYX_ERR(0, 124, __pyx_L3_error)
   }
   goto __pyx_L4_argument_unpacking_done;
   __pyx_L5_argtuple_error:;
-  __Pyx_RaiseArgtupleInvalid("distmat_reorder_condensed_cy", 1, 3, 3, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 126, __pyx_L3_error)
+  __Pyx_RaiseArgtupleInvalid("distmat_reorder_condensed_cy", 1, 3, 3, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 123, __pyx_L3_error)
   __pyx_L3_error:;
   __Pyx_AddTraceback("skbio.stats.distance._cutils.distmat_reorder_condensed_cy", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __Pyx_RefNannyFinishContext();
@@ -5733,7 +5737,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_22distmat_reorder_con
   int __pyx_clineno = 0;
   __Pyx_RefNannySetupContext("__pyx_fuse_1distmat_reorder_condensed_cy", 0);
 
-  /* "skbio/stats/distance/_cutils.pyx":155
+  /* "skbio/stats/distance/_cutils.pyx":152
  *         Output, condensed distance matrix
  *     """
  *     cdef Py_ssize_t in_n = in_mat.shape[0]             # <<<<<<<<<<<<<<
@@ -5742,7 +5746,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_22distmat_reorder_con
  */
   __pyx_v_in_n = (__pyx_v_in_mat.shape[0]);
 
-  /* "skbio/stats/distance/_cutils.pyx":156
+  /* "skbio/stats/distance/_cutils.pyx":153
  *     """
  *     cdef Py_ssize_t in_n = in_mat.shape[0]
  *     cdef Py_ssize_t in2 = in_mat.shape[1]             # <<<<<<<<<<<<<<
@@ -5751,7 +5755,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_22distmat_reorder_con
  */
   __pyx_v_in2 = (__pyx_v_in_mat.shape[1]);
 
-  /* "skbio/stats/distance/_cutils.pyx":157
+  /* "skbio/stats/distance/_cutils.pyx":154
  *     cdef Py_ssize_t in_n = in_mat.shape[0]
  *     cdef Py_ssize_t in2 = in_mat.shape[1]
  *     cdef Py_ssize_t out_n = reorder_vec.shape[0]             # <<<<<<<<<<<<<<
@@ -5760,7 +5764,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_22distmat_reorder_con
  */
   __pyx_v_out_n = (__pyx_v_reorder_vec.shape[0]);
 
-  /* "skbio/stats/distance/_cutils.pyx":158
+  /* "skbio/stats/distance/_cutils.pyx":155
  *     cdef Py_ssize_t in2 = in_mat.shape[1]
  *     cdef Py_ssize_t out_n = reorder_vec.shape[0]
  *     cdef Py_ssize_t on2 = out_mat_condensed.shape[0]             # <<<<<<<<<<<<<<
@@ -5769,7 +5773,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_22distmat_reorder_con
  */
   __pyx_v_on2 = (__pyx_v_out_mat_condensed.shape[0]);
 
-  /* "skbio/stats/distance/_cutils.pyx":160
+  /* "skbio/stats/distance/_cutils.pyx":157
  *     cdef Py_ssize_t on2 = out_mat_condensed.shape[0]
  * 
  *     assert in_n == in2             # <<<<<<<<<<<<<<
@@ -5780,12 +5784,12 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_22distmat_reorder_con
   if (unlikely(!Py_OptimizeFlag)) {
     if (unlikely(!((__pyx_v_in_n == __pyx_v_in2) != 0))) {
       PyErr_SetNone(PyExc_AssertionError);
-      __PYX_ERR(0, 160, __pyx_L1_error)
+      __PYX_ERR(0, 157, __pyx_L1_error)
     }
   }
   #endif
 
-  /* "skbio/stats/distance/_cutils.pyx":161
+  /* "skbio/stats/distance/_cutils.pyx":158
  * 
  *     assert in_n == in2
  *     assert on2 == ((out_n-1)*out_n)/2             # <<<<<<<<<<<<<<
@@ -5796,12 +5800,12 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_22distmat_reorder_con
   if (unlikely(!Py_OptimizeFlag)) {
     if (unlikely(!((__pyx_v_on2 == __Pyx_div_Py_ssize_t(((__pyx_v_out_n - 1) * __pyx_v_out_n), 2)) != 0))) {
       PyErr_SetNone(PyExc_AssertionError);
-      __PYX_ERR(0, 161, __pyx_L1_error)
+      __PYX_ERR(0, 158, __pyx_L1_error)
     }
   }
   #endif
 
-  /* "skbio/stats/distance/_cutils.pyx":167
+  /* "skbio/stats/distance/_cutils.pyx":164
  *     cdef Py_ssize_t idx
  * 
  *     for row in prange(out_n-1, nogil=True):             # <<<<<<<<<<<<<<
@@ -5842,7 +5846,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_22distmat_reorder_con
                             __pyx_v_idx = ((Py_ssize_t)0xbad0bad0);
                             __pyx_v_vrow = ((Py_ssize_t)0xbad0bad0);
 
-                            /* "skbio/stats/distance/_cutils.pyx":168
+                            /* "skbio/stats/distance/_cutils.pyx":165
  * 
  *     for row in prange(out_n-1, nogil=True):
  *         vrow = reorder_vec[row]             # <<<<<<<<<<<<<<
@@ -5852,7 +5856,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_22distmat_reorder_con
                             __pyx_t_4 = __pyx_v_row;
                             __pyx_v_vrow = (*((long *) ( /* dim=0 */ ((char *) (((long *) __pyx_v_reorder_vec.data) + __pyx_t_4)) )));
 
-                            /* "skbio/stats/distance/_cutils.pyx":169
+                            /* "skbio/stats/distance/_cutils.pyx":166
  *     for row in prange(out_n-1, nogil=True):
  *         vrow = reorder_vec[row]
  *         idx = row*(out_n-1) - ((row-1)*row)/2             # <<<<<<<<<<<<<<
@@ -5861,7 +5865,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_22distmat_reorder_con
  */
                             __pyx_v_idx = ((__pyx_v_row * (__pyx_v_out_n - 1)) - __Pyx_div_Py_ssize_t(((__pyx_v_row - 1) * __pyx_v_row), 2));
 
-                            /* "skbio/stats/distance/_cutils.pyx":170
+                            /* "skbio/stats/distance/_cutils.pyx":167
  *         vrow = reorder_vec[row]
  *         idx = row*(out_n-1) - ((row-1)*row)/2
  *         for col in range(out_n-row-1):             # <<<<<<<<<<<<<<
@@ -5873,7 +5877,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_22distmat_reorder_con
                             for (__pyx_t_7 = 0; __pyx_t_7 < __pyx_t_6; __pyx_t_7+=1) {
                               __pyx_v_col = __pyx_t_7;
 
-                              /* "skbio/stats/distance/_cutils.pyx":171
+                              /* "skbio/stats/distance/_cutils.pyx":168
  *         idx = row*(out_n-1) - ((row-1)*row)/2
  *         for col in range(out_n-row-1):
  *            out_mat_condensed[idx+col] = in_mat[vrow, reorder_vec[col+row+1]]             # <<<<<<<<<<<<<<
@@ -5899,7 +5903,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_22distmat_reorder_con
         #endif
       }
 
-      /* "skbio/stats/distance/_cutils.pyx":167
+      /* "skbio/stats/distance/_cutils.pyx":164
  *     cdef Py_ssize_t idx
  * 
  *     for row in prange(out_n-1, nogil=True):             # <<<<<<<<<<<<<<
@@ -5918,7 +5922,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_22distmat_reorder_con
       }
   }
 
-  /* "skbio/stats/distance/_cutils.pyx":126
+  /* "skbio/stats/distance/_cutils.pyx":123
  * @cython.boundscheck(False)
  * @cython.wraparound(False)
  * def distmat_reorder_condensed_cy(TReal[:, ::1] in_mat, long[::1] reorder_vec,             # <<<<<<<<<<<<<<
@@ -5941,7 +5945,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_22distmat_reorder_con
   return __pyx_r;
 }
 
-/* "skbio/stats/distance/_cutils.pyx":176
+/* "skbio/stats/distance/_cutils.pyx":173
  * @cython.boundscheck(False)
  * @cython.wraparound(False)
  * def mantel_perm_pearsonr_cy(TReal[:, ::1] x_data, long[:, ::1] perm_order,             # <<<<<<<<<<<<<<
@@ -5991,23 +5995,23 @@ static PyObject *__pyx_pw_5skbio_5stats_8distance_7_cutils_7mantel_perm_pearsonr
         case  1:
         if (likely((values[1] = __Pyx_PyDict_GetItemStr(__pyx_kwds, __pyx_n_s_args)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("__pyx_fused_cpdef", 1, 4, 4, 1); __PYX_ERR(0, 176, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("__pyx_fused_cpdef", 1, 4, 4, 1); __PYX_ERR(0, 173, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  2:
         if (likely((values[2] = __Pyx_PyDict_GetItemStr(__pyx_kwds, __pyx_n_s_kwargs)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("__pyx_fused_cpdef", 1, 4, 4, 2); __PYX_ERR(0, 176, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("__pyx_fused_cpdef", 1, 4, 4, 2); __PYX_ERR(0, 173, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  3:
         if (likely((values[3] = __Pyx_PyDict_GetItemStr(__pyx_kwds, __pyx_n_s_defaults)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("__pyx_fused_cpdef", 1, 4, 4, 3); __PYX_ERR(0, 176, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("__pyx_fused_cpdef", 1, 4, 4, 3); __PYX_ERR(0, 173, __pyx_L3_error)
         }
       }
       if (unlikely(kw_args > 0)) {
-        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "__pyx_fused_cpdef") < 0)) __PYX_ERR(0, 176, __pyx_L3_error)
+        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "__pyx_fused_cpdef") < 0)) __PYX_ERR(0, 173, __pyx_L3_error)
       }
     } else if (PyTuple_GET_SIZE(__pyx_args) != 4) {
       goto __pyx_L5_argtuple_error;
@@ -6024,7 +6028,7 @@ static PyObject *__pyx_pw_5skbio_5stats_8distance_7_cutils_7mantel_perm_pearsonr
   }
   goto __pyx_L4_argument_unpacking_done;
   __pyx_L5_argtuple_error:;
-  __Pyx_RaiseArgtupleInvalid("__pyx_fused_cpdef", 1, 4, 4, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 176, __pyx_L3_error)
+  __Pyx_RaiseArgtupleInvalid("__pyx_fused_cpdef", 1, 4, 4, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 173, __pyx_L3_error)
   __pyx_L3_error:;
   __Pyx_AddTraceback("skbio.stats.distance._cutils.__pyx_fused_cpdef", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __Pyx_RefNannyFinishContext();
@@ -6078,7 +6082,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_6mantel_perm_pearsonr
   int __pyx_clineno = 0;
   __Pyx_RefNannySetupContext("mantel_perm_pearsonr_cy", 0);
   __Pyx_INCREF(__pyx_v_kwargs);
-  __pyx_t_1 = PyList_New(1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 176, __pyx_L1_error)
+  __pyx_t_1 = PyList_New(1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 173, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __Pyx_INCREF(Py_None);
   __Pyx_GIVEREF(Py_None);
@@ -6092,7 +6096,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_6mantel_perm_pearsonr
     __pyx_t_2 = __pyx_t_4;
     goto __pyx_L4_bool_binop_done;
   }
-  __pyx_t_4 = __Pyx_PyObject_IsTrue(__pyx_v_kwargs); if (unlikely(__pyx_t_4 < 0)) __PYX_ERR(0, 176, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_PyObject_IsTrue(__pyx_v_kwargs); if (unlikely(__pyx_t_4 < 0)) __PYX_ERR(0, 173, __pyx_L1_error)
   __pyx_t_3 = ((!__pyx_t_4) != 0);
   __pyx_t_2 = __pyx_t_3;
   __pyx_L4_bool_binop_done:;
@@ -6100,21 +6104,21 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_6mantel_perm_pearsonr
     __Pyx_INCREF(Py_None);
     __Pyx_DECREF_SET(__pyx_v_kwargs, Py_None);
   }
-  __pyx_t_1 = ((PyObject *)__Pyx_ImportNumPyArrayTypeIfAvailable()); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 176, __pyx_L1_error)
+  __pyx_t_1 = ((PyObject *)__Pyx_ImportNumPyArrayTypeIfAvailable()); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 173, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __pyx_v_ndarray = ((PyTypeObject*)__pyx_t_1);
   __pyx_t_1 = 0;
   __pyx_v_itemsize = -1L;
   if (unlikely(__pyx_v_args == Py_None)) {
     PyErr_SetString(PyExc_TypeError, "object of type 'NoneType' has no len()");
-    __PYX_ERR(0, 176, __pyx_L1_error)
+    __PYX_ERR(0, 173, __pyx_L1_error)
   }
-  __pyx_t_5 = PyTuple_GET_SIZE(((PyObject*)__pyx_v_args)); if (unlikely(__pyx_t_5 == ((Py_ssize_t)-1))) __PYX_ERR(0, 176, __pyx_L1_error)
+  __pyx_t_5 = PyTuple_GET_SIZE(((PyObject*)__pyx_v_args)); if (unlikely(__pyx_t_5 == ((Py_ssize_t)-1))) __PYX_ERR(0, 173, __pyx_L1_error)
   __pyx_t_2 = ((0 < __pyx_t_5) != 0);
   if (__pyx_t_2) {
     if (unlikely(__pyx_v_args == Py_None)) {
       PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-      __PYX_ERR(0, 176, __pyx_L1_error)
+      __PYX_ERR(0, 173, __pyx_L1_error)
     }
     __pyx_t_1 = PyTuple_GET_ITEM(((PyObject*)__pyx_v_args), 0);
     __Pyx_INCREF(__pyx_t_1);
@@ -6131,18 +6135,18 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_6mantel_perm_pearsonr
   }
   if (unlikely(__pyx_v_kwargs == Py_None)) {
     PyErr_SetString(PyExc_TypeError, "'NoneType' object is not iterable");
-    __PYX_ERR(0, 176, __pyx_L1_error)
+    __PYX_ERR(0, 173, __pyx_L1_error)
   }
-  __pyx_t_4 = (__Pyx_PyDict_ContainsTF(__pyx_n_s_x_data, ((PyObject*)__pyx_v_kwargs), Py_EQ)); if (unlikely(__pyx_t_4 < 0)) __PYX_ERR(0, 176, __pyx_L1_error)
+  __pyx_t_4 = (__Pyx_PyDict_ContainsTF(__pyx_n_s_x_data, ((PyObject*)__pyx_v_kwargs), Py_EQ)); if (unlikely(__pyx_t_4 < 0)) __PYX_ERR(0, 173, __pyx_L1_error)
   __pyx_t_3 = (__pyx_t_4 != 0);
   __pyx_t_2 = __pyx_t_3;
   __pyx_L7_bool_binop_done:;
   if (__pyx_t_2) {
     if (unlikely(__pyx_v_kwargs == Py_None)) {
       PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-      __PYX_ERR(0, 176, __pyx_L1_error)
+      __PYX_ERR(0, 173, __pyx_L1_error)
     }
-    __pyx_t_1 = __Pyx_PyDict_GetItem(((PyObject*)__pyx_v_kwargs), __pyx_n_s_x_data); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 176, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_PyDict_GetItem(((PyObject*)__pyx_v_kwargs), __pyx_n_s_x_data); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 173, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
     __pyx_v_arg = __pyx_t_1;
     __pyx_t_1 = 0;
@@ -6151,12 +6155,12 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_6mantel_perm_pearsonr
   /*else*/ {
     if (unlikely(__pyx_v_args == Py_None)) {
       PyErr_SetString(PyExc_TypeError, "object of type 'NoneType' has no len()");
-      __PYX_ERR(0, 176, __pyx_L1_error)
+      __PYX_ERR(0, 173, __pyx_L1_error)
     }
-    __pyx_t_5 = PyTuple_GET_SIZE(((PyObject*)__pyx_v_args)); if (unlikely(__pyx_t_5 == ((Py_ssize_t)-1))) __PYX_ERR(0, 176, __pyx_L1_error)
-    __pyx_t_1 = PyInt_FromSsize_t(__pyx_t_5); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 176, __pyx_L1_error)
+    __pyx_t_5 = PyTuple_GET_SIZE(((PyObject*)__pyx_v_args)); if (unlikely(__pyx_t_5 == ((Py_ssize_t)-1))) __PYX_ERR(0, 173, __pyx_L1_error)
+    __pyx_t_1 = PyInt_FromSsize_t(__pyx_t_5); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 173, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
-    __pyx_t_6 = PyTuple_New(3); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 176, __pyx_L1_error)
+    __pyx_t_6 = PyTuple_New(3); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 173, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_6);
     __Pyx_INCREF(__pyx_int_6);
     __Pyx_GIVEREF(__pyx_int_6);
@@ -6167,15 +6171,15 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_6mantel_perm_pearsonr
     __Pyx_GIVEREF(__pyx_t_1);
     PyTuple_SET_ITEM(__pyx_t_6, 2, __pyx_t_1);
     __pyx_t_1 = 0;
-    __pyx_t_1 = __Pyx_PyString_Format(__pyx_kp_s_Expected_at_least_d_argument_s_g, __pyx_t_6); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 176, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_PyString_Format(__pyx_kp_s_Expected_at_least_d_argument_s_g, __pyx_t_6); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 173, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
-    __pyx_t_6 = __Pyx_PyObject_CallOneArg(__pyx_builtin_TypeError, __pyx_t_1); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 176, __pyx_L1_error)
+    __pyx_t_6 = __Pyx_PyObject_CallOneArg(__pyx_builtin_TypeError, __pyx_t_1); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 173, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_6);
     __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
     __Pyx_Raise(__pyx_t_6, 0, 0, 0);
     __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
-    __PYX_ERR(0, 176, __pyx_L1_error)
+    __PYX_ERR(0, 173, __pyx_L1_error)
   }
   __pyx_L6:;
   while (1) {
@@ -6185,7 +6189,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_6mantel_perm_pearsonr
       __pyx_t_3 = __Pyx_TypeCheck(__pyx_v_arg, __pyx_v_ndarray); 
       __pyx_t_2 = (__pyx_t_3 != 0);
       if (__pyx_t_2) {
-        __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_dtype); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 176, __pyx_L1_error)
+        __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_dtype); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 173, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_6);
         __pyx_v_dtype = __pyx_t_6;
         __pyx_t_6 = 0;
@@ -6194,14 +6198,14 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_6mantel_perm_pearsonr
       __pyx_t_2 = __pyx_memoryview_check(__pyx_v_arg); 
       __pyx_t_3 = (__pyx_t_2 != 0);
       if (__pyx_t_3) {
-        __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_base); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 176, __pyx_L1_error)
+        __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_base); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 173, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_6);
         __pyx_v_arg_base = __pyx_t_6;
         __pyx_t_6 = 0;
         __pyx_t_3 = __Pyx_TypeCheck(__pyx_v_arg_base, __pyx_v_ndarray); 
         __pyx_t_2 = (__pyx_t_3 != 0);
         if (__pyx_t_2) {
-          __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg_base, __pyx_n_s_dtype); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 176, __pyx_L1_error)
+          __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg_base, __pyx_n_s_dtype); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 173, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_6);
           __pyx_v_dtype = __pyx_t_6;
           __pyx_t_6 = 0;
@@ -6223,14 +6227,14 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_6mantel_perm_pearsonr
       __pyx_t_2 = (__pyx_v_dtype != Py_None);
       __pyx_t_3 = (__pyx_t_2 != 0);
       if (__pyx_t_3) {
-        __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_v_dtype, __pyx_n_s_itemsize); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 176, __pyx_L1_error)
+        __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_v_dtype, __pyx_n_s_itemsize); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 173, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_6);
-        __pyx_t_5 = __Pyx_PyIndex_AsSsize_t(__pyx_t_6); if (unlikely((__pyx_t_5 == (Py_ssize_t)-1) && PyErr_Occurred())) __PYX_ERR(0, 176, __pyx_L1_error)
+        __pyx_t_5 = __Pyx_PyIndex_AsSsize_t(__pyx_t_6); if (unlikely((__pyx_t_5 == (Py_ssize_t)-1) && PyErr_Occurred())) __PYX_ERR(0, 173, __pyx_L1_error)
         __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
         __pyx_v_itemsize = __pyx_t_5;
-        __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_v_dtype, __pyx_n_s_kind); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 176, __pyx_L1_error)
+        __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_v_dtype, __pyx_n_s_kind); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 173, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_6);
-        __pyx_t_7 = __Pyx_PyObject_Ord(__pyx_t_6); if (unlikely(__pyx_t_7 == ((long)(long)(Py_UCS4)-1))) __PYX_ERR(0, 176, __pyx_L1_error)
+        __pyx_t_7 = __Pyx_PyObject_Ord(__pyx_t_6); if (unlikely(__pyx_t_7 == ((long)(long)(Py_UCS4)-1))) __PYX_ERR(0, 173, __pyx_L1_error)
         __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
         __pyx_v_kind = __pyx_t_7;
         __pyx_v_dtype_signed = (__pyx_v_kind == 'i');
@@ -6245,15 +6249,15 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_6mantel_perm_pearsonr
             __pyx_t_3 = __pyx_t_2;
             goto __pyx_L16_bool_binop_done;
           }
-          __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_ndim); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 176, __pyx_L1_error)
+          __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_ndim); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 173, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_6);
-          __pyx_t_5 = __Pyx_PyIndex_AsSsize_t(__pyx_t_6); if (unlikely((__pyx_t_5 == (Py_ssize_t)-1) && PyErr_Occurred())) __PYX_ERR(0, 176, __pyx_L1_error)
+          __pyx_t_5 = __Pyx_PyIndex_AsSsize_t(__pyx_t_6); if (unlikely((__pyx_t_5 == (Py_ssize_t)-1) && PyErr_Occurred())) __PYX_ERR(0, 173, __pyx_L1_error)
           __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
           __pyx_t_2 = ((((Py_ssize_t)__pyx_t_5) == 2) != 0);
           __pyx_t_3 = __pyx_t_2;
           __pyx_L16_bool_binop_done:;
           if (__pyx_t_3) {
-            if (unlikely(__Pyx_SetItemInt(__pyx_v_dest_sig, 0, __pyx_n_s_float, long, 1, __Pyx_PyInt_From_long, 1, 0, 0) < 0)) __PYX_ERR(0, 176, __pyx_L1_error)
+            if (unlikely(__Pyx_SetItemInt(__pyx_v_dest_sig, 0, __pyx_n_s_float, long, 1, __Pyx_PyInt_From_long, 1, 0, 0) < 0)) __PYX_ERR(0, 173, __pyx_L1_error)
             goto __pyx_L10_break;
           }
           __pyx_t_2 = (((sizeof(double)) == __pyx_v_itemsize) != 0);
@@ -6262,15 +6266,15 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_6mantel_perm_pearsonr
             __pyx_t_3 = __pyx_t_2;
             goto __pyx_L19_bool_binop_done;
           }
-          __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_ndim); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 176, __pyx_L1_error)
+          __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_ndim); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 173, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_6);
-          __pyx_t_5 = __Pyx_PyIndex_AsSsize_t(__pyx_t_6); if (unlikely((__pyx_t_5 == (Py_ssize_t)-1) && PyErr_Occurred())) __PYX_ERR(0, 176, __pyx_L1_error)
+          __pyx_t_5 = __Pyx_PyIndex_AsSsize_t(__pyx_t_6); if (unlikely((__pyx_t_5 == (Py_ssize_t)-1) && PyErr_Occurred())) __PYX_ERR(0, 173, __pyx_L1_error)
           __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
           __pyx_t_2 = ((((Py_ssize_t)__pyx_t_5) == 2) != 0);
           __pyx_t_3 = __pyx_t_2;
           __pyx_L19_bool_binop_done:;
           if (__pyx_t_3) {
-            if (unlikely(__Pyx_SetItemInt(__pyx_v_dest_sig, 0, __pyx_n_s_double, long, 1, __Pyx_PyInt_From_long, 1, 0, 0) < 0)) __PYX_ERR(0, 176, __pyx_L1_error)
+            if (unlikely(__Pyx_SetItemInt(__pyx_v_dest_sig, 0, __pyx_n_s_double, long, 1, __Pyx_PyInt_From_long, 1, 0, 0) < 0)) __PYX_ERR(0, 173, __pyx_L1_error)
             goto __pyx_L10_break;
           }
           break;
@@ -6297,7 +6301,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_6mantel_perm_pearsonr
       __pyx_t_3 = (__pyx_v_memslice.memview != 0);
       if (__pyx_t_3) {
         __PYX_XDEC_MEMVIEW((&__pyx_v_memslice), 1); 
-        if (unlikely(__Pyx_SetItemInt(__pyx_v_dest_sig, 0, __pyx_n_s_float, long, 1, __Pyx_PyInt_From_long, 1, 0, 0) < 0)) __PYX_ERR(0, 176, __pyx_L1_error)
+        if (unlikely(__Pyx_SetItemInt(__pyx_v_dest_sig, 0, __pyx_n_s_float, long, 1, __Pyx_PyInt_From_long, 1, 0, 0) < 0)) __PYX_ERR(0, 173, __pyx_L1_error)
         goto __pyx_L10_break;
       }
       /*else*/ {
@@ -6319,27 +6323,27 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_6mantel_perm_pearsonr
       __pyx_t_3 = (__pyx_v_memslice.memview != 0);
       if (__pyx_t_3) {
         __PYX_XDEC_MEMVIEW((&__pyx_v_memslice), 1); 
-        if (unlikely(__Pyx_SetItemInt(__pyx_v_dest_sig, 0, __pyx_n_s_double, long, 1, __Pyx_PyInt_From_long, 1, 0, 0) < 0)) __PYX_ERR(0, 176, __pyx_L1_error)
+        if (unlikely(__Pyx_SetItemInt(__pyx_v_dest_sig, 0, __pyx_n_s_double, long, 1, __Pyx_PyInt_From_long, 1, 0, 0) < 0)) __PYX_ERR(0, 173, __pyx_L1_error)
         goto __pyx_L10_break;
       }
       /*else*/ {
         PyErr_Clear(); 
       }
     }
-    if (unlikely(__Pyx_SetItemInt(__pyx_v_dest_sig, 0, Py_None, long, 1, __Pyx_PyInt_From_long, 1, 0, 0) < 0)) __PYX_ERR(0, 176, __pyx_L1_error)
+    if (unlikely(__Pyx_SetItemInt(__pyx_v_dest_sig, 0, Py_None, long, 1, __Pyx_PyInt_From_long, 1, 0, 0) < 0)) __PYX_ERR(0, 173, __pyx_L1_error)
     goto __pyx_L10_break;
   }
   __pyx_L10_break:;
-  __pyx_t_6 = PyList_New(0); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 176, __pyx_L1_error)
+  __pyx_t_6 = PyList_New(0); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 173, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_6);
   __pyx_v_candidates = ((PyObject*)__pyx_t_6);
   __pyx_t_6 = 0;
   __pyx_t_5 = 0;
   if (unlikely(__pyx_v_signatures == Py_None)) {
     PyErr_SetString(PyExc_TypeError, "'NoneType' object is not iterable");
-    __PYX_ERR(0, 176, __pyx_L1_error)
+    __PYX_ERR(0, 173, __pyx_L1_error)
   }
-  __pyx_t_1 = __Pyx_dict_iterator(((PyObject*)__pyx_v_signatures), 1, ((PyObject *)NULL), (&__pyx_t_9), (&__pyx_t_10)); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 176, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_dict_iterator(((PyObject*)__pyx_v_signatures), 1, ((PyObject *)NULL), (&__pyx_t_9), (&__pyx_t_10)); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 173, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __Pyx_XDECREF(__pyx_t_6);
   __pyx_t_6 = __pyx_t_1;
@@ -6347,12 +6351,12 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_6mantel_perm_pearsonr
   while (1) {
     __pyx_t_11 = __Pyx_dict_iter_next(__pyx_t_6, __pyx_t_9, &__pyx_t_5, &__pyx_t_1, NULL, NULL, __pyx_t_10);
     if (unlikely(__pyx_t_11 == 0)) break;
-    if (unlikely(__pyx_t_11 == -1)) __PYX_ERR(0, 176, __pyx_L1_error)
+    if (unlikely(__pyx_t_11 == -1)) __PYX_ERR(0, 173, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_XDECREF_SET(__pyx_v_sig, __pyx_t_1);
     __pyx_t_1 = 0;
     __pyx_v_match_found = 0;
-    __pyx_t_13 = __Pyx_PyObject_GetAttrStr(__pyx_v_sig, __pyx_n_s_strip); if (unlikely(!__pyx_t_13)) __PYX_ERR(0, 176, __pyx_L1_error)
+    __pyx_t_13 = __Pyx_PyObject_GetAttrStr(__pyx_v_sig, __pyx_n_s_strip); if (unlikely(!__pyx_t_13)) __PYX_ERR(0, 173, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_13);
     __pyx_t_14 = NULL;
     if (CYTHON_UNPACK_METHODS && likely(PyMethod_Check(__pyx_t_13))) {
@@ -6366,10 +6370,10 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_6mantel_perm_pearsonr
     }
     __pyx_t_12 = (__pyx_t_14) ? __Pyx_PyObject_Call2Args(__pyx_t_13, __pyx_t_14, __pyx_kp_s__2) : __Pyx_PyObject_CallOneArg(__pyx_t_13, __pyx_kp_s__2);
     __Pyx_XDECREF(__pyx_t_14); __pyx_t_14 = 0;
-    if (unlikely(!__pyx_t_12)) __PYX_ERR(0, 176, __pyx_L1_error)
+    if (unlikely(!__pyx_t_12)) __PYX_ERR(0, 173, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_12);
     __Pyx_DECREF(__pyx_t_13); __pyx_t_13 = 0;
-    __pyx_t_13 = __Pyx_PyObject_GetAttrStr(__pyx_t_12, __pyx_n_s_split); if (unlikely(!__pyx_t_13)) __PYX_ERR(0, 176, __pyx_L1_error)
+    __pyx_t_13 = __Pyx_PyObject_GetAttrStr(__pyx_t_12, __pyx_n_s_split); if (unlikely(!__pyx_t_13)) __PYX_ERR(0, 173, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_13);
     __Pyx_DECREF(__pyx_t_12); __pyx_t_12 = 0;
     __pyx_t_12 = NULL;
@@ -6384,12 +6388,12 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_6mantel_perm_pearsonr
     }
     __pyx_t_1 = (__pyx_t_12) ? __Pyx_PyObject_Call2Args(__pyx_t_13, __pyx_t_12, __pyx_kp_s__3) : __Pyx_PyObject_CallOneArg(__pyx_t_13, __pyx_kp_s__3);
     __Pyx_XDECREF(__pyx_t_12); __pyx_t_12 = 0;
-    if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 176, __pyx_L1_error)
+    if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 173, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF(__pyx_t_13); __pyx_t_13 = 0;
     __Pyx_XDECREF_SET(__pyx_v_src_sig, __pyx_t_1);
     __pyx_t_1 = 0;
-    __pyx_t_15 = PyList_GET_SIZE(__pyx_v_dest_sig); if (unlikely(__pyx_t_15 == ((Py_ssize_t)-1))) __PYX_ERR(0, 176, __pyx_L1_error)
+    __pyx_t_15 = PyList_GET_SIZE(__pyx_v_dest_sig); if (unlikely(__pyx_t_15 == ((Py_ssize_t)-1))) __PYX_ERR(0, 173, __pyx_L1_error)
     __pyx_t_16 = __pyx_t_15;
     for (__pyx_t_17 = 0; __pyx_t_17 < __pyx_t_16; __pyx_t_17+=1) {
       __pyx_v_i = __pyx_t_17;
@@ -6400,11 +6404,11 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_6mantel_perm_pearsonr
       __pyx_t_3 = (__pyx_v_dst_type != Py_None);
       __pyx_t_2 = (__pyx_t_3 != 0);
       if (__pyx_t_2) {
-        __pyx_t_1 = __Pyx_GetItemInt(__pyx_v_src_sig, __pyx_v_i, Py_ssize_t, 1, PyInt_FromSsize_t, 0, 0, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 176, __pyx_L1_error)
+        __pyx_t_1 = __Pyx_GetItemInt(__pyx_v_src_sig, __pyx_v_i, Py_ssize_t, 1, PyInt_FromSsize_t, 0, 0, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 173, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_1);
-        __pyx_t_13 = PyObject_RichCompare(__pyx_t_1, __pyx_v_dst_type, Py_EQ); __Pyx_XGOTREF(__pyx_t_13); if (unlikely(!__pyx_t_13)) __PYX_ERR(0, 176, __pyx_L1_error)
+        __pyx_t_13 = PyObject_RichCompare(__pyx_t_1, __pyx_v_dst_type, Py_EQ); __Pyx_XGOTREF(__pyx_t_13); if (unlikely(!__pyx_t_13)) __PYX_ERR(0, 173, __pyx_L1_error)
         __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
-        __pyx_t_2 = __Pyx_PyObject_IsTrue(__pyx_t_13); if (unlikely(__pyx_t_2 < 0)) __PYX_ERR(0, 176, __pyx_L1_error)
+        __pyx_t_2 = __Pyx_PyObject_IsTrue(__pyx_t_13); if (unlikely(__pyx_t_2 < 0)) __PYX_ERR(0, 173, __pyx_L1_error)
         __Pyx_DECREF(__pyx_t_13); __pyx_t_13 = 0;
         if (__pyx_t_2) {
           __pyx_v_match_found = 1;
@@ -6420,35 +6424,35 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_6mantel_perm_pearsonr
     __pyx_L32_break:;
     __pyx_t_2 = (__pyx_v_match_found != 0);
     if (__pyx_t_2) {
-      __pyx_t_18 = __Pyx_PyList_Append(__pyx_v_candidates, __pyx_v_sig); if (unlikely(__pyx_t_18 == ((int)-1))) __PYX_ERR(0, 176, __pyx_L1_error)
+      __pyx_t_18 = __Pyx_PyList_Append(__pyx_v_candidates, __pyx_v_sig); if (unlikely(__pyx_t_18 == ((int)-1))) __PYX_ERR(0, 173, __pyx_L1_error)
     }
   }
   __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
   __pyx_t_2 = (PyList_GET_SIZE(__pyx_v_candidates) != 0);
   __pyx_t_3 = ((!__pyx_t_2) != 0);
   if (__pyx_t_3) {
-    __pyx_t_6 = __Pyx_PyObject_Call(__pyx_builtin_TypeError, __pyx_tuple__4, NULL); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 176, __pyx_L1_error)
+    __pyx_t_6 = __Pyx_PyObject_Call(__pyx_builtin_TypeError, __pyx_tuple__4, NULL); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 173, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_6);
     __Pyx_Raise(__pyx_t_6, 0, 0, 0);
     __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
-    __PYX_ERR(0, 176, __pyx_L1_error)
+    __PYX_ERR(0, 173, __pyx_L1_error)
   }
-  __pyx_t_9 = PyList_GET_SIZE(__pyx_v_candidates); if (unlikely(__pyx_t_9 == ((Py_ssize_t)-1))) __PYX_ERR(0, 176, __pyx_L1_error)
+  __pyx_t_9 = PyList_GET_SIZE(__pyx_v_candidates); if (unlikely(__pyx_t_9 == ((Py_ssize_t)-1))) __PYX_ERR(0, 173, __pyx_L1_error)
   __pyx_t_3 = ((__pyx_t_9 > 1) != 0);
   if (__pyx_t_3) {
-    __pyx_t_6 = __Pyx_PyObject_Call(__pyx_builtin_TypeError, __pyx_tuple__5, NULL); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 176, __pyx_L1_error)
+    __pyx_t_6 = __Pyx_PyObject_Call(__pyx_builtin_TypeError, __pyx_tuple__5, NULL); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 173, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_6);
     __Pyx_Raise(__pyx_t_6, 0, 0, 0);
     __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
-    __PYX_ERR(0, 176, __pyx_L1_error)
+    __PYX_ERR(0, 173, __pyx_L1_error)
   }
   /*else*/ {
     __Pyx_XDECREF(__pyx_r);
     if (unlikely(__pyx_v_signatures == Py_None)) {
       PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-      __PYX_ERR(0, 176, __pyx_L1_error)
+      __PYX_ERR(0, 173, __pyx_L1_error)
     }
-    __pyx_t_6 = __Pyx_PyDict_GetItem(((PyObject*)__pyx_v_signatures), PyList_GET_ITEM(__pyx_v_candidates, 0)); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 176, __pyx_L1_error)
+    __pyx_t_6 = __Pyx_PyDict_GetItem(((PyObject*)__pyx_v_signatures), PyList_GET_ITEM(__pyx_v_candidates, 0)); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 173, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_6);
     __pyx_r = __pyx_t_6;
     __pyx_t_6 = 0;
@@ -6527,35 +6531,35 @@ static PyObject *__pyx_fuse_0__pyx_pw_5skbio_5stats_8distance_7_cutils_27mantel_
         case  1:
         if (likely((values[1] = __Pyx_PyDict_GetItemStr(__pyx_kwds, __pyx_n_s_perm_order)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("mantel_perm_pearsonr_cy", 1, 6, 6, 1); __PYX_ERR(0, 176, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("mantel_perm_pearsonr_cy", 1, 6, 6, 1); __PYX_ERR(0, 173, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  2:
         if (likely((values[2] = __Pyx_PyDict_GetItemStr(__pyx_kwds, __pyx_n_s_xmean)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("mantel_perm_pearsonr_cy", 1, 6, 6, 2); __PYX_ERR(0, 176, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("mantel_perm_pearsonr_cy", 1, 6, 6, 2); __PYX_ERR(0, 173, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  3:
         if (likely((values[3] = __Pyx_PyDict_GetItemStr(__pyx_kwds, __pyx_n_s_normxm)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("mantel_perm_pearsonr_cy", 1, 6, 6, 3); __PYX_ERR(0, 176, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("mantel_perm_pearsonr_cy", 1, 6, 6, 3); __PYX_ERR(0, 173, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  4:
         if (likely((values[4] = __Pyx_PyDict_GetItemStr(__pyx_kwds, __pyx_n_s_ym_normalized)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("mantel_perm_pearsonr_cy", 1, 6, 6, 4); __PYX_ERR(0, 176, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("mantel_perm_pearsonr_cy", 1, 6, 6, 4); __PYX_ERR(0, 173, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  5:
         if (likely((values[5] = __Pyx_PyDict_GetItemStr(__pyx_kwds, __pyx_n_s_permuted_stats)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("mantel_perm_pearsonr_cy", 1, 6, 6, 5); __PYX_ERR(0, 176, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("mantel_perm_pearsonr_cy", 1, 6, 6, 5); __PYX_ERR(0, 173, __pyx_L3_error)
         }
       }
       if (unlikely(kw_args > 0)) {
-        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "mantel_perm_pearsonr_cy") < 0)) __PYX_ERR(0, 176, __pyx_L3_error)
+        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "mantel_perm_pearsonr_cy") < 0)) __PYX_ERR(0, 173, __pyx_L3_error)
       }
     } else if (PyTuple_GET_SIZE(__pyx_args) != 6) {
       goto __pyx_L5_argtuple_error;
@@ -6567,16 +6571,16 @@ static PyObject *__pyx_fuse_0__pyx_pw_5skbio_5stats_8distance_7_cutils_27mantel_
       values[4] = PyTuple_GET_ITEM(__pyx_args, 4);
       values[5] = PyTuple_GET_ITEM(__pyx_args, 5);
     }
-    __pyx_v_x_data = __Pyx_PyObject_to_MemoryviewSlice_d_dc_float(values[0], PyBUF_WRITABLE); if (unlikely(!__pyx_v_x_data.memview)) __PYX_ERR(0, 176, __pyx_L3_error)
-    __pyx_v_perm_order = __Pyx_PyObject_to_MemoryviewSlice_d_dc_long(values[1], PyBUF_WRITABLE); if (unlikely(!__pyx_v_perm_order.memview)) __PYX_ERR(0, 176, __pyx_L3_error)
-    __pyx_v_xmean = __pyx_PyFloat_AsFloat(values[2]); if (unlikely((__pyx_v_xmean == (float)-1) && PyErr_Occurred())) __PYX_ERR(0, 177, __pyx_L3_error)
-    __pyx_v_normxm = __pyx_PyFloat_AsFloat(values[3]); if (unlikely((__pyx_v_normxm == (float)-1) && PyErr_Occurred())) __PYX_ERR(0, 177, __pyx_L3_error)
-    __pyx_v_ym_normalized = __Pyx_PyObject_to_MemoryviewSlice_dc_float(values[4], PyBUF_WRITABLE); if (unlikely(!__pyx_v_ym_normalized.memview)) __PYX_ERR(0, 178, __pyx_L3_error)
-    __pyx_v_permuted_stats = __Pyx_PyObject_to_MemoryviewSlice_dc_float(values[5], PyBUF_WRITABLE); if (unlikely(!__pyx_v_permuted_stats.memview)) __PYX_ERR(0, 179, __pyx_L3_error)
+    __pyx_v_x_data = __Pyx_PyObject_to_MemoryviewSlice_d_dc_float(values[0], PyBUF_WRITABLE); if (unlikely(!__pyx_v_x_data.memview)) __PYX_ERR(0, 173, __pyx_L3_error)
+    __pyx_v_perm_order = __Pyx_PyObject_to_MemoryviewSlice_d_dc_long(values[1], PyBUF_WRITABLE); if (unlikely(!__pyx_v_perm_order.memview)) __PYX_ERR(0, 173, __pyx_L3_error)
+    __pyx_v_xmean = __pyx_PyFloat_AsFloat(values[2]); if (unlikely((__pyx_v_xmean == (float)-1) && PyErr_Occurred())) __PYX_ERR(0, 174, __pyx_L3_error)
+    __pyx_v_normxm = __pyx_PyFloat_AsFloat(values[3]); if (unlikely((__pyx_v_normxm == (float)-1) && PyErr_Occurred())) __PYX_ERR(0, 174, __pyx_L3_error)
+    __pyx_v_ym_normalized = __Pyx_PyObject_to_MemoryviewSlice_dc_float(values[4], PyBUF_WRITABLE); if (unlikely(!__pyx_v_ym_normalized.memview)) __PYX_ERR(0, 175, __pyx_L3_error)
+    __pyx_v_permuted_stats = __Pyx_PyObject_to_MemoryviewSlice_dc_float(values[5], PyBUF_WRITABLE); if (unlikely(!__pyx_v_permuted_stats.memview)) __PYX_ERR(0, 176, __pyx_L3_error)
   }
   goto __pyx_L4_argument_unpacking_done;
   __pyx_L5_argtuple_error:;
-  __Pyx_RaiseArgtupleInvalid("mantel_perm_pearsonr_cy", 1, 6, 6, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 176, __pyx_L3_error)
+  __Pyx_RaiseArgtupleInvalid("mantel_perm_pearsonr_cy", 1, 6, 6, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 173, __pyx_L3_error)
   __pyx_L3_error:;
   __Pyx_AddTraceback("skbio.stats.distance._cutils.mantel_perm_pearsonr_cy", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __Pyx_RefNannyFinishContext();
@@ -6629,7 +6633,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_26mantel_perm_pearson
   int __pyx_clineno = 0;
   __Pyx_RefNannySetupContext("__pyx_fuse_0mantel_perm_pearsonr_cy", 0);
 
-  /* "skbio/stats/distance/_cutils.pyx":212
+  /* "skbio/stats/distance/_cutils.pyx":209
  *         Output, Pearson stats
  *     """
  *     cdef Py_ssize_t in_n = x_data.shape[0]             # <<<<<<<<<<<<<<
@@ -6638,7 +6642,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_26mantel_perm_pearson
  */
   __pyx_v_in_n = (__pyx_v_x_data.shape[0]);
 
-  /* "skbio/stats/distance/_cutils.pyx":213
+  /* "skbio/stats/distance/_cutils.pyx":210
  *     """
  *     cdef Py_ssize_t in_n = x_data.shape[0]
  *     cdef Py_ssize_t in2 = x_data.shape[1]             # <<<<<<<<<<<<<<
@@ -6647,7 +6651,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_26mantel_perm_pearson
  */
   __pyx_v_in2 = (__pyx_v_x_data.shape[1]);
 
-  /* "skbio/stats/distance/_cutils.pyx":214
+  /* "skbio/stats/distance/_cutils.pyx":211
  *     cdef Py_ssize_t in_n = x_data.shape[0]
  *     cdef Py_ssize_t in2 = x_data.shape[1]
  *     cdef Py_ssize_t perms_n = perm_order.shape[0]             # <<<<<<<<<<<<<<
@@ -6656,7 +6660,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_26mantel_perm_pearson
  */
   __pyx_v_perms_n = (__pyx_v_perm_order.shape[0]);
 
-  /* "skbio/stats/distance/_cutils.pyx":215
+  /* "skbio/stats/distance/_cutils.pyx":212
  *     cdef Py_ssize_t in2 = x_data.shape[1]
  *     cdef Py_ssize_t perms_n = perm_order.shape[0]
  *     cdef Py_ssize_t out_n = perm_order.shape[1]             # <<<<<<<<<<<<<<
@@ -6665,7 +6669,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_26mantel_perm_pearson
  */
   __pyx_v_out_n = (__pyx_v_perm_order.shape[1]);
 
-  /* "skbio/stats/distance/_cutils.pyx":216
+  /* "skbio/stats/distance/_cutils.pyx":213
  *     cdef Py_ssize_t perms_n = perm_order.shape[0]
  *     cdef Py_ssize_t out_n = perm_order.shape[1]
  *     cdef Py_ssize_t y_n = ym_normalized.shape[0]             # <<<<<<<<<<<<<<
@@ -6674,7 +6678,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_26mantel_perm_pearson
  */
   __pyx_v_y_n = (__pyx_v_ym_normalized.shape[0]);
 
-  /* "skbio/stats/distance/_cutils.pyx":217
+  /* "skbio/stats/distance/_cutils.pyx":214
  *     cdef Py_ssize_t out_n = perm_order.shape[1]
  *     cdef Py_ssize_t y_n = ym_normalized.shape[0]
  *     cdef Py_ssize_t on2 = permuted_stats.shape[0]             # <<<<<<<<<<<<<<
@@ -6683,7 +6687,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_26mantel_perm_pearson
  */
   __pyx_v_on2 = (__pyx_v_permuted_stats.shape[0]);
 
-  /* "skbio/stats/distance/_cutils.pyx":219
+  /* "skbio/stats/distance/_cutils.pyx":216
  *     cdef Py_ssize_t on2 = permuted_stats.shape[0]
  * 
  *     assert in_n == in2             # <<<<<<<<<<<<<<
@@ -6694,12 +6698,12 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_26mantel_perm_pearson
   if (unlikely(!Py_OptimizeFlag)) {
     if (unlikely(!((__pyx_v_in_n == __pyx_v_in2) != 0))) {
       PyErr_SetNone(PyExc_AssertionError);
-      __PYX_ERR(0, 219, __pyx_L1_error)
+      __PYX_ERR(0, 216, __pyx_L1_error)
     }
   }
   #endif
 
-  /* "skbio/stats/distance/_cutils.pyx":220
+  /* "skbio/stats/distance/_cutils.pyx":217
  * 
  *     assert in_n == in2
  *     assert y_n == ((out_n-1)*out_n)/2             # <<<<<<<<<<<<<<
@@ -6710,12 +6714,12 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_26mantel_perm_pearson
   if (unlikely(!Py_OptimizeFlag)) {
     if (unlikely(!((__pyx_v_y_n == __Pyx_div_Py_ssize_t(((__pyx_v_out_n - 1) * __pyx_v_out_n), 2)) != 0))) {
       PyErr_SetNone(PyExc_AssertionError);
-      __PYX_ERR(0, 220, __pyx_L1_error)
+      __PYX_ERR(0, 217, __pyx_L1_error)
     }
   }
   #endif
 
-  /* "skbio/stats/distance/_cutils.pyx":221
+  /* "skbio/stats/distance/_cutils.pyx":218
  *     assert in_n == in2
  *     assert y_n == ((out_n-1)*out_n)/2
  *     assert perms_n == on2             # <<<<<<<<<<<<<<
@@ -6726,12 +6730,12 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_26mantel_perm_pearson
   if (unlikely(!Py_OptimizeFlag)) {
     if (unlikely(!((__pyx_v_perms_n == __pyx_v_on2) != 0))) {
       PyErr_SetNone(PyExc_AssertionError);
-      __PYX_ERR(0, 221, __pyx_L1_error)
+      __PYX_ERR(0, 218, __pyx_L1_error)
     }
   }
   #endif
 
-  /* "skbio/stats/distance/_cutils.pyx":228
+  /* "skbio/stats/distance/_cutils.pyx":225
  *     cdef Py_ssize_t idx
  * 
  *     cdef TReal mul = 1.0/normxm             # <<<<<<<<<<<<<<
@@ -6740,11 +6744,11 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_26mantel_perm_pearson
  */
   if (unlikely(__pyx_v_normxm == 0)) {
     PyErr_SetString(PyExc_ZeroDivisionError, "float division");
-    __PYX_ERR(0, 228, __pyx_L1_error)
+    __PYX_ERR(0, 225, __pyx_L1_error)
   }
   __pyx_v_mul = (1.0 / __pyx_v_normxm);
 
-  /* "skbio/stats/distance/_cutils.pyx":229
+  /* "skbio/stats/distance/_cutils.pyx":226
  * 
  *     cdef TReal mul = 1.0/normxm
  *     cdef TReal add = -xmean/normxm             # <<<<<<<<<<<<<<
@@ -6754,11 +6758,11 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_26mantel_perm_pearson
   __pyx_t_1 = (-__pyx_v_xmean);
   if (unlikely(__pyx_v_normxm == 0)) {
     PyErr_SetString(PyExc_ZeroDivisionError, "float division");
-    __PYX_ERR(0, 229, __pyx_L1_error)
+    __PYX_ERR(0, 226, __pyx_L1_error)
   }
   __pyx_v_add = (__pyx_t_1 / __pyx_v_normxm);
 
-  /* "skbio/stats/distance/_cutils.pyx":235
+  /* "skbio/stats/distance/_cutils.pyx":232
  *     cdef TReal xval
  * 
  *     for p in prange(perms_n, nogil=True):             # <<<<<<<<<<<<<<
@@ -6804,7 +6808,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_26mantel_perm_pearson
                             __pyx_v_xval = ((float)__PYX_NAN());
                             __pyx_v_yval = ((float)__PYX_NAN());
 
-                            /* "skbio/stats/distance/_cutils.pyx":236
+                            /* "skbio/stats/distance/_cutils.pyx":233
  * 
  *     for p in prange(perms_n, nogil=True):
  *         my_ps = 0.0             # <<<<<<<<<<<<<<
@@ -6813,7 +6817,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_26mantel_perm_pearson
  */
                             __pyx_v_my_ps = 0.0;
 
-                            /* "skbio/stats/distance/_cutils.pyx":237
+                            /* "skbio/stats/distance/_cutils.pyx":234
  *     for p in prange(perms_n, nogil=True):
  *         my_ps = 0.0
  *         for row in range(out_n-1):             # <<<<<<<<<<<<<<
@@ -6825,7 +6829,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_26mantel_perm_pearson
                             for (__pyx_t_7 = 0; __pyx_t_7 < __pyx_t_6; __pyx_t_7+=1) {
                               __pyx_v_row = __pyx_t_7;
 
-                              /* "skbio/stats/distance/_cutils.pyx":238
+                              /* "skbio/stats/distance/_cutils.pyx":235
  *         my_ps = 0.0
  *         for row in range(out_n-1):
  *             vrow = perm_order[p, row]             # <<<<<<<<<<<<<<
@@ -6836,7 +6840,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_26mantel_perm_pearson
                               __pyx_t_9 = __pyx_v_row;
                               __pyx_v_vrow = (*((long *) ( /* dim=1 */ ((char *) (((long *) ( /* dim=0 */ (__pyx_v_perm_order.data + __pyx_t_8 * __pyx_v_perm_order.strides[0]) )) + __pyx_t_9)) )));
 
-                              /* "skbio/stats/distance/_cutils.pyx":239
+                              /* "skbio/stats/distance/_cutils.pyx":236
  *         for row in range(out_n-1):
  *             vrow = perm_order[p, row]
  *             idx = row*(out_n-1) - ((row-1)*row)/2             # <<<<<<<<<<<<<<
@@ -6845,7 +6849,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_26mantel_perm_pearson
  */
                               __pyx_v_idx = ((__pyx_v_row * (__pyx_v_out_n - 1)) - __Pyx_div_Py_ssize_t(((__pyx_v_row - 1) * __pyx_v_row), 2));
 
-                              /* "skbio/stats/distance/_cutils.pyx":240
+                              /* "skbio/stats/distance/_cutils.pyx":237
  *             vrow = perm_order[p, row]
  *             idx = row*(out_n-1) - ((row-1)*row)/2
  *             for icol in range(out_n-row-1):             # <<<<<<<<<<<<<<
@@ -6857,7 +6861,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_26mantel_perm_pearson
                               for (__pyx_t_12 = 0; __pyx_t_12 < __pyx_t_11; __pyx_t_12+=1) {
                                 __pyx_v_icol = __pyx_t_12;
 
-                                /* "skbio/stats/distance/_cutils.pyx":241
+                                /* "skbio/stats/distance/_cutils.pyx":238
  *             idx = row*(out_n-1) - ((row-1)*row)/2
  *             for icol in range(out_n-row-1):
  *                col = icol+row+1             # <<<<<<<<<<<<<<
@@ -6866,7 +6870,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_26mantel_perm_pearson
  */
                                 __pyx_v_col = ((__pyx_v_icol + __pyx_v_row) + 1);
 
-                                /* "skbio/stats/distance/_cutils.pyx":242
+                                /* "skbio/stats/distance/_cutils.pyx":239
  *             for icol in range(out_n-row-1):
  *                col = icol+row+1
  *                yval = ym_normalized[idx+icol]             # <<<<<<<<<<<<<<
@@ -6876,7 +6880,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_26mantel_perm_pearson
                                 __pyx_t_9 = (__pyx_v_idx + __pyx_v_icol);
                                 __pyx_v_yval = (*((float *) ( /* dim=0 */ ((char *) (((float *) __pyx_v_ym_normalized.data) + __pyx_t_9)) )));
 
-                                /* "skbio/stats/distance/_cutils.pyx":243
+                                /* "skbio/stats/distance/_cutils.pyx":240
  *                col = icol+row+1
  *                yval = ym_normalized[idx+icol]
  *                xval = x_data[vrow, perm_order[p, col]]*mul + add             # <<<<<<<<<<<<<<
@@ -6889,7 +6893,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_26mantel_perm_pearson
                                 __pyx_t_14 = (*((long *) ( /* dim=1 */ ((char *) (((long *) ( /* dim=0 */ (__pyx_v_perm_order.data + __pyx_t_9 * __pyx_v_perm_order.strides[0]) )) + __pyx_t_8)) )));
                                 __pyx_v_xval = (((*((float *) ( /* dim=1 */ ((char *) (((float *) ( /* dim=0 */ (__pyx_v_x_data.data + __pyx_t_13 * __pyx_v_x_data.strides[0]) )) + __pyx_t_14)) ))) * __pyx_v_mul) + __pyx_v_add);
 
-                                /* "skbio/stats/distance/_cutils.pyx":245
+                                /* "skbio/stats/distance/_cutils.pyx":242
  *                xval = x_data[vrow, perm_order[p, col]]*mul + add
  *                # do not use += to avoid having prange consider it for reduction
  *                my_ps = yval*xval + my_ps             # <<<<<<<<<<<<<<
@@ -6900,7 +6904,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_26mantel_perm_pearson
                               }
                             }
 
-                            /* "skbio/stats/distance/_cutils.pyx":249
+                            /* "skbio/stats/distance/_cutils.pyx":246
  *         # Presumably, if abs(one_stat) > 1, then it is only some small artifact of
  *         # floating point arithmetic.
  *         if my_ps>1.0:             # <<<<<<<<<<<<<<
@@ -6910,7 +6914,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_26mantel_perm_pearson
                             __pyx_t_15 = ((__pyx_v_my_ps > 1.0) != 0);
                             if (__pyx_t_15) {
 
-                              /* "skbio/stats/distance/_cutils.pyx":250
+                              /* "skbio/stats/distance/_cutils.pyx":247
  *         # floating point arithmetic.
  *         if my_ps>1.0:
  *             my_ps = 1.0             # <<<<<<<<<<<<<<
@@ -6919,7 +6923,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_26mantel_perm_pearson
  */
                               __pyx_v_my_ps = 1.0;
 
-                              /* "skbio/stats/distance/_cutils.pyx":249
+                              /* "skbio/stats/distance/_cutils.pyx":246
  *         # Presumably, if abs(one_stat) > 1, then it is only some small artifact of
  *         # floating point arithmetic.
  *         if my_ps>1.0:             # <<<<<<<<<<<<<<
@@ -6929,7 +6933,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_26mantel_perm_pearson
                               goto __pyx_L14;
                             }
 
-                            /* "skbio/stats/distance/_cutils.pyx":251
+                            /* "skbio/stats/distance/_cutils.pyx":248
  *         if my_ps>1.0:
  *             my_ps = 1.0
  *         elif my_ps<-1.0:             # <<<<<<<<<<<<<<
@@ -6939,7 +6943,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_26mantel_perm_pearson
                             __pyx_t_15 = ((__pyx_v_my_ps < -1.0) != 0);
                             if (__pyx_t_15) {
 
-                              /* "skbio/stats/distance/_cutils.pyx":252
+                              /* "skbio/stats/distance/_cutils.pyx":249
  *             my_ps = 1.0
  *         elif my_ps<-1.0:
  *             my_ps = -1.0             # <<<<<<<<<<<<<<
@@ -6947,7 +6951,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_26mantel_perm_pearson
  */
                               __pyx_v_my_ps = -1.0;
 
-                              /* "skbio/stats/distance/_cutils.pyx":251
+                              /* "skbio/stats/distance/_cutils.pyx":248
  *         if my_ps>1.0:
  *             my_ps = 1.0
  *         elif my_ps<-1.0:             # <<<<<<<<<<<<<<
@@ -6957,7 +6961,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_26mantel_perm_pearson
                             }
                             __pyx_L14:;
 
-                            /* "skbio/stats/distance/_cutils.pyx":253
+                            /* "skbio/stats/distance/_cutils.pyx":250
  *         elif my_ps<-1.0:
  *             my_ps = -1.0
  *         permuted_stats[p] = my_ps             # <<<<<<<<<<<<<<
@@ -6977,7 +6981,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_26mantel_perm_pearson
         #endif
       }
 
-      /* "skbio/stats/distance/_cutils.pyx":235
+      /* "skbio/stats/distance/_cutils.pyx":232
  *     cdef TReal xval
  * 
  *     for p in prange(perms_n, nogil=True):             # <<<<<<<<<<<<<<
@@ -6996,7 +7000,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_26mantel_perm_pearson
       }
   }
 
-  /* "skbio/stats/distance/_cutils.pyx":176
+  /* "skbio/stats/distance/_cutils.pyx":173
  * @cython.boundscheck(False)
  * @cython.wraparound(False)
  * def mantel_perm_pearsonr_cy(TReal[:, ::1] x_data, long[:, ::1] perm_order,             # <<<<<<<<<<<<<<
@@ -7067,35 +7071,35 @@ static PyObject *__pyx_fuse_1__pyx_pw_5skbio_5stats_8distance_7_cutils_29mantel_
         case  1:
         if (likely((values[1] = __Pyx_PyDict_GetItemStr(__pyx_kwds, __pyx_n_s_perm_order)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("mantel_perm_pearsonr_cy", 1, 6, 6, 1); __PYX_ERR(0, 176, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("mantel_perm_pearsonr_cy", 1, 6, 6, 1); __PYX_ERR(0, 173, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  2:
         if (likely((values[2] = __Pyx_PyDict_GetItemStr(__pyx_kwds, __pyx_n_s_xmean)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("mantel_perm_pearsonr_cy", 1, 6, 6, 2); __PYX_ERR(0, 176, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("mantel_perm_pearsonr_cy", 1, 6, 6, 2); __PYX_ERR(0, 173, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  3:
         if (likely((values[3] = __Pyx_PyDict_GetItemStr(__pyx_kwds, __pyx_n_s_normxm)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("mantel_perm_pearsonr_cy", 1, 6, 6, 3); __PYX_ERR(0, 176, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("mantel_perm_pearsonr_cy", 1, 6, 6, 3); __PYX_ERR(0, 173, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  4:
         if (likely((values[4] = __Pyx_PyDict_GetItemStr(__pyx_kwds, __pyx_n_s_ym_normalized)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("mantel_perm_pearsonr_cy", 1, 6, 6, 4); __PYX_ERR(0, 176, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("mantel_perm_pearsonr_cy", 1, 6, 6, 4); __PYX_ERR(0, 173, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  5:
         if (likely((values[5] = __Pyx_PyDict_GetItemStr(__pyx_kwds, __pyx_n_s_permuted_stats)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("mantel_perm_pearsonr_cy", 1, 6, 6, 5); __PYX_ERR(0, 176, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("mantel_perm_pearsonr_cy", 1, 6, 6, 5); __PYX_ERR(0, 173, __pyx_L3_error)
         }
       }
       if (unlikely(kw_args > 0)) {
-        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "mantel_perm_pearsonr_cy") < 0)) __PYX_ERR(0, 176, __pyx_L3_error)
+        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "mantel_perm_pearsonr_cy") < 0)) __PYX_ERR(0, 173, __pyx_L3_error)
       }
     } else if (PyTuple_GET_SIZE(__pyx_args) != 6) {
       goto __pyx_L5_argtuple_error;
@@ -7107,16 +7111,16 @@ static PyObject *__pyx_fuse_1__pyx_pw_5skbio_5stats_8distance_7_cutils_29mantel_
       values[4] = PyTuple_GET_ITEM(__pyx_args, 4);
       values[5] = PyTuple_GET_ITEM(__pyx_args, 5);
     }
-    __pyx_v_x_data = __Pyx_PyObject_to_MemoryviewSlice_d_dc_double(values[0], PyBUF_WRITABLE); if (unlikely(!__pyx_v_x_data.memview)) __PYX_ERR(0, 176, __pyx_L3_error)
-    __pyx_v_perm_order = __Pyx_PyObject_to_MemoryviewSlice_d_dc_long(values[1], PyBUF_WRITABLE); if (unlikely(!__pyx_v_perm_order.memview)) __PYX_ERR(0, 176, __pyx_L3_error)
-    __pyx_v_xmean = __pyx_PyFloat_AsDouble(values[2]); if (unlikely((__pyx_v_xmean == (double)-1) && PyErr_Occurred())) __PYX_ERR(0, 177, __pyx_L3_error)
-    __pyx_v_normxm = __pyx_PyFloat_AsDouble(values[3]); if (unlikely((__pyx_v_normxm == (double)-1) && PyErr_Occurred())) __PYX_ERR(0, 177, __pyx_L3_error)
-    __pyx_v_ym_normalized = __Pyx_PyObject_to_MemoryviewSlice_dc_double(values[4], PyBUF_WRITABLE); if (unlikely(!__pyx_v_ym_normalized.memview)) __PYX_ERR(0, 178, __pyx_L3_error)
-    __pyx_v_permuted_stats = __Pyx_PyObject_to_MemoryviewSlice_dc_double(values[5], PyBUF_WRITABLE); if (unlikely(!__pyx_v_permuted_stats.memview)) __PYX_ERR(0, 179, __pyx_L3_error)
+    __pyx_v_x_data = __Pyx_PyObject_to_MemoryviewSlice_d_dc_double(values[0], PyBUF_WRITABLE); if (unlikely(!__pyx_v_x_data.memview)) __PYX_ERR(0, 173, __pyx_L3_error)
+    __pyx_v_perm_order = __Pyx_PyObject_to_MemoryviewSlice_d_dc_long(values[1], PyBUF_WRITABLE); if (unlikely(!__pyx_v_perm_order.memview)) __PYX_ERR(0, 173, __pyx_L3_error)
+    __pyx_v_xmean = __pyx_PyFloat_AsDouble(values[2]); if (unlikely((__pyx_v_xmean == (double)-1) && PyErr_Occurred())) __PYX_ERR(0, 174, __pyx_L3_error)
+    __pyx_v_normxm = __pyx_PyFloat_AsDouble(values[3]); if (unlikely((__pyx_v_normxm == (double)-1) && PyErr_Occurred())) __PYX_ERR(0, 174, __pyx_L3_error)
+    __pyx_v_ym_normalized = __Pyx_PyObject_to_MemoryviewSlice_dc_double(values[4], PyBUF_WRITABLE); if (unlikely(!__pyx_v_ym_normalized.memview)) __PYX_ERR(0, 175, __pyx_L3_error)
+    __pyx_v_permuted_stats = __Pyx_PyObject_to_MemoryviewSlice_dc_double(values[5], PyBUF_WRITABLE); if (unlikely(!__pyx_v_permuted_stats.memview)) __PYX_ERR(0, 176, __pyx_L3_error)
   }
   goto __pyx_L4_argument_unpacking_done;
   __pyx_L5_argtuple_error:;
-  __Pyx_RaiseArgtupleInvalid("mantel_perm_pearsonr_cy", 1, 6, 6, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 176, __pyx_L3_error)
+  __Pyx_RaiseArgtupleInvalid("mantel_perm_pearsonr_cy", 1, 6, 6, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 173, __pyx_L3_error)
   __pyx_L3_error:;
   __Pyx_AddTraceback("skbio.stats.distance._cutils.mantel_perm_pearsonr_cy", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __Pyx_RefNannyFinishContext();
@@ -7169,7 +7173,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_28mantel_perm_pearson
   int __pyx_clineno = 0;
   __Pyx_RefNannySetupContext("__pyx_fuse_1mantel_perm_pearsonr_cy", 0);
 
-  /* "skbio/stats/distance/_cutils.pyx":212
+  /* "skbio/stats/distance/_cutils.pyx":209
  *         Output, Pearson stats
  *     """
  *     cdef Py_ssize_t in_n = x_data.shape[0]             # <<<<<<<<<<<<<<
@@ -7178,7 +7182,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_28mantel_perm_pearson
  */
   __pyx_v_in_n = (__pyx_v_x_data.shape[0]);
 
-  /* "skbio/stats/distance/_cutils.pyx":213
+  /* "skbio/stats/distance/_cutils.pyx":210
  *     """
  *     cdef Py_ssize_t in_n = x_data.shape[0]
  *     cdef Py_ssize_t in2 = x_data.shape[1]             # <<<<<<<<<<<<<<
@@ -7187,7 +7191,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_28mantel_perm_pearson
  */
   __pyx_v_in2 = (__pyx_v_x_data.shape[1]);
 
-  /* "skbio/stats/distance/_cutils.pyx":214
+  /* "skbio/stats/distance/_cutils.pyx":211
  *     cdef Py_ssize_t in_n = x_data.shape[0]
  *     cdef Py_ssize_t in2 = x_data.shape[1]
  *     cdef Py_ssize_t perms_n = perm_order.shape[0]             # <<<<<<<<<<<<<<
@@ -7196,7 +7200,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_28mantel_perm_pearson
  */
   __pyx_v_perms_n = (__pyx_v_perm_order.shape[0]);
 
-  /* "skbio/stats/distance/_cutils.pyx":215
+  /* "skbio/stats/distance/_cutils.pyx":212
  *     cdef Py_ssize_t in2 = x_data.shape[1]
  *     cdef Py_ssize_t perms_n = perm_order.shape[0]
  *     cdef Py_ssize_t out_n = perm_order.shape[1]             # <<<<<<<<<<<<<<
@@ -7205,7 +7209,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_28mantel_perm_pearson
  */
   __pyx_v_out_n = (__pyx_v_perm_order.shape[1]);
 
-  /* "skbio/stats/distance/_cutils.pyx":216
+  /* "skbio/stats/distance/_cutils.pyx":213
  *     cdef Py_ssize_t perms_n = perm_order.shape[0]
  *     cdef Py_ssize_t out_n = perm_order.shape[1]
  *     cdef Py_ssize_t y_n = ym_normalized.shape[0]             # <<<<<<<<<<<<<<
@@ -7214,7 +7218,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_28mantel_perm_pearson
  */
   __pyx_v_y_n = (__pyx_v_ym_normalized.shape[0]);
 
-  /* "skbio/stats/distance/_cutils.pyx":217
+  /* "skbio/stats/distance/_cutils.pyx":214
  *     cdef Py_ssize_t out_n = perm_order.shape[1]
  *     cdef Py_ssize_t y_n = ym_normalized.shape[0]
  *     cdef Py_ssize_t on2 = permuted_stats.shape[0]             # <<<<<<<<<<<<<<
@@ -7223,7 +7227,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_28mantel_perm_pearson
  */
   __pyx_v_on2 = (__pyx_v_permuted_stats.shape[0]);
 
-  /* "skbio/stats/distance/_cutils.pyx":219
+  /* "skbio/stats/distance/_cutils.pyx":216
  *     cdef Py_ssize_t on2 = permuted_stats.shape[0]
  * 
  *     assert in_n == in2             # <<<<<<<<<<<<<<
@@ -7234,12 +7238,12 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_28mantel_perm_pearson
   if (unlikely(!Py_OptimizeFlag)) {
     if (unlikely(!((__pyx_v_in_n == __pyx_v_in2) != 0))) {
       PyErr_SetNone(PyExc_AssertionError);
-      __PYX_ERR(0, 219, __pyx_L1_error)
+      __PYX_ERR(0, 216, __pyx_L1_error)
     }
   }
   #endif
 
-  /* "skbio/stats/distance/_cutils.pyx":220
+  /* "skbio/stats/distance/_cutils.pyx":217
  * 
  *     assert in_n == in2
  *     assert y_n == ((out_n-1)*out_n)/2             # <<<<<<<<<<<<<<
@@ -7250,12 +7254,12 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_28mantel_perm_pearson
   if (unlikely(!Py_OptimizeFlag)) {
     if (unlikely(!((__pyx_v_y_n == __Pyx_div_Py_ssize_t(((__pyx_v_out_n - 1) * __pyx_v_out_n), 2)) != 0))) {
       PyErr_SetNone(PyExc_AssertionError);
-      __PYX_ERR(0, 220, __pyx_L1_error)
+      __PYX_ERR(0, 217, __pyx_L1_error)
     }
   }
   #endif
 
-  /* "skbio/stats/distance/_cutils.pyx":221
+  /* "skbio/stats/distance/_cutils.pyx":218
  *     assert in_n == in2
  *     assert y_n == ((out_n-1)*out_n)/2
  *     assert perms_n == on2             # <<<<<<<<<<<<<<
@@ -7266,12 +7270,12 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_28mantel_perm_pearson
   if (unlikely(!Py_OptimizeFlag)) {
     if (unlikely(!((__pyx_v_perms_n == __pyx_v_on2) != 0))) {
       PyErr_SetNone(PyExc_AssertionError);
-      __PYX_ERR(0, 221, __pyx_L1_error)
+      __PYX_ERR(0, 218, __pyx_L1_error)
     }
   }
   #endif
 
-  /* "skbio/stats/distance/_cutils.pyx":228
+  /* "skbio/stats/distance/_cutils.pyx":225
  *     cdef Py_ssize_t idx
  * 
  *     cdef TReal mul = 1.0/normxm             # <<<<<<<<<<<<<<
@@ -7280,11 +7284,11 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_28mantel_perm_pearson
  */
   if (unlikely(__pyx_v_normxm == 0)) {
     PyErr_SetString(PyExc_ZeroDivisionError, "float division");
-    __PYX_ERR(0, 228, __pyx_L1_error)
+    __PYX_ERR(0, 225, __pyx_L1_error)
   }
   __pyx_v_mul = (1.0 / __pyx_v_normxm);
 
-  /* "skbio/stats/distance/_cutils.pyx":229
+  /* "skbio/stats/distance/_cutils.pyx":226
  * 
  *     cdef TReal mul = 1.0/normxm
  *     cdef TReal add = -xmean/normxm             # <<<<<<<<<<<<<<
@@ -7294,11 +7298,11 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_28mantel_perm_pearson
   __pyx_t_1 = (-__pyx_v_xmean);
   if (unlikely(__pyx_v_normxm == 0)) {
     PyErr_SetString(PyExc_ZeroDivisionError, "float division");
-    __PYX_ERR(0, 229, __pyx_L1_error)
+    __PYX_ERR(0, 226, __pyx_L1_error)
   }
   __pyx_v_add = (__pyx_t_1 / __pyx_v_normxm);
 
-  /* "skbio/stats/distance/_cutils.pyx":235
+  /* "skbio/stats/distance/_cutils.pyx":232
  *     cdef TReal xval
  * 
  *     for p in prange(perms_n, nogil=True):             # <<<<<<<<<<<<<<
@@ -7344,7 +7348,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_28mantel_perm_pearson
                             __pyx_v_xval = ((double)__PYX_NAN());
                             __pyx_v_yval = ((double)__PYX_NAN());
 
-                            /* "skbio/stats/distance/_cutils.pyx":236
+                            /* "skbio/stats/distance/_cutils.pyx":233
  * 
  *     for p in prange(perms_n, nogil=True):
  *         my_ps = 0.0             # <<<<<<<<<<<<<<
@@ -7353,7 +7357,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_28mantel_perm_pearson
  */
                             __pyx_v_my_ps = 0.0;
 
-                            /* "skbio/stats/distance/_cutils.pyx":237
+                            /* "skbio/stats/distance/_cutils.pyx":234
  *     for p in prange(perms_n, nogil=True):
  *         my_ps = 0.0
  *         for row in range(out_n-1):             # <<<<<<<<<<<<<<
@@ -7365,7 +7369,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_28mantel_perm_pearson
                             for (__pyx_t_7 = 0; __pyx_t_7 < __pyx_t_6; __pyx_t_7+=1) {
                               __pyx_v_row = __pyx_t_7;
 
-                              /* "skbio/stats/distance/_cutils.pyx":238
+                              /* "skbio/stats/distance/_cutils.pyx":235
  *         my_ps = 0.0
  *         for row in range(out_n-1):
  *             vrow = perm_order[p, row]             # <<<<<<<<<<<<<<
@@ -7376,7 +7380,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_28mantel_perm_pearson
                               __pyx_t_9 = __pyx_v_row;
                               __pyx_v_vrow = (*((long *) ( /* dim=1 */ ((char *) (((long *) ( /* dim=0 */ (__pyx_v_perm_order.data + __pyx_t_8 * __pyx_v_perm_order.strides[0]) )) + __pyx_t_9)) )));
 
-                              /* "skbio/stats/distance/_cutils.pyx":239
+                              /* "skbio/stats/distance/_cutils.pyx":236
  *         for row in range(out_n-1):
  *             vrow = perm_order[p, row]
  *             idx = row*(out_n-1) - ((row-1)*row)/2             # <<<<<<<<<<<<<<
@@ -7385,7 +7389,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_28mantel_perm_pearson
  */
                               __pyx_v_idx = ((__pyx_v_row * (__pyx_v_out_n - 1)) - __Pyx_div_Py_ssize_t(((__pyx_v_row - 1) * __pyx_v_row), 2));
 
-                              /* "skbio/stats/distance/_cutils.pyx":240
+                              /* "skbio/stats/distance/_cutils.pyx":237
  *             vrow = perm_order[p, row]
  *             idx = row*(out_n-1) - ((row-1)*row)/2
  *             for icol in range(out_n-row-1):             # <<<<<<<<<<<<<<
@@ -7397,7 +7401,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_28mantel_perm_pearson
                               for (__pyx_t_12 = 0; __pyx_t_12 < __pyx_t_11; __pyx_t_12+=1) {
                                 __pyx_v_icol = __pyx_t_12;
 
-                                /* "skbio/stats/distance/_cutils.pyx":241
+                                /* "skbio/stats/distance/_cutils.pyx":238
  *             idx = row*(out_n-1) - ((row-1)*row)/2
  *             for icol in range(out_n-row-1):
  *                col = icol+row+1             # <<<<<<<<<<<<<<
@@ -7406,7 +7410,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_28mantel_perm_pearson
  */
                                 __pyx_v_col = ((__pyx_v_icol + __pyx_v_row) + 1);
 
-                                /* "skbio/stats/distance/_cutils.pyx":242
+                                /* "skbio/stats/distance/_cutils.pyx":239
  *             for icol in range(out_n-row-1):
  *                col = icol+row+1
  *                yval = ym_normalized[idx+icol]             # <<<<<<<<<<<<<<
@@ -7416,7 +7420,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_28mantel_perm_pearson
                                 __pyx_t_9 = (__pyx_v_idx + __pyx_v_icol);
                                 __pyx_v_yval = (*((double *) ( /* dim=0 */ ((char *) (((double *) __pyx_v_ym_normalized.data) + __pyx_t_9)) )));
 
-                                /* "skbio/stats/distance/_cutils.pyx":243
+                                /* "skbio/stats/distance/_cutils.pyx":240
  *                col = icol+row+1
  *                yval = ym_normalized[idx+icol]
  *                xval = x_data[vrow, perm_order[p, col]]*mul + add             # <<<<<<<<<<<<<<
@@ -7429,7 +7433,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_28mantel_perm_pearson
                                 __pyx_t_14 = (*((long *) ( /* dim=1 */ ((char *) (((long *) ( /* dim=0 */ (__pyx_v_perm_order.data + __pyx_t_9 * __pyx_v_perm_order.strides[0]) )) + __pyx_t_8)) )));
                                 __pyx_v_xval = (((*((double *) ( /* dim=1 */ ((char *) (((double *) ( /* dim=0 */ (__pyx_v_x_data.data + __pyx_t_13 * __pyx_v_x_data.strides[0]) )) + __pyx_t_14)) ))) * __pyx_v_mul) + __pyx_v_add);
 
-                                /* "skbio/stats/distance/_cutils.pyx":245
+                                /* "skbio/stats/distance/_cutils.pyx":242
  *                xval = x_data[vrow, perm_order[p, col]]*mul + add
  *                # do not use += to avoid having prange consider it for reduction
  *                my_ps = yval*xval + my_ps             # <<<<<<<<<<<<<<
@@ -7440,7 +7444,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_28mantel_perm_pearson
                               }
                             }
 
-                            /* "skbio/stats/distance/_cutils.pyx":249
+                            /* "skbio/stats/distance/_cutils.pyx":246
  *         # Presumably, if abs(one_stat) > 1, then it is only some small artifact of
  *         # floating point arithmetic.
  *         if my_ps>1.0:             # <<<<<<<<<<<<<<
@@ -7450,7 +7454,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_28mantel_perm_pearson
                             __pyx_t_15 = ((__pyx_v_my_ps > 1.0) != 0);
                             if (__pyx_t_15) {
 
-                              /* "skbio/stats/distance/_cutils.pyx":250
+                              /* "skbio/stats/distance/_cutils.pyx":247
  *         # floating point arithmetic.
  *         if my_ps>1.0:
  *             my_ps = 1.0             # <<<<<<<<<<<<<<
@@ -7459,7 +7463,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_28mantel_perm_pearson
  */
                               __pyx_v_my_ps = 1.0;
 
-                              /* "skbio/stats/distance/_cutils.pyx":249
+                              /* "skbio/stats/distance/_cutils.pyx":246
  *         # Presumably, if abs(one_stat) > 1, then it is only some small artifact of
  *         # floating point arithmetic.
  *         if my_ps>1.0:             # <<<<<<<<<<<<<<
@@ -7469,7 +7473,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_28mantel_perm_pearson
                               goto __pyx_L14;
                             }
 
-                            /* "skbio/stats/distance/_cutils.pyx":251
+                            /* "skbio/stats/distance/_cutils.pyx":248
  *         if my_ps>1.0:
  *             my_ps = 1.0
  *         elif my_ps<-1.0:             # <<<<<<<<<<<<<<
@@ -7479,7 +7483,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_28mantel_perm_pearson
                             __pyx_t_15 = ((__pyx_v_my_ps < -1.0) != 0);
                             if (__pyx_t_15) {
 
-                              /* "skbio/stats/distance/_cutils.pyx":252
+                              /* "skbio/stats/distance/_cutils.pyx":249
  *             my_ps = 1.0
  *         elif my_ps<-1.0:
  *             my_ps = -1.0             # <<<<<<<<<<<<<<
@@ -7487,7 +7491,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_28mantel_perm_pearson
  */
                               __pyx_v_my_ps = -1.0;
 
-                              /* "skbio/stats/distance/_cutils.pyx":251
+                              /* "skbio/stats/distance/_cutils.pyx":248
  *         if my_ps>1.0:
  *             my_ps = 1.0
  *         elif my_ps<-1.0:             # <<<<<<<<<<<<<<
@@ -7497,7 +7501,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_28mantel_perm_pearson
                             }
                             __pyx_L14:;
 
-                            /* "skbio/stats/distance/_cutils.pyx":253
+                            /* "skbio/stats/distance/_cutils.pyx":250
  *         elif my_ps<-1.0:
  *             my_ps = -1.0
  *         permuted_stats[p] = my_ps             # <<<<<<<<<<<<<<
@@ -7517,7 +7521,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_28mantel_perm_pearson
         #endif
       }
 
-      /* "skbio/stats/distance/_cutils.pyx":235
+      /* "skbio/stats/distance/_cutils.pyx":232
  *     cdef TReal xval
  * 
  *     for p in prange(perms_n, nogil=True):             # <<<<<<<<<<<<<<
@@ -7536,7 +7540,7 @@ static PyObject *__pyx_pf_5skbio_5stats_8distance_7_cutils_28mantel_perm_pearson
       }
   }
 
-  /* "skbio/stats/distance/_cutils.pyx":176
+  /* "skbio/stats/distance/_cutils.pyx":173
  * @cython.boundscheck(False)
  * @cython.wraparound(False)
  * def mantel_perm_pearsonr_cy(TReal[:, ::1] x_data, long[:, ::1] perm_order,             # <<<<<<<<<<<<<<
@@ -21724,41 +21728,41 @@ static CYTHON_SMALL_CODE int __Pyx_InitCachedConstants(void) {
   __Pyx_GIVEREF(__pyx_tuple__24);
   __pyx_codeobj__25 = (PyObject*)__Pyx_PyCode_New(1, 0, 13, 0, CO_OPTIMIZED|CO_NEWLOCALS, __pyx_empty_bytes, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_tuple__24, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_kp_s_skbio_stats_distance__cutils_pyx, __pyx_n_s_is_symmetric_and_hollow_cy, 22, __pyx_empty_bytes); if (unlikely(!__pyx_codeobj__25)) __PYX_ERR(0, 22, __pyx_L1_error)
 
-  /* "skbio/stats/distance/_cutils.pyx":74
+  /* "skbio/stats/distance/_cutils.pyx":71
  * @cython.boundscheck(False)
  * @cython.wraparound(False)
  * def distmat_reorder_cy(TReal[:, ::1] in_mat, long[::1] reorder_vec,             # <<<<<<<<<<<<<<
  *                        TReal[:, ::1] out_mat):
  *     """
  */
-  __pyx_tuple__26 = PyTuple_Pack(11, __pyx_n_s_in_mat, __pyx_n_s_reorder_vec, __pyx_n_s_out_mat, __pyx_n_s_in_n, __pyx_n_s_in2, __pyx_n_s_out_n, __pyx_n_s_on2, __pyx_n_s_on3, __pyx_n_s_row, __pyx_n_s_col, __pyx_n_s_vrow); if (unlikely(!__pyx_tuple__26)) __PYX_ERR(0, 74, __pyx_L1_error)
+  __pyx_tuple__26 = PyTuple_Pack(11, __pyx_n_s_in_mat, __pyx_n_s_reorder_vec, __pyx_n_s_out_mat, __pyx_n_s_in_n, __pyx_n_s_in2, __pyx_n_s_out_n, __pyx_n_s_on2, __pyx_n_s_on3, __pyx_n_s_row, __pyx_n_s_col, __pyx_n_s_vrow); if (unlikely(!__pyx_tuple__26)) __PYX_ERR(0, 71, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_tuple__26);
   __Pyx_GIVEREF(__pyx_tuple__26);
-  __pyx_codeobj__27 = (PyObject*)__Pyx_PyCode_New(3, 0, 11, 0, CO_OPTIMIZED|CO_NEWLOCALS, __pyx_empty_bytes, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_tuple__26, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_kp_s_skbio_stats_distance__cutils_pyx, __pyx_n_s_distmat_reorder_cy, 74, __pyx_empty_bytes); if (unlikely(!__pyx_codeobj__27)) __PYX_ERR(0, 74, __pyx_L1_error)
+  __pyx_codeobj__27 = (PyObject*)__Pyx_PyCode_New(3, 0, 11, 0, CO_OPTIMIZED|CO_NEWLOCALS, __pyx_empty_bytes, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_tuple__26, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_kp_s_skbio_stats_distance__cutils_pyx, __pyx_n_s_distmat_reorder_cy, 71, __pyx_empty_bytes); if (unlikely(!__pyx_codeobj__27)) __PYX_ERR(0, 71, __pyx_L1_error)
 
-  /* "skbio/stats/distance/_cutils.pyx":126
+  /* "skbio/stats/distance/_cutils.pyx":123
  * @cython.boundscheck(False)
  * @cython.wraparound(False)
  * def distmat_reorder_condensed_cy(TReal[:, ::1] in_mat, long[::1] reorder_vec,             # <<<<<<<<<<<<<<
  *                                   TReal[::1] out_mat_condensed):
  *     """
  */
-  __pyx_tuple__28 = PyTuple_Pack(11, __pyx_n_s_in_mat, __pyx_n_s_reorder_vec, __pyx_n_s_out_mat_condensed, __pyx_n_s_in_n, __pyx_n_s_in2, __pyx_n_s_out_n, __pyx_n_s_on2, __pyx_n_s_row, __pyx_n_s_col, __pyx_n_s_vrow, __pyx_n_s_idx); if (unlikely(!__pyx_tuple__28)) __PYX_ERR(0, 126, __pyx_L1_error)
+  __pyx_tuple__28 = PyTuple_Pack(11, __pyx_n_s_in_mat, __pyx_n_s_reorder_vec, __pyx_n_s_out_mat_condensed, __pyx_n_s_in_n, __pyx_n_s_in2, __pyx_n_s_out_n, __pyx_n_s_on2, __pyx_n_s_row, __pyx_n_s_col, __pyx_n_s_vrow, __pyx_n_s_idx); if (unlikely(!__pyx_tuple__28)) __PYX_ERR(0, 123, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_tuple__28);
   __Pyx_GIVEREF(__pyx_tuple__28);
-  __pyx_codeobj__29 = (PyObject*)__Pyx_PyCode_New(3, 0, 11, 0, CO_OPTIMIZED|CO_NEWLOCALS, __pyx_empty_bytes, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_tuple__28, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_kp_s_skbio_stats_distance__cutils_pyx, __pyx_n_s_distmat_reorder_condensed_cy, 126, __pyx_empty_bytes); if (unlikely(!__pyx_codeobj__29)) __PYX_ERR(0, 126, __pyx_L1_error)
+  __pyx_codeobj__29 = (PyObject*)__Pyx_PyCode_New(3, 0, 11, 0, CO_OPTIMIZED|CO_NEWLOCALS, __pyx_empty_bytes, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_tuple__28, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_kp_s_skbio_stats_distance__cutils_pyx, __pyx_n_s_distmat_reorder_condensed_cy, 123, __pyx_empty_bytes); if (unlikely(!__pyx_codeobj__29)) __PYX_ERR(0, 123, __pyx_L1_error)
 
-  /* "skbio/stats/distance/_cutils.pyx":176
+  /* "skbio/stats/distance/_cutils.pyx":173
  * @cython.boundscheck(False)
  * @cython.wraparound(False)
  * def mantel_perm_pearsonr_cy(TReal[:, ::1] x_data, long[:, ::1] perm_order,             # <<<<<<<<<<<<<<
  *                             TReal xmean, TReal normxm,
  *                             TReal[::1] ym_normalized,
  */
-  __pyx_tuple__30 = PyTuple_Pack(23, __pyx_n_s_x_data, __pyx_n_s_perm_order, __pyx_n_s_xmean, __pyx_n_s_normxm, __pyx_n_s_ym_normalized, __pyx_n_s_permuted_stats, __pyx_n_s_in_n, __pyx_n_s_in2, __pyx_n_s_perms_n, __pyx_n_s_out_n, __pyx_n_s_y_n, __pyx_n_s_on2, __pyx_n_s_p, __pyx_n_s_row, __pyx_n_s_col, __pyx_n_s_icol, __pyx_n_s_vrow, __pyx_n_s_idx, __pyx_n_s_mul, __pyx_n_s_add, __pyx_n_s_my_ps, __pyx_n_s_yval, __pyx_n_s_xval); if (unlikely(!__pyx_tuple__30)) __PYX_ERR(0, 176, __pyx_L1_error)
+  __pyx_tuple__30 = PyTuple_Pack(23, __pyx_n_s_x_data, __pyx_n_s_perm_order, __pyx_n_s_xmean, __pyx_n_s_normxm, __pyx_n_s_ym_normalized, __pyx_n_s_permuted_stats, __pyx_n_s_in_n, __pyx_n_s_in2, __pyx_n_s_perms_n, __pyx_n_s_out_n, __pyx_n_s_y_n, __pyx_n_s_on2, __pyx_n_s_p, __pyx_n_s_row, __pyx_n_s_col, __pyx_n_s_icol, __pyx_n_s_vrow, __pyx_n_s_idx, __pyx_n_s_mul, __pyx_n_s_add, __pyx_n_s_my_ps, __pyx_n_s_yval, __pyx_n_s_xval); if (unlikely(!__pyx_tuple__30)) __PYX_ERR(0, 173, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_tuple__30);
   __Pyx_GIVEREF(__pyx_tuple__30);
-  __pyx_codeobj__31 = (PyObject*)__Pyx_PyCode_New(6, 0, 23, 0, CO_OPTIMIZED|CO_NEWLOCALS, __pyx_empty_bytes, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_tuple__30, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_kp_s_skbio_stats_distance__cutils_pyx, __pyx_n_s_mantel_perm_pearsonr_cy, 176, __pyx_empty_bytes); if (unlikely(!__pyx_codeobj__31)) __PYX_ERR(0, 176, __pyx_L1_error)
+  __pyx_codeobj__31 = (PyObject*)__Pyx_PyCode_New(6, 0, 23, 0, CO_OPTIMIZED|CO_NEWLOCALS, __pyx_empty_bytes, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_tuple__30, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_kp_s_skbio_stats_distance__cutils_pyx, __pyx_n_s_mantel_perm_pearsonr_cy, 173, __pyx_empty_bytes); if (unlikely(!__pyx_codeobj__31)) __PYX_ERR(0, 173, __pyx_L1_error)
 
   /* "View.MemoryView":286
  *         return self.name
@@ -22221,88 +22225,88 @@ if (!__Pyx_RefNanny) {
   if (PyDict_SetItem(__pyx_d, __pyx_n_s_is_symmetric_and_hollow_cy, __pyx_t_2) < 0) __PYX_ERR(0, 22, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
 
-  /* "skbio/stats/distance/_cutils.pyx":74
+  /* "skbio/stats/distance/_cutils.pyx":71
  * @cython.boundscheck(False)
  * @cython.wraparound(False)
  * def distmat_reorder_cy(TReal[:, ::1] in_mat, long[::1] reorder_vec,             # <<<<<<<<<<<<<<
  *                        TReal[:, ::1] out_mat):
  *     """
  */
-  __pyx_t_2 = __Pyx_PyDict_NewPresized(2); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 74, __pyx_L1_error)
+  __pyx_t_2 = __Pyx_PyDict_NewPresized(2); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 71, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
-  __pyx_t_1 = __pyx_FusedFunction_New(&__pyx_fuse_0__pyx_mdef_5skbio_5stats_8distance_7_cutils_15distmat_reorder_cy, 0, __pyx_n_s_distmat_reorder_cy, NULL, __pyx_n_s_skbio_stats_distance__cutils, __pyx_d, ((PyObject *)__pyx_codeobj__27)); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 74, __pyx_L1_error)
+  __pyx_t_1 = __pyx_FusedFunction_New(&__pyx_fuse_0__pyx_mdef_5skbio_5stats_8distance_7_cutils_15distmat_reorder_cy, 0, __pyx_n_s_distmat_reorder_cy, NULL, __pyx_n_s_skbio_stats_distance__cutils, __pyx_d, ((PyObject *)__pyx_codeobj__27)); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 71, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __Pyx_CyFunction_SetDefaultsTuple(__pyx_t_1, __pyx_empty_tuple);
-  if (PyDict_SetItem(__pyx_t_2, __pyx_n_s_float, __pyx_t_1) < 0) __PYX_ERR(0, 74, __pyx_L1_error)
+  if (PyDict_SetItem(__pyx_t_2, __pyx_n_s_float, __pyx_t_1) < 0) __PYX_ERR(0, 71, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
-  __pyx_t_1 = __pyx_FusedFunction_New(&__pyx_fuse_1__pyx_mdef_5skbio_5stats_8distance_7_cutils_17distmat_reorder_cy, 0, __pyx_n_s_distmat_reorder_cy, NULL, __pyx_n_s_skbio_stats_distance__cutils, __pyx_d, ((PyObject *)__pyx_codeobj__27)); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 74, __pyx_L1_error)
+  __pyx_t_1 = __pyx_FusedFunction_New(&__pyx_fuse_1__pyx_mdef_5skbio_5stats_8distance_7_cutils_17distmat_reorder_cy, 0, __pyx_n_s_distmat_reorder_cy, NULL, __pyx_n_s_skbio_stats_distance__cutils, __pyx_d, ((PyObject *)__pyx_codeobj__27)); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 71, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __Pyx_CyFunction_SetDefaultsTuple(__pyx_t_1, __pyx_empty_tuple);
-  if (PyDict_SetItem(__pyx_t_2, __pyx_n_s_double, __pyx_t_1) < 0) __PYX_ERR(0, 74, __pyx_L1_error)
+  if (PyDict_SetItem(__pyx_t_2, __pyx_n_s_double, __pyx_t_1) < 0) __PYX_ERR(0, 71, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
-  __pyx_t_1 = __pyx_FusedFunction_New(&__pyx_mdef_5skbio_5stats_8distance_7_cutils_3distmat_reorder_cy, 0, __pyx_n_s_distmat_reorder_cy, NULL, __pyx_n_s_skbio_stats_distance__cutils, __pyx_d, ((PyObject *)__pyx_codeobj__27)); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 74, __pyx_L1_error)
+  __pyx_t_1 = __pyx_FusedFunction_New(&__pyx_mdef_5skbio_5stats_8distance_7_cutils_3distmat_reorder_cy, 0, __pyx_n_s_distmat_reorder_cy, NULL, __pyx_n_s_skbio_stats_distance__cutils, __pyx_d, ((PyObject *)__pyx_codeobj__27)); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 71, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __Pyx_CyFunction_SetDefaultsTuple(__pyx_t_1, __pyx_empty_tuple);
   ((__pyx_FusedFunctionObject *) __pyx_t_1)->__signatures__ = __pyx_t_2;
   __Pyx_GIVEREF(__pyx_t_2);
   __pyx_t_2 = 0;
-  if (PyDict_SetItem(__pyx_d, __pyx_n_s_distmat_reorder_cy, __pyx_t_1) < 0) __PYX_ERR(0, 74, __pyx_L1_error)
+  if (PyDict_SetItem(__pyx_d, __pyx_n_s_distmat_reorder_cy, __pyx_t_1) < 0) __PYX_ERR(0, 71, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
 
-  /* "skbio/stats/distance/_cutils.pyx":126
+  /* "skbio/stats/distance/_cutils.pyx":123
  * @cython.boundscheck(False)
  * @cython.wraparound(False)
  * def distmat_reorder_condensed_cy(TReal[:, ::1] in_mat, long[::1] reorder_vec,             # <<<<<<<<<<<<<<
  *                                   TReal[::1] out_mat_condensed):
  *     """
  */
-  __pyx_t_1 = __Pyx_PyDict_NewPresized(2); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 126, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyDict_NewPresized(2); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 123, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_2 = __pyx_FusedFunction_New(&__pyx_fuse_0__pyx_mdef_5skbio_5stats_8distance_7_cutils_21distmat_reorder_condensed_cy, 0, __pyx_n_s_distmat_reorder_condensed_cy, NULL, __pyx_n_s_skbio_stats_distance__cutils, __pyx_d, ((PyObject *)__pyx_codeobj__29)); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 126, __pyx_L1_error)
+  __pyx_t_2 = __pyx_FusedFunction_New(&__pyx_fuse_0__pyx_mdef_5skbio_5stats_8distance_7_cutils_21distmat_reorder_condensed_cy, 0, __pyx_n_s_distmat_reorder_condensed_cy, NULL, __pyx_n_s_skbio_stats_distance__cutils, __pyx_d, ((PyObject *)__pyx_codeobj__29)); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 123, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
   __Pyx_CyFunction_SetDefaultsTuple(__pyx_t_2, __pyx_empty_tuple);
-  if (PyDict_SetItem(__pyx_t_1, __pyx_n_s_float, __pyx_t_2) < 0) __PYX_ERR(0, 126, __pyx_L1_error)
+  if (PyDict_SetItem(__pyx_t_1, __pyx_n_s_float, __pyx_t_2) < 0) __PYX_ERR(0, 123, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
-  __pyx_t_2 = __pyx_FusedFunction_New(&__pyx_fuse_1__pyx_mdef_5skbio_5stats_8distance_7_cutils_23distmat_reorder_condensed_cy, 0, __pyx_n_s_distmat_reorder_condensed_cy, NULL, __pyx_n_s_skbio_stats_distance__cutils, __pyx_d, ((PyObject *)__pyx_codeobj__29)); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 126, __pyx_L1_error)
+  __pyx_t_2 = __pyx_FusedFunction_New(&__pyx_fuse_1__pyx_mdef_5skbio_5stats_8distance_7_cutils_23distmat_reorder_condensed_cy, 0, __pyx_n_s_distmat_reorder_condensed_cy, NULL, __pyx_n_s_skbio_stats_distance__cutils, __pyx_d, ((PyObject *)__pyx_codeobj__29)); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 123, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
   __Pyx_CyFunction_SetDefaultsTuple(__pyx_t_2, __pyx_empty_tuple);
-  if (PyDict_SetItem(__pyx_t_1, __pyx_n_s_double, __pyx_t_2) < 0) __PYX_ERR(0, 126, __pyx_L1_error)
+  if (PyDict_SetItem(__pyx_t_1, __pyx_n_s_double, __pyx_t_2) < 0) __PYX_ERR(0, 123, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
-  __pyx_t_2 = __pyx_FusedFunction_New(&__pyx_mdef_5skbio_5stats_8distance_7_cutils_5distmat_reorder_condensed_cy, 0, __pyx_n_s_distmat_reorder_condensed_cy, NULL, __pyx_n_s_skbio_stats_distance__cutils, __pyx_d, ((PyObject *)__pyx_codeobj__29)); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 126, __pyx_L1_error)
+  __pyx_t_2 = __pyx_FusedFunction_New(&__pyx_mdef_5skbio_5stats_8distance_7_cutils_5distmat_reorder_condensed_cy, 0, __pyx_n_s_distmat_reorder_condensed_cy, NULL, __pyx_n_s_skbio_stats_distance__cutils, __pyx_d, ((PyObject *)__pyx_codeobj__29)); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 123, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
   __Pyx_CyFunction_SetDefaultsTuple(__pyx_t_2, __pyx_empty_tuple);
   ((__pyx_FusedFunctionObject *) __pyx_t_2)->__signatures__ = __pyx_t_1;
   __Pyx_GIVEREF(__pyx_t_1);
   __pyx_t_1 = 0;
-  if (PyDict_SetItem(__pyx_d, __pyx_n_s_distmat_reorder_condensed_cy, __pyx_t_2) < 0) __PYX_ERR(0, 126, __pyx_L1_error)
+  if (PyDict_SetItem(__pyx_d, __pyx_n_s_distmat_reorder_condensed_cy, __pyx_t_2) < 0) __PYX_ERR(0, 123, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
 
-  /* "skbio/stats/distance/_cutils.pyx":176
+  /* "skbio/stats/distance/_cutils.pyx":173
  * @cython.boundscheck(False)
  * @cython.wraparound(False)
  * def mantel_perm_pearsonr_cy(TReal[:, ::1] x_data, long[:, ::1] perm_order,             # <<<<<<<<<<<<<<
  *                             TReal xmean, TReal normxm,
  *                             TReal[::1] ym_normalized,
  */
-  __pyx_t_2 = __Pyx_PyDict_NewPresized(2); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 176, __pyx_L1_error)
+  __pyx_t_2 = __Pyx_PyDict_NewPresized(2); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 173, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
-  __pyx_t_1 = __pyx_FusedFunction_New(&__pyx_fuse_0__pyx_mdef_5skbio_5stats_8distance_7_cutils_27mantel_perm_pearsonr_cy, 0, __pyx_n_s_mantel_perm_pearsonr_cy, NULL, __pyx_n_s_skbio_stats_distance__cutils, __pyx_d, ((PyObject *)__pyx_codeobj__31)); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 176, __pyx_L1_error)
+  __pyx_t_1 = __pyx_FusedFunction_New(&__pyx_fuse_0__pyx_mdef_5skbio_5stats_8distance_7_cutils_27mantel_perm_pearsonr_cy, 0, __pyx_n_s_mantel_perm_pearsonr_cy, NULL, __pyx_n_s_skbio_stats_distance__cutils, __pyx_d, ((PyObject *)__pyx_codeobj__31)); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 173, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __Pyx_CyFunction_SetDefaultsTuple(__pyx_t_1, __pyx_empty_tuple);
-  if (PyDict_SetItem(__pyx_t_2, __pyx_n_s_float, __pyx_t_1) < 0) __PYX_ERR(0, 176, __pyx_L1_error)
+  if (PyDict_SetItem(__pyx_t_2, __pyx_n_s_float, __pyx_t_1) < 0) __PYX_ERR(0, 173, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
-  __pyx_t_1 = __pyx_FusedFunction_New(&__pyx_fuse_1__pyx_mdef_5skbio_5stats_8distance_7_cutils_29mantel_perm_pearsonr_cy, 0, __pyx_n_s_mantel_perm_pearsonr_cy, NULL, __pyx_n_s_skbio_stats_distance__cutils, __pyx_d, ((PyObject *)__pyx_codeobj__31)); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 176, __pyx_L1_error)
+  __pyx_t_1 = __pyx_FusedFunction_New(&__pyx_fuse_1__pyx_mdef_5skbio_5stats_8distance_7_cutils_29mantel_perm_pearsonr_cy, 0, __pyx_n_s_mantel_perm_pearsonr_cy, NULL, __pyx_n_s_skbio_stats_distance__cutils, __pyx_d, ((PyObject *)__pyx_codeobj__31)); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 173, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __Pyx_CyFunction_SetDefaultsTuple(__pyx_t_1, __pyx_empty_tuple);
-  if (PyDict_SetItem(__pyx_t_2, __pyx_n_s_double, __pyx_t_1) < 0) __PYX_ERR(0, 176, __pyx_L1_error)
+  if (PyDict_SetItem(__pyx_t_2, __pyx_n_s_double, __pyx_t_1) < 0) __PYX_ERR(0, 173, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
-  __pyx_t_1 = __pyx_FusedFunction_New(&__pyx_mdef_5skbio_5stats_8distance_7_cutils_7mantel_perm_pearsonr_cy, 0, __pyx_n_s_mantel_perm_pearsonr_cy, NULL, __pyx_n_s_skbio_stats_distance__cutils, __pyx_d, ((PyObject *)__pyx_codeobj__31)); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 176, __pyx_L1_error)
+  __pyx_t_1 = __pyx_FusedFunction_New(&__pyx_mdef_5skbio_5stats_8distance_7_cutils_7mantel_perm_pearsonr_cy, 0, __pyx_n_s_mantel_perm_pearsonr_cy, NULL, __pyx_n_s_skbio_stats_distance__cutils, __pyx_d, ((PyObject *)__pyx_codeobj__31)); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 173, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __Pyx_CyFunction_SetDefaultsTuple(__pyx_t_1, __pyx_empty_tuple);
   ((__pyx_FusedFunctionObject *) __pyx_t_1)->__signatures__ = __pyx_t_2;
   __Pyx_GIVEREF(__pyx_t_2);
   __pyx_t_2 = 0;
-  if (PyDict_SetItem(__pyx_d, __pyx_n_s_mantel_perm_pearsonr_cy, __pyx_t_1) < 0) __PYX_ERR(0, 176, __pyx_L1_error)
+  if (PyDict_SetItem(__pyx_d, __pyx_n_s_mantel_perm_pearsonr_cy, __pyx_t_1) < 0) __PYX_ERR(0, 173, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
 
   /* "skbio/stats/distance/_cutils.pyx":1

--- a/skbio/stats/distance/_cutils.pyx
+++ b/skbio/stats/distance/_cutils.pyx
@@ -52,19 +52,16 @@ def is_symmetric_and_hollow_cy(TReal[:, ::1] mat):
     cdef int is_hollow = True
 
     # use a tiled approach to maximize memory locality
-    for trow in prange(0, in_n, 64, nogil=True):
-        trow_max = min(trow+64, in_n)
-        for tcol in range(0, in_n, 64):
-            tcol_max = min(tcol+64, in_n)
+    for trow in prange(0, in_n, 24, nogil=True):
+        trow_max = min(trow+24, in_n)
+        for tcol in range(0, in_n, 24):
+            tcol_max = min(tcol+24, in_n)
             for row in range(trow, trow_max, 1):
                 for col in range(tcol, tcol_max, 1):
-                   testval = mat[row,col]
-                   if (row==col):
-                       # diagonal elements are always symmetric,
-                       # so no need to check
-                       is_hollow &= (testval==0)
-                   else:
-                       is_sym &= (testval==mat[col,row])
+                   is_sym &= (mat[row,col]==mat[col,row])
+            if (trow==tcol): # diagonal block, only ones that can have col==row
+                for col in range(tcol, tcol_max, 1):
+                   is_hollow &= (mat[col,col]==0)
 
     return [(is_sym==True), (is_hollow==True)]
 

--- a/skbio/stats/ordination/_cutils.c
+++ b/skbio/stats/ordination/_cutils.c
@@ -2307,7 +2307,7 @@ static PyObject *__pyx_codeobj__35;
 
 /* Python wrapper */
 static PyObject *__pyx_pw_5skbio_5stats_10ordination_7_cutils_1e_matrix_means_cy(PyObject *__pyx_self, PyObject *__pyx_args, PyObject *__pyx_kwds); /*proto*/
-static char __pyx_doc_5skbio_5stats_10ordination_7_cutils_e_matrix_means_cy[] = "\n    Compute E matrix from a distance matrix, and \n    also compute the means in the process.\n\n    Squares and divides by -2 the input elementwise. Eq. 9.20 in\n    Legendre & Legendre 1998.\n\n\n    Parameters\n    ----------\n    mat : 2D array_like\n        Distance matrix.\n    centered : 2D array_like\n        Output, E matrix. Must be pre-allocated and same shape as mat.\n        Can point to mat (i.e. in-place)\n    row_means : 1D_array_like\n        Outpuit, Mean values of each row in `centered`\n    Returns\n    -------\n    global_mean : real\n        Global mean value\n    ";
+static char __pyx_doc_5skbio_5stats_10ordination_7_cutils_e_matrix_means_cy[] = "\n    Compute E matrix from a distance matrix, and \n    also compute the means in the process.\n\n    Squares and divides by -2 the input elementwise. Eq. 9.20 in\n    Legendre & Legendre 1998.\n\n\n    Parameters\n    ----------\n    mat : 2D array_like\n        Distance matrix.\n    centered : 2D array_like\n        Output, E matrix. Must be pre-allocated and same shape as mat.\n        Can point to mat (i.e. in-place)\n    row_means : 1D_array_like\n        Output, Mean values of each row in `centered`\n    Returns\n    -------\n    global_mean : real\n        Global mean value\n    ";
 static PyMethodDef __pyx_mdef_5skbio_5stats_10ordination_7_cutils_1e_matrix_means_cy = {"e_matrix_means_cy", (PyCFunction)(void*)(PyCFunctionWithKeywords)__pyx_pw_5skbio_5stats_10ordination_7_cutils_1e_matrix_means_cy, METH_VARARGS|METH_KEYWORDS, __pyx_doc_5skbio_5stats_10ordination_7_cutils_e_matrix_means_cy};
 static PyObject *__pyx_pw_5skbio_5stats_10ordination_7_cutils_1e_matrix_means_cy(PyObject *__pyx_self, PyObject *__pyx_args, PyObject *__pyx_kwds) {
   PyObject *__pyx_v_signatures = 0;
@@ -2920,9 +2920,10 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_6e_matrix_means_cy
   Py_ssize_t __pyx_v_d5;
   Py_ssize_t __pyx_v_row;
   Py_ssize_t __pyx_v_col;
-  float __pyx_v_row_sum;
+  long double __pyx_v_row_sum;
   float __pyx_v_el0;
-  float __pyx_v_global_sum;
+  long double __pyx_v_global_sum;
+  float __pyx_v_global_mean;
   PyObject *__pyx_r = NULL;
   __Pyx_RefNannyDeclarations
   Py_ssize_t __pyx_t_1;
@@ -2933,7 +2934,7 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_6e_matrix_means_cy
   Py_ssize_t __pyx_t_6;
   Py_ssize_t __pyx_t_7;
   Py_ssize_t __pyx_t_8;
-  float __pyx_t_9;
+  long double __pyx_t_9;
   PyObject *__pyx_t_10 = NULL;
   int __pyx_lineno = 0;
   const char *__pyx_filename = NULL;
@@ -3052,7 +3053,7 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_6e_matrix_means_cy
   /* "skbio/stats/ordination/_cutils.pyx":61
  *     cdef TReal el0
  * 
- *     cdef TReal global_sum = 0.0             # <<<<<<<<<<<<<<
+ *     cdef long double global_sum = 0.0             # <<<<<<<<<<<<<<
  *     for row in prange(n_samples, nogil=True):
  *         row_sum = 0.0
  */
@@ -3060,7 +3061,7 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_6e_matrix_means_cy
 
   /* "skbio/stats/ordination/_cutils.pyx":62
  * 
- *     cdef TReal global_sum = 0.0
+ *     cdef long double global_sum = 0.0
  *     for row in prange(n_samples, nogil=True):             # <<<<<<<<<<<<<<
  *         row_sum = 0.0
  * 
@@ -3077,9 +3078,9 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_6e_matrix_means_cy
         {
             Py_ssize_t __pyx_parallel_temp0 = ((Py_ssize_t)0xbad0bad0);
             float __pyx_parallel_temp1 = ((float)__PYX_NAN());
-            float __pyx_parallel_temp2 = ((float)__PYX_NAN());
+            long double __pyx_parallel_temp2 = ((long double)__PYX_NAN());
             Py_ssize_t __pyx_parallel_temp3 = ((Py_ssize_t)0xbad0bad0);
-            float __pyx_parallel_temp4 = ((float)__PYX_NAN());
+            long double __pyx_parallel_temp4 = ((long double)__PYX_NAN());
             const char *__pyx_parallel_filename = NULL; int __pyx_parallel_lineno = 0, __pyx_parallel_clineno = 0;
             PyObject *__pyx_parallel_exc_type = NULL, *__pyx_parallel_exc_value = NULL, *__pyx_parallel_exc_tb = NULL;
             int __pyx_parallel_why;
@@ -3113,10 +3114,10 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_6e_matrix_means_cy
                             /* Initialize private variables to invalid values */
                             __pyx_v_col = ((Py_ssize_t)0xbad0bad0);
                             __pyx_v_el0 = ((float)__PYX_NAN());
-                            __pyx_v_row_sum = ((float)__PYX_NAN());
+                            __pyx_v_row_sum = ((long double)__PYX_NAN());
 
                             /* "skbio/stats/ordination/_cutils.pyx":63
- *     cdef TReal global_sum = 0.0
+ *     cdef long double global_sum = 0.0
  *     for row in prange(n_samples, nogil=True):
  *         row_sum = 0.0             # <<<<<<<<<<<<<<
  * 
@@ -3191,7 +3192,7 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_6e_matrix_means_cy
  *         global_sum += row_sum
  *         row_means[row] = row_sum/n_samples             # <<<<<<<<<<<<<<
  * 
- *     return (global_sum/n_samples)/n_samples
+ *     cdef TReal global_mean = (global_sum/n_samples)/n_samples
  */
                             if (unlikely(__pyx_v_n_samples == 0)) {
                               #ifdef WITH_THREAD
@@ -3296,7 +3297,7 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_6e_matrix_means_cy
 
       /* "skbio/stats/ordination/_cutils.pyx":62
  * 
- *     cdef TReal global_sum = 0.0
+ *     cdef long double global_sum = 0.0
  *     for row in prange(n_samples, nogil=True):             # <<<<<<<<<<<<<<
  *         row_sum = 0.0
  * 
@@ -3323,11 +3324,10 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_6e_matrix_means_cy
   /* "skbio/stats/ordination/_cutils.pyx":75
  *         row_means[row] = row_sum/n_samples
  * 
- *     return (global_sum/n_samples)/n_samples             # <<<<<<<<<<<<<<
+ *     cdef TReal global_mean = (global_sum/n_samples)/n_samples             # <<<<<<<<<<<<<<
  * 
- * @cython.boundscheck(False)
+ *     return global_mean
  */
-  __Pyx_XDECREF(__pyx_r);
   if (unlikely(__pyx_v_n_samples == 0)) {
     PyErr_SetString(PyExc_ZeroDivisionError, "float division");
     __PYX_ERR(0, 75, __pyx_L1_error)
@@ -3337,7 +3337,17 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_6e_matrix_means_cy
     PyErr_SetString(PyExc_ZeroDivisionError, "float division");
     __PYX_ERR(0, 75, __pyx_L1_error)
   }
-  __pyx_t_10 = PyFloat_FromDouble((__pyx_t_9 / __pyx_v_n_samples)); if (unlikely(!__pyx_t_10)) __PYX_ERR(0, 75, __pyx_L1_error)
+  __pyx_v_global_mean = (__pyx_t_9 / __pyx_v_n_samples);
+
+  /* "skbio/stats/ordination/_cutils.pyx":77
+ *     cdef TReal global_mean = (global_sum/n_samples)/n_samples
+ * 
+ *     return global_mean             # <<<<<<<<<<<<<<
+ * 
+ * @cython.boundscheck(False)
+ */
+  __Pyx_XDECREF(__pyx_r);
+  __pyx_t_10 = PyFloat_FromDouble(__pyx_v_global_mean); if (unlikely(!__pyx_t_10)) __PYX_ERR(0, 77, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_10);
   __pyx_r = __pyx_t_10;
   __pyx_t_10 = 0;
@@ -3449,9 +3459,10 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_8e_matrix_means_cy
   Py_ssize_t __pyx_v_d5;
   Py_ssize_t __pyx_v_row;
   Py_ssize_t __pyx_v_col;
-  double __pyx_v_row_sum;
+  long double __pyx_v_row_sum;
   double __pyx_v_el0;
-  double __pyx_v_global_sum;
+  long double __pyx_v_global_sum;
+  double __pyx_v_global_mean;
   PyObject *__pyx_r = NULL;
   __Pyx_RefNannyDeclarations
   Py_ssize_t __pyx_t_1;
@@ -3462,7 +3473,7 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_8e_matrix_means_cy
   Py_ssize_t __pyx_t_6;
   Py_ssize_t __pyx_t_7;
   Py_ssize_t __pyx_t_8;
-  double __pyx_t_9;
+  long double __pyx_t_9;
   PyObject *__pyx_t_10 = NULL;
   int __pyx_lineno = 0;
   const char *__pyx_filename = NULL;
@@ -3581,7 +3592,7 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_8e_matrix_means_cy
   /* "skbio/stats/ordination/_cutils.pyx":61
  *     cdef TReal el0
  * 
- *     cdef TReal global_sum = 0.0             # <<<<<<<<<<<<<<
+ *     cdef long double global_sum = 0.0             # <<<<<<<<<<<<<<
  *     for row in prange(n_samples, nogil=True):
  *         row_sum = 0.0
  */
@@ -3589,7 +3600,7 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_8e_matrix_means_cy
 
   /* "skbio/stats/ordination/_cutils.pyx":62
  * 
- *     cdef TReal global_sum = 0.0
+ *     cdef long double global_sum = 0.0
  *     for row in prange(n_samples, nogil=True):             # <<<<<<<<<<<<<<
  *         row_sum = 0.0
  * 
@@ -3606,9 +3617,9 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_8e_matrix_means_cy
         {
             Py_ssize_t __pyx_parallel_temp0 = ((Py_ssize_t)0xbad0bad0);
             double __pyx_parallel_temp1 = ((double)__PYX_NAN());
-            double __pyx_parallel_temp2 = ((double)__PYX_NAN());
+            long double __pyx_parallel_temp2 = ((long double)__PYX_NAN());
             Py_ssize_t __pyx_parallel_temp3 = ((Py_ssize_t)0xbad0bad0);
-            double __pyx_parallel_temp4 = ((double)__PYX_NAN());
+            long double __pyx_parallel_temp4 = ((long double)__PYX_NAN());
             const char *__pyx_parallel_filename = NULL; int __pyx_parallel_lineno = 0, __pyx_parallel_clineno = 0;
             PyObject *__pyx_parallel_exc_type = NULL, *__pyx_parallel_exc_value = NULL, *__pyx_parallel_exc_tb = NULL;
             int __pyx_parallel_why;
@@ -3642,10 +3653,10 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_8e_matrix_means_cy
                             /* Initialize private variables to invalid values */
                             __pyx_v_col = ((Py_ssize_t)0xbad0bad0);
                             __pyx_v_el0 = ((double)__PYX_NAN());
-                            __pyx_v_row_sum = ((double)__PYX_NAN());
+                            __pyx_v_row_sum = ((long double)__PYX_NAN());
 
                             /* "skbio/stats/ordination/_cutils.pyx":63
- *     cdef TReal global_sum = 0.0
+ *     cdef long double global_sum = 0.0
  *     for row in prange(n_samples, nogil=True):
  *         row_sum = 0.0             # <<<<<<<<<<<<<<
  * 
@@ -3720,7 +3731,7 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_8e_matrix_means_cy
  *         global_sum += row_sum
  *         row_means[row] = row_sum/n_samples             # <<<<<<<<<<<<<<
  * 
- *     return (global_sum/n_samples)/n_samples
+ *     cdef TReal global_mean = (global_sum/n_samples)/n_samples
  */
                             if (unlikely(__pyx_v_n_samples == 0)) {
                               #ifdef WITH_THREAD
@@ -3825,7 +3836,7 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_8e_matrix_means_cy
 
       /* "skbio/stats/ordination/_cutils.pyx":62
  * 
- *     cdef TReal global_sum = 0.0
+ *     cdef long double global_sum = 0.0
  *     for row in prange(n_samples, nogil=True):             # <<<<<<<<<<<<<<
  *         row_sum = 0.0
  * 
@@ -3852,11 +3863,10 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_8e_matrix_means_cy
   /* "skbio/stats/ordination/_cutils.pyx":75
  *         row_means[row] = row_sum/n_samples
  * 
- *     return (global_sum/n_samples)/n_samples             # <<<<<<<<<<<<<<
+ *     cdef TReal global_mean = (global_sum/n_samples)/n_samples             # <<<<<<<<<<<<<<
  * 
- * @cython.boundscheck(False)
+ *     return global_mean
  */
-  __Pyx_XDECREF(__pyx_r);
   if (unlikely(__pyx_v_n_samples == 0)) {
     PyErr_SetString(PyExc_ZeroDivisionError, "float division");
     __PYX_ERR(0, 75, __pyx_L1_error)
@@ -3866,7 +3876,17 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_8e_matrix_means_cy
     PyErr_SetString(PyExc_ZeroDivisionError, "float division");
     __PYX_ERR(0, 75, __pyx_L1_error)
   }
-  __pyx_t_10 = PyFloat_FromDouble((__pyx_t_9 / __pyx_v_n_samples)); if (unlikely(!__pyx_t_10)) __PYX_ERR(0, 75, __pyx_L1_error)
+  __pyx_v_global_mean = (__pyx_t_9 / __pyx_v_n_samples);
+
+  /* "skbio/stats/ordination/_cutils.pyx":77
+ *     cdef TReal global_mean = (global_sum/n_samples)/n_samples
+ * 
+ *     return global_mean             # <<<<<<<<<<<<<<
+ * 
+ * @cython.boundscheck(False)
+ */
+  __Pyx_XDECREF(__pyx_r);
+  __pyx_t_10 = PyFloat_FromDouble(__pyx_v_global_mean); if (unlikely(!__pyx_t_10)) __PYX_ERR(0, 77, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_10);
   __pyx_r = __pyx_t_10;
   __pyx_t_10 = 0;
@@ -3894,7 +3914,7 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_8e_matrix_means_cy
   return __pyx_r;
 }
 
-/* "skbio/stats/ordination/_cutils.pyx":79
+/* "skbio/stats/ordination/_cutils.pyx":81
  * @cython.boundscheck(False)
  * @cython.wraparound(False)
  * def f_matrix_inplace_cy(TReal[::1] row_means, TReal global_mean, TReal[:, ::1] centered):             # <<<<<<<<<<<<<<
@@ -3944,23 +3964,23 @@ static PyObject *__pyx_pw_5skbio_5stats_10ordination_7_cutils_3f_matrix_inplace_
         case  1:
         if (likely((values[1] = __Pyx_PyDict_GetItemStr(__pyx_kwds, __pyx_n_s_args)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("__pyx_fused_cpdef", 1, 4, 4, 1); __PYX_ERR(0, 79, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("__pyx_fused_cpdef", 1, 4, 4, 1); __PYX_ERR(0, 81, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  2:
         if (likely((values[2] = __Pyx_PyDict_GetItemStr(__pyx_kwds, __pyx_n_s_kwargs)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("__pyx_fused_cpdef", 1, 4, 4, 2); __PYX_ERR(0, 79, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("__pyx_fused_cpdef", 1, 4, 4, 2); __PYX_ERR(0, 81, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  3:
         if (likely((values[3] = __Pyx_PyDict_GetItemStr(__pyx_kwds, __pyx_n_s_defaults)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("__pyx_fused_cpdef", 1, 4, 4, 3); __PYX_ERR(0, 79, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("__pyx_fused_cpdef", 1, 4, 4, 3); __PYX_ERR(0, 81, __pyx_L3_error)
         }
       }
       if (unlikely(kw_args > 0)) {
-        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "__pyx_fused_cpdef") < 0)) __PYX_ERR(0, 79, __pyx_L3_error)
+        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "__pyx_fused_cpdef") < 0)) __PYX_ERR(0, 81, __pyx_L3_error)
       }
     } else if (PyTuple_GET_SIZE(__pyx_args) != 4) {
       goto __pyx_L5_argtuple_error;
@@ -3977,7 +3997,7 @@ static PyObject *__pyx_pw_5skbio_5stats_10ordination_7_cutils_3f_matrix_inplace_
   }
   goto __pyx_L4_argument_unpacking_done;
   __pyx_L5_argtuple_error:;
-  __Pyx_RaiseArgtupleInvalid("__pyx_fused_cpdef", 1, 4, 4, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 79, __pyx_L3_error)
+  __Pyx_RaiseArgtupleInvalid("__pyx_fused_cpdef", 1, 4, 4, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 81, __pyx_L3_error)
   __pyx_L3_error:;
   __Pyx_AddTraceback("skbio.stats.ordination._cutils.__pyx_fused_cpdef", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __Pyx_RefNannyFinishContext();
@@ -4031,7 +4051,7 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_2f_matrix_inplace_
   int __pyx_clineno = 0;
   __Pyx_RefNannySetupContext("f_matrix_inplace_cy", 0);
   __Pyx_INCREF(__pyx_v_kwargs);
-  __pyx_t_1 = PyList_New(1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 79, __pyx_L1_error)
+  __pyx_t_1 = PyList_New(1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 81, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __Pyx_INCREF(Py_None);
   __Pyx_GIVEREF(Py_None);
@@ -4045,7 +4065,7 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_2f_matrix_inplace_
     __pyx_t_2 = __pyx_t_4;
     goto __pyx_L4_bool_binop_done;
   }
-  __pyx_t_4 = __Pyx_PyObject_IsTrue(__pyx_v_kwargs); if (unlikely(__pyx_t_4 < 0)) __PYX_ERR(0, 79, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_PyObject_IsTrue(__pyx_v_kwargs); if (unlikely(__pyx_t_4 < 0)) __PYX_ERR(0, 81, __pyx_L1_error)
   __pyx_t_3 = ((!__pyx_t_4) != 0);
   __pyx_t_2 = __pyx_t_3;
   __pyx_L4_bool_binop_done:;
@@ -4053,21 +4073,21 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_2f_matrix_inplace_
     __Pyx_INCREF(Py_None);
     __Pyx_DECREF_SET(__pyx_v_kwargs, Py_None);
   }
-  __pyx_t_1 = ((PyObject *)__Pyx_ImportNumPyArrayTypeIfAvailable()); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 79, __pyx_L1_error)
+  __pyx_t_1 = ((PyObject *)__Pyx_ImportNumPyArrayTypeIfAvailable()); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 81, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __pyx_v_ndarray = ((PyTypeObject*)__pyx_t_1);
   __pyx_t_1 = 0;
   __pyx_v_itemsize = -1L;
   if (unlikely(__pyx_v_args == Py_None)) {
     PyErr_SetString(PyExc_TypeError, "object of type 'NoneType' has no len()");
-    __PYX_ERR(0, 79, __pyx_L1_error)
+    __PYX_ERR(0, 81, __pyx_L1_error)
   }
-  __pyx_t_5 = PyTuple_GET_SIZE(((PyObject*)__pyx_v_args)); if (unlikely(__pyx_t_5 == ((Py_ssize_t)-1))) __PYX_ERR(0, 79, __pyx_L1_error)
+  __pyx_t_5 = PyTuple_GET_SIZE(((PyObject*)__pyx_v_args)); if (unlikely(__pyx_t_5 == ((Py_ssize_t)-1))) __PYX_ERR(0, 81, __pyx_L1_error)
   __pyx_t_2 = ((0 < __pyx_t_5) != 0);
   if (__pyx_t_2) {
     if (unlikely(__pyx_v_args == Py_None)) {
       PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-      __PYX_ERR(0, 79, __pyx_L1_error)
+      __PYX_ERR(0, 81, __pyx_L1_error)
     }
     __pyx_t_1 = PyTuple_GET_ITEM(((PyObject*)__pyx_v_args), 0);
     __Pyx_INCREF(__pyx_t_1);
@@ -4084,18 +4104,18 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_2f_matrix_inplace_
   }
   if (unlikely(__pyx_v_kwargs == Py_None)) {
     PyErr_SetString(PyExc_TypeError, "'NoneType' object is not iterable");
-    __PYX_ERR(0, 79, __pyx_L1_error)
+    __PYX_ERR(0, 81, __pyx_L1_error)
   }
-  __pyx_t_4 = (__Pyx_PyDict_ContainsTF(__pyx_n_s_row_means, ((PyObject*)__pyx_v_kwargs), Py_EQ)); if (unlikely(__pyx_t_4 < 0)) __PYX_ERR(0, 79, __pyx_L1_error)
+  __pyx_t_4 = (__Pyx_PyDict_ContainsTF(__pyx_n_s_row_means, ((PyObject*)__pyx_v_kwargs), Py_EQ)); if (unlikely(__pyx_t_4 < 0)) __PYX_ERR(0, 81, __pyx_L1_error)
   __pyx_t_3 = (__pyx_t_4 != 0);
   __pyx_t_2 = __pyx_t_3;
   __pyx_L7_bool_binop_done:;
   if (__pyx_t_2) {
     if (unlikely(__pyx_v_kwargs == Py_None)) {
       PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-      __PYX_ERR(0, 79, __pyx_L1_error)
+      __PYX_ERR(0, 81, __pyx_L1_error)
     }
-    __pyx_t_1 = __Pyx_PyDict_GetItem(((PyObject*)__pyx_v_kwargs), __pyx_n_s_row_means); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 79, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_PyDict_GetItem(((PyObject*)__pyx_v_kwargs), __pyx_n_s_row_means); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 81, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
     __pyx_v_arg = __pyx_t_1;
     __pyx_t_1 = 0;
@@ -4104,12 +4124,12 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_2f_matrix_inplace_
   /*else*/ {
     if (unlikely(__pyx_v_args == Py_None)) {
       PyErr_SetString(PyExc_TypeError, "object of type 'NoneType' has no len()");
-      __PYX_ERR(0, 79, __pyx_L1_error)
+      __PYX_ERR(0, 81, __pyx_L1_error)
     }
-    __pyx_t_5 = PyTuple_GET_SIZE(((PyObject*)__pyx_v_args)); if (unlikely(__pyx_t_5 == ((Py_ssize_t)-1))) __PYX_ERR(0, 79, __pyx_L1_error)
-    __pyx_t_1 = PyInt_FromSsize_t(__pyx_t_5); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 79, __pyx_L1_error)
+    __pyx_t_5 = PyTuple_GET_SIZE(((PyObject*)__pyx_v_args)); if (unlikely(__pyx_t_5 == ((Py_ssize_t)-1))) __PYX_ERR(0, 81, __pyx_L1_error)
+    __pyx_t_1 = PyInt_FromSsize_t(__pyx_t_5); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 81, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
-    __pyx_t_6 = PyTuple_New(3); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 79, __pyx_L1_error)
+    __pyx_t_6 = PyTuple_New(3); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 81, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_6);
     __Pyx_INCREF(__pyx_int_3);
     __Pyx_GIVEREF(__pyx_int_3);
@@ -4120,15 +4140,15 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_2f_matrix_inplace_
     __Pyx_GIVEREF(__pyx_t_1);
     PyTuple_SET_ITEM(__pyx_t_6, 2, __pyx_t_1);
     __pyx_t_1 = 0;
-    __pyx_t_1 = __Pyx_PyString_Format(__pyx_kp_s_Expected_at_least_d_argument_s_g, __pyx_t_6); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 79, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_PyString_Format(__pyx_kp_s_Expected_at_least_d_argument_s_g, __pyx_t_6); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 81, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
-    __pyx_t_6 = __Pyx_PyObject_CallOneArg(__pyx_builtin_TypeError, __pyx_t_1); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 79, __pyx_L1_error)
+    __pyx_t_6 = __Pyx_PyObject_CallOneArg(__pyx_builtin_TypeError, __pyx_t_1); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 81, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_6);
     __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
     __Pyx_Raise(__pyx_t_6, 0, 0, 0);
     __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
-    __PYX_ERR(0, 79, __pyx_L1_error)
+    __PYX_ERR(0, 81, __pyx_L1_error)
   }
   __pyx_L6:;
   while (1) {
@@ -4138,7 +4158,7 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_2f_matrix_inplace_
       __pyx_t_3 = __Pyx_TypeCheck(__pyx_v_arg, __pyx_v_ndarray); 
       __pyx_t_2 = (__pyx_t_3 != 0);
       if (__pyx_t_2) {
-        __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_dtype); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 79, __pyx_L1_error)
+        __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_dtype); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 81, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_6);
         __pyx_v_dtype = __pyx_t_6;
         __pyx_t_6 = 0;
@@ -4147,14 +4167,14 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_2f_matrix_inplace_
       __pyx_t_2 = __pyx_memoryview_check(__pyx_v_arg); 
       __pyx_t_3 = (__pyx_t_2 != 0);
       if (__pyx_t_3) {
-        __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_base); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 79, __pyx_L1_error)
+        __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_base); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 81, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_6);
         __pyx_v_arg_base = __pyx_t_6;
         __pyx_t_6 = 0;
         __pyx_t_3 = __Pyx_TypeCheck(__pyx_v_arg_base, __pyx_v_ndarray); 
         __pyx_t_2 = (__pyx_t_3 != 0);
         if (__pyx_t_2) {
-          __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg_base, __pyx_n_s_dtype); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 79, __pyx_L1_error)
+          __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg_base, __pyx_n_s_dtype); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 81, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_6);
           __pyx_v_dtype = __pyx_t_6;
           __pyx_t_6 = 0;
@@ -4176,14 +4196,14 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_2f_matrix_inplace_
       __pyx_t_2 = (__pyx_v_dtype != Py_None);
       __pyx_t_3 = (__pyx_t_2 != 0);
       if (__pyx_t_3) {
-        __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_v_dtype, __pyx_n_s_itemsize); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 79, __pyx_L1_error)
+        __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_v_dtype, __pyx_n_s_itemsize); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 81, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_6);
-        __pyx_t_5 = __Pyx_PyIndex_AsSsize_t(__pyx_t_6); if (unlikely((__pyx_t_5 == (Py_ssize_t)-1) && PyErr_Occurred())) __PYX_ERR(0, 79, __pyx_L1_error)
+        __pyx_t_5 = __Pyx_PyIndex_AsSsize_t(__pyx_t_6); if (unlikely((__pyx_t_5 == (Py_ssize_t)-1) && PyErr_Occurred())) __PYX_ERR(0, 81, __pyx_L1_error)
         __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
         __pyx_v_itemsize = __pyx_t_5;
-        __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_v_dtype, __pyx_n_s_kind); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 79, __pyx_L1_error)
+        __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_v_dtype, __pyx_n_s_kind); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 81, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_6);
-        __pyx_t_7 = __Pyx_PyObject_Ord(__pyx_t_6); if (unlikely(__pyx_t_7 == ((long)(long)(Py_UCS4)-1))) __PYX_ERR(0, 79, __pyx_L1_error)
+        __pyx_t_7 = __Pyx_PyObject_Ord(__pyx_t_6); if (unlikely(__pyx_t_7 == ((long)(long)(Py_UCS4)-1))) __PYX_ERR(0, 81, __pyx_L1_error)
         __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
         __pyx_v_kind = __pyx_t_7;
         __pyx_v_dtype_signed = (__pyx_v_kind == 'i');
@@ -4198,15 +4218,15 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_2f_matrix_inplace_
             __pyx_t_3 = __pyx_t_2;
             goto __pyx_L16_bool_binop_done;
           }
-          __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_ndim); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 79, __pyx_L1_error)
+          __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_ndim); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 81, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_6);
-          __pyx_t_5 = __Pyx_PyIndex_AsSsize_t(__pyx_t_6); if (unlikely((__pyx_t_5 == (Py_ssize_t)-1) && PyErr_Occurred())) __PYX_ERR(0, 79, __pyx_L1_error)
+          __pyx_t_5 = __Pyx_PyIndex_AsSsize_t(__pyx_t_6); if (unlikely((__pyx_t_5 == (Py_ssize_t)-1) && PyErr_Occurred())) __PYX_ERR(0, 81, __pyx_L1_error)
           __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
           __pyx_t_2 = ((((Py_ssize_t)__pyx_t_5) == 1) != 0);
           __pyx_t_3 = __pyx_t_2;
           __pyx_L16_bool_binop_done:;
           if (__pyx_t_3) {
-            if (unlikely(__Pyx_SetItemInt(__pyx_v_dest_sig, 0, __pyx_n_s_float, long, 1, __Pyx_PyInt_From_long, 1, 0, 0) < 0)) __PYX_ERR(0, 79, __pyx_L1_error)
+            if (unlikely(__Pyx_SetItemInt(__pyx_v_dest_sig, 0, __pyx_n_s_float, long, 1, __Pyx_PyInt_From_long, 1, 0, 0) < 0)) __PYX_ERR(0, 81, __pyx_L1_error)
             goto __pyx_L10_break;
           }
           __pyx_t_2 = (((sizeof(double)) == __pyx_v_itemsize) != 0);
@@ -4215,15 +4235,15 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_2f_matrix_inplace_
             __pyx_t_3 = __pyx_t_2;
             goto __pyx_L19_bool_binop_done;
           }
-          __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_ndim); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 79, __pyx_L1_error)
+          __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_ndim); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 81, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_6);
-          __pyx_t_5 = __Pyx_PyIndex_AsSsize_t(__pyx_t_6); if (unlikely((__pyx_t_5 == (Py_ssize_t)-1) && PyErr_Occurred())) __PYX_ERR(0, 79, __pyx_L1_error)
+          __pyx_t_5 = __Pyx_PyIndex_AsSsize_t(__pyx_t_6); if (unlikely((__pyx_t_5 == (Py_ssize_t)-1) && PyErr_Occurred())) __PYX_ERR(0, 81, __pyx_L1_error)
           __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
           __pyx_t_2 = ((((Py_ssize_t)__pyx_t_5) == 1) != 0);
           __pyx_t_3 = __pyx_t_2;
           __pyx_L19_bool_binop_done:;
           if (__pyx_t_3) {
-            if (unlikely(__Pyx_SetItemInt(__pyx_v_dest_sig, 0, __pyx_n_s_double, long, 1, __Pyx_PyInt_From_long, 1, 0, 0) < 0)) __PYX_ERR(0, 79, __pyx_L1_error)
+            if (unlikely(__Pyx_SetItemInt(__pyx_v_dest_sig, 0, __pyx_n_s_double, long, 1, __Pyx_PyInt_From_long, 1, 0, 0) < 0)) __PYX_ERR(0, 81, __pyx_L1_error)
             goto __pyx_L10_break;
           }
           break;
@@ -4250,7 +4270,7 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_2f_matrix_inplace_
       __pyx_t_3 = (__pyx_v_memslice.memview != 0);
       if (__pyx_t_3) {
         __PYX_XDEC_MEMVIEW((&__pyx_v_memslice), 1); 
-        if (unlikely(__Pyx_SetItemInt(__pyx_v_dest_sig, 0, __pyx_n_s_float, long, 1, __Pyx_PyInt_From_long, 1, 0, 0) < 0)) __PYX_ERR(0, 79, __pyx_L1_error)
+        if (unlikely(__Pyx_SetItemInt(__pyx_v_dest_sig, 0, __pyx_n_s_float, long, 1, __Pyx_PyInt_From_long, 1, 0, 0) < 0)) __PYX_ERR(0, 81, __pyx_L1_error)
         goto __pyx_L10_break;
       }
       /*else*/ {
@@ -4272,27 +4292,27 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_2f_matrix_inplace_
       __pyx_t_3 = (__pyx_v_memslice.memview != 0);
       if (__pyx_t_3) {
         __PYX_XDEC_MEMVIEW((&__pyx_v_memslice), 1); 
-        if (unlikely(__Pyx_SetItemInt(__pyx_v_dest_sig, 0, __pyx_n_s_double, long, 1, __Pyx_PyInt_From_long, 1, 0, 0) < 0)) __PYX_ERR(0, 79, __pyx_L1_error)
+        if (unlikely(__Pyx_SetItemInt(__pyx_v_dest_sig, 0, __pyx_n_s_double, long, 1, __Pyx_PyInt_From_long, 1, 0, 0) < 0)) __PYX_ERR(0, 81, __pyx_L1_error)
         goto __pyx_L10_break;
       }
       /*else*/ {
         PyErr_Clear(); 
       }
     }
-    if (unlikely(__Pyx_SetItemInt(__pyx_v_dest_sig, 0, Py_None, long, 1, __Pyx_PyInt_From_long, 1, 0, 0) < 0)) __PYX_ERR(0, 79, __pyx_L1_error)
+    if (unlikely(__Pyx_SetItemInt(__pyx_v_dest_sig, 0, Py_None, long, 1, __Pyx_PyInt_From_long, 1, 0, 0) < 0)) __PYX_ERR(0, 81, __pyx_L1_error)
     goto __pyx_L10_break;
   }
   __pyx_L10_break:;
-  __pyx_t_6 = PyList_New(0); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 79, __pyx_L1_error)
+  __pyx_t_6 = PyList_New(0); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 81, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_6);
   __pyx_v_candidates = ((PyObject*)__pyx_t_6);
   __pyx_t_6 = 0;
   __pyx_t_5 = 0;
   if (unlikely(__pyx_v_signatures == Py_None)) {
     PyErr_SetString(PyExc_TypeError, "'NoneType' object is not iterable");
-    __PYX_ERR(0, 79, __pyx_L1_error)
+    __PYX_ERR(0, 81, __pyx_L1_error)
   }
-  __pyx_t_1 = __Pyx_dict_iterator(((PyObject*)__pyx_v_signatures), 1, ((PyObject *)NULL), (&__pyx_t_9), (&__pyx_t_10)); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 79, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_dict_iterator(((PyObject*)__pyx_v_signatures), 1, ((PyObject *)NULL), (&__pyx_t_9), (&__pyx_t_10)); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 81, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __Pyx_XDECREF(__pyx_t_6);
   __pyx_t_6 = __pyx_t_1;
@@ -4300,12 +4320,12 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_2f_matrix_inplace_
   while (1) {
     __pyx_t_11 = __Pyx_dict_iter_next(__pyx_t_6, __pyx_t_9, &__pyx_t_5, &__pyx_t_1, NULL, NULL, __pyx_t_10);
     if (unlikely(__pyx_t_11 == 0)) break;
-    if (unlikely(__pyx_t_11 == -1)) __PYX_ERR(0, 79, __pyx_L1_error)
+    if (unlikely(__pyx_t_11 == -1)) __PYX_ERR(0, 81, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_XDECREF_SET(__pyx_v_sig, __pyx_t_1);
     __pyx_t_1 = 0;
     __pyx_v_match_found = 0;
-    __pyx_t_13 = __Pyx_PyObject_GetAttrStr(__pyx_v_sig, __pyx_n_s_strip); if (unlikely(!__pyx_t_13)) __PYX_ERR(0, 79, __pyx_L1_error)
+    __pyx_t_13 = __Pyx_PyObject_GetAttrStr(__pyx_v_sig, __pyx_n_s_strip); if (unlikely(!__pyx_t_13)) __PYX_ERR(0, 81, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_13);
     __pyx_t_14 = NULL;
     if (CYTHON_UNPACK_METHODS && likely(PyMethod_Check(__pyx_t_13))) {
@@ -4319,10 +4339,10 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_2f_matrix_inplace_
     }
     __pyx_t_12 = (__pyx_t_14) ? __Pyx_PyObject_Call2Args(__pyx_t_13, __pyx_t_14, __pyx_kp_s_) : __Pyx_PyObject_CallOneArg(__pyx_t_13, __pyx_kp_s_);
     __Pyx_XDECREF(__pyx_t_14); __pyx_t_14 = 0;
-    if (unlikely(!__pyx_t_12)) __PYX_ERR(0, 79, __pyx_L1_error)
+    if (unlikely(!__pyx_t_12)) __PYX_ERR(0, 81, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_12);
     __Pyx_DECREF(__pyx_t_13); __pyx_t_13 = 0;
-    __pyx_t_13 = __Pyx_PyObject_GetAttrStr(__pyx_t_12, __pyx_n_s_split); if (unlikely(!__pyx_t_13)) __PYX_ERR(0, 79, __pyx_L1_error)
+    __pyx_t_13 = __Pyx_PyObject_GetAttrStr(__pyx_t_12, __pyx_n_s_split); if (unlikely(!__pyx_t_13)) __PYX_ERR(0, 81, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_13);
     __Pyx_DECREF(__pyx_t_12); __pyx_t_12 = 0;
     __pyx_t_12 = NULL;
@@ -4337,12 +4357,12 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_2f_matrix_inplace_
     }
     __pyx_t_1 = (__pyx_t_12) ? __Pyx_PyObject_Call2Args(__pyx_t_13, __pyx_t_12, __pyx_kp_s__2) : __Pyx_PyObject_CallOneArg(__pyx_t_13, __pyx_kp_s__2);
     __Pyx_XDECREF(__pyx_t_12); __pyx_t_12 = 0;
-    if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 79, __pyx_L1_error)
+    if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 81, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF(__pyx_t_13); __pyx_t_13 = 0;
     __Pyx_XDECREF_SET(__pyx_v_src_sig, __pyx_t_1);
     __pyx_t_1 = 0;
-    __pyx_t_15 = PyList_GET_SIZE(__pyx_v_dest_sig); if (unlikely(__pyx_t_15 == ((Py_ssize_t)-1))) __PYX_ERR(0, 79, __pyx_L1_error)
+    __pyx_t_15 = PyList_GET_SIZE(__pyx_v_dest_sig); if (unlikely(__pyx_t_15 == ((Py_ssize_t)-1))) __PYX_ERR(0, 81, __pyx_L1_error)
     __pyx_t_16 = __pyx_t_15;
     for (__pyx_t_17 = 0; __pyx_t_17 < __pyx_t_16; __pyx_t_17+=1) {
       __pyx_v_i = __pyx_t_17;
@@ -4353,11 +4373,11 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_2f_matrix_inplace_
       __pyx_t_3 = (__pyx_v_dst_type != Py_None);
       __pyx_t_2 = (__pyx_t_3 != 0);
       if (__pyx_t_2) {
-        __pyx_t_1 = __Pyx_GetItemInt(__pyx_v_src_sig, __pyx_v_i, Py_ssize_t, 1, PyInt_FromSsize_t, 0, 0, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 79, __pyx_L1_error)
+        __pyx_t_1 = __Pyx_GetItemInt(__pyx_v_src_sig, __pyx_v_i, Py_ssize_t, 1, PyInt_FromSsize_t, 0, 0, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 81, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_1);
-        __pyx_t_13 = PyObject_RichCompare(__pyx_t_1, __pyx_v_dst_type, Py_EQ); __Pyx_XGOTREF(__pyx_t_13); if (unlikely(!__pyx_t_13)) __PYX_ERR(0, 79, __pyx_L1_error)
+        __pyx_t_13 = PyObject_RichCompare(__pyx_t_1, __pyx_v_dst_type, Py_EQ); __Pyx_XGOTREF(__pyx_t_13); if (unlikely(!__pyx_t_13)) __PYX_ERR(0, 81, __pyx_L1_error)
         __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
-        __pyx_t_2 = __Pyx_PyObject_IsTrue(__pyx_t_13); if (unlikely(__pyx_t_2 < 0)) __PYX_ERR(0, 79, __pyx_L1_error)
+        __pyx_t_2 = __Pyx_PyObject_IsTrue(__pyx_t_13); if (unlikely(__pyx_t_2 < 0)) __PYX_ERR(0, 81, __pyx_L1_error)
         __Pyx_DECREF(__pyx_t_13); __pyx_t_13 = 0;
         if (__pyx_t_2) {
           __pyx_v_match_found = 1;
@@ -4373,35 +4393,35 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_2f_matrix_inplace_
     __pyx_L32_break:;
     __pyx_t_2 = (__pyx_v_match_found != 0);
     if (__pyx_t_2) {
-      __pyx_t_18 = __Pyx_PyList_Append(__pyx_v_candidates, __pyx_v_sig); if (unlikely(__pyx_t_18 == ((int)-1))) __PYX_ERR(0, 79, __pyx_L1_error)
+      __pyx_t_18 = __Pyx_PyList_Append(__pyx_v_candidates, __pyx_v_sig); if (unlikely(__pyx_t_18 == ((int)-1))) __PYX_ERR(0, 81, __pyx_L1_error)
     }
   }
   __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
   __pyx_t_2 = (PyList_GET_SIZE(__pyx_v_candidates) != 0);
   __pyx_t_3 = ((!__pyx_t_2) != 0);
   if (__pyx_t_3) {
-    __pyx_t_6 = __Pyx_PyObject_Call(__pyx_builtin_TypeError, __pyx_tuple__3, NULL); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 79, __pyx_L1_error)
+    __pyx_t_6 = __Pyx_PyObject_Call(__pyx_builtin_TypeError, __pyx_tuple__3, NULL); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 81, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_6);
     __Pyx_Raise(__pyx_t_6, 0, 0, 0);
     __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
-    __PYX_ERR(0, 79, __pyx_L1_error)
+    __PYX_ERR(0, 81, __pyx_L1_error)
   }
-  __pyx_t_9 = PyList_GET_SIZE(__pyx_v_candidates); if (unlikely(__pyx_t_9 == ((Py_ssize_t)-1))) __PYX_ERR(0, 79, __pyx_L1_error)
+  __pyx_t_9 = PyList_GET_SIZE(__pyx_v_candidates); if (unlikely(__pyx_t_9 == ((Py_ssize_t)-1))) __PYX_ERR(0, 81, __pyx_L1_error)
   __pyx_t_3 = ((__pyx_t_9 > 1) != 0);
   if (__pyx_t_3) {
-    __pyx_t_6 = __Pyx_PyObject_Call(__pyx_builtin_TypeError, __pyx_tuple__4, NULL); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 79, __pyx_L1_error)
+    __pyx_t_6 = __Pyx_PyObject_Call(__pyx_builtin_TypeError, __pyx_tuple__4, NULL); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 81, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_6);
     __Pyx_Raise(__pyx_t_6, 0, 0, 0);
     __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
-    __PYX_ERR(0, 79, __pyx_L1_error)
+    __PYX_ERR(0, 81, __pyx_L1_error)
   }
   /*else*/ {
     __Pyx_XDECREF(__pyx_r);
     if (unlikely(__pyx_v_signatures == Py_None)) {
       PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-      __PYX_ERR(0, 79, __pyx_L1_error)
+      __PYX_ERR(0, 81, __pyx_L1_error)
     }
-    __pyx_t_6 = __Pyx_PyDict_GetItem(((PyObject*)__pyx_v_signatures), PyList_GET_ITEM(__pyx_v_candidates, 0)); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 79, __pyx_L1_error)
+    __pyx_t_6 = __Pyx_PyDict_GetItem(((PyObject*)__pyx_v_signatures), PyList_GET_ITEM(__pyx_v_candidates, 0)); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 81, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_6);
     __pyx_r = __pyx_t_6;
     __pyx_t_6 = 0;
@@ -4471,17 +4491,17 @@ static PyObject *__pyx_fuse_0__pyx_pw_5skbio_5stats_10ordination_7_cutils_13f_ma
         case  1:
         if (likely((values[1] = __Pyx_PyDict_GetItemStr(__pyx_kwds, __pyx_n_s_global_mean)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("f_matrix_inplace_cy", 1, 3, 3, 1); __PYX_ERR(0, 79, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("f_matrix_inplace_cy", 1, 3, 3, 1); __PYX_ERR(0, 81, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  2:
         if (likely((values[2] = __Pyx_PyDict_GetItemStr(__pyx_kwds, __pyx_n_s_centered)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("f_matrix_inplace_cy", 1, 3, 3, 2); __PYX_ERR(0, 79, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("f_matrix_inplace_cy", 1, 3, 3, 2); __PYX_ERR(0, 81, __pyx_L3_error)
         }
       }
       if (unlikely(kw_args > 0)) {
-        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "f_matrix_inplace_cy") < 0)) __PYX_ERR(0, 79, __pyx_L3_error)
+        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "f_matrix_inplace_cy") < 0)) __PYX_ERR(0, 81, __pyx_L3_error)
       }
     } else if (PyTuple_GET_SIZE(__pyx_args) != 3) {
       goto __pyx_L5_argtuple_error;
@@ -4490,13 +4510,13 @@ static PyObject *__pyx_fuse_0__pyx_pw_5skbio_5stats_10ordination_7_cutils_13f_ma
       values[1] = PyTuple_GET_ITEM(__pyx_args, 1);
       values[2] = PyTuple_GET_ITEM(__pyx_args, 2);
     }
-    __pyx_v_row_means = __Pyx_PyObject_to_MemoryviewSlice_dc_float(values[0], PyBUF_WRITABLE); if (unlikely(!__pyx_v_row_means.memview)) __PYX_ERR(0, 79, __pyx_L3_error)
-    __pyx_v_global_mean = __pyx_PyFloat_AsFloat(values[1]); if (unlikely((__pyx_v_global_mean == (float)-1) && PyErr_Occurred())) __PYX_ERR(0, 79, __pyx_L3_error)
-    __pyx_v_centered = __Pyx_PyObject_to_MemoryviewSlice_d_dc_float(values[2], PyBUF_WRITABLE); if (unlikely(!__pyx_v_centered.memview)) __PYX_ERR(0, 79, __pyx_L3_error)
+    __pyx_v_row_means = __Pyx_PyObject_to_MemoryviewSlice_dc_float(values[0], PyBUF_WRITABLE); if (unlikely(!__pyx_v_row_means.memview)) __PYX_ERR(0, 81, __pyx_L3_error)
+    __pyx_v_global_mean = __pyx_PyFloat_AsFloat(values[1]); if (unlikely((__pyx_v_global_mean == (float)-1) && PyErr_Occurred())) __PYX_ERR(0, 81, __pyx_L3_error)
+    __pyx_v_centered = __Pyx_PyObject_to_MemoryviewSlice_d_dc_float(values[2], PyBUF_WRITABLE); if (unlikely(!__pyx_v_centered.memview)) __PYX_ERR(0, 81, __pyx_L3_error)
   }
   goto __pyx_L4_argument_unpacking_done;
   __pyx_L5_argtuple_error:;
-  __Pyx_RaiseArgtupleInvalid("f_matrix_inplace_cy", 1, 3, 3, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 79, __pyx_L3_error)
+  __Pyx_RaiseArgtupleInvalid("f_matrix_inplace_cy", 1, 3, 3, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 81, __pyx_L3_error)
   __pyx_L3_error:;
   __Pyx_AddTraceback("skbio.stats.ordination._cutils.f_matrix_inplace_cy", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __Pyx_RefNannyFinishContext();
@@ -4544,7 +4564,7 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_12f_matrix_inplace
   int __pyx_clineno = 0;
   __Pyx_RefNannySetupContext("__pyx_fuse_0f_matrix_inplace_cy", 0);
 
-  /* "skbio/stats/ordination/_cutils.pyx":98
+  /* "skbio/stats/ordination/_cutils.pyx":100
  *         Out, the centered matrix
  *     """
  *     cdef Py_ssize_t n_samples = centered.shape[0]             # <<<<<<<<<<<<<<
@@ -4553,7 +4573,7 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_12f_matrix_inplace
  */
   __pyx_v_n_samples = (__pyx_v_centered.shape[0]);
 
-  /* "skbio/stats/ordination/_cutils.pyx":99
+  /* "skbio/stats/ordination/_cutils.pyx":101
  *     """
  *     cdef Py_ssize_t n_samples = centered.shape[0]
  *     cdef Py_ssize_t d2 = centered.shape[1]             # <<<<<<<<<<<<<<
@@ -4562,7 +4582,7 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_12f_matrix_inplace
  */
   __pyx_v_d2 = (__pyx_v_centered.shape[1]);
 
-  /* "skbio/stats/ordination/_cutils.pyx":100
+  /* "skbio/stats/ordination/_cutils.pyx":102
  *     cdef Py_ssize_t n_samples = centered.shape[0]
  *     cdef Py_ssize_t d2 = centered.shape[1]
  *     cdef Py_ssize_t d3 = row_means.shape[0]             # <<<<<<<<<<<<<<
@@ -4571,7 +4591,7 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_12f_matrix_inplace
  */
   __pyx_v_d3 = (__pyx_v_row_means.shape[0]);
 
-  /* "skbio/stats/ordination/_cutils.pyx":102
+  /* "skbio/stats/ordination/_cutils.pyx":104
  *     cdef Py_ssize_t d3 = row_means.shape[0]
  * 
  *     assert n_samples == d2             # <<<<<<<<<<<<<<
@@ -4582,12 +4602,12 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_12f_matrix_inplace
   if (unlikely(!Py_OptimizeFlag)) {
     if (unlikely(!((__pyx_v_n_samples == __pyx_v_d2) != 0))) {
       PyErr_SetNone(PyExc_AssertionError);
-      __PYX_ERR(0, 102, __pyx_L1_error)
+      __PYX_ERR(0, 104, __pyx_L1_error)
     }
   }
   #endif
 
-  /* "skbio/stats/ordination/_cutils.pyx":103
+  /* "skbio/stats/ordination/_cutils.pyx":105
  * 
  *     assert n_samples == d2
  *     assert n_samples == d3             # <<<<<<<<<<<<<<
@@ -4598,16 +4618,16 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_12f_matrix_inplace
   if (unlikely(!Py_OptimizeFlag)) {
     if (unlikely(!((__pyx_v_n_samples == __pyx_v_d3) != 0))) {
       PyErr_SetNone(PyExc_AssertionError);
-      __PYX_ERR(0, 103, __pyx_L1_error)
+      __PYX_ERR(0, 105, __pyx_L1_error)
     }
   }
   #endif
 
-  /* "skbio/stats/ordination/_cutils.pyx":110
+  /* "skbio/stats/ordination/_cutils.pyx":112
  * 
  *     # use a tiled pattern to maximize locality of row_means
- *     for trow in prange(0, n_samples, 512, nogil=True):             # <<<<<<<<<<<<<<
- *         trow_max = min(trow+512, n_samples)
+ *     for trow in prange(0, n_samples, 24, nogil=True):             # <<<<<<<<<<<<<<
+ *         trow_max = min(trow+24, n_samples)
  * 
  */
   {
@@ -4618,7 +4638,7 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_12f_matrix_inplace
       #endif
       /*try:*/ {
         __pyx_t_1 = __pyx_v_n_samples;
-        if ((0x200 == 0)) abort();
+        if ((24 == 0)) abort();
         {
             #if ((defined(__APPLE__) || defined(__OSX__)) && (defined(__GNUC__) && (__GNUC__ > 2 || (__GNUC__ == 2 && (__GNUC_MINOR__ > 95)))))
                 #undef likely
@@ -4626,7 +4646,7 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_12f_matrix_inplace
                 #define likely(x)   (x)
                 #define unlikely(x) (x)
             #endif
-            __pyx_t_3 = (__pyx_t_1 - 0 + 0x200 - 0x200/abs(0x200)) / 0x200;
+            __pyx_t_3 = (__pyx_t_1 - 0 + 24 - 24/abs(24)) / 24;
             if (__pyx_t_3 > 0)
             {
                 #ifdef _OPENMP
@@ -4638,7 +4658,7 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_12f_matrix_inplace
                     #endif /* _OPENMP */
                     for (__pyx_t_2 = 0; __pyx_t_2 < __pyx_t_3; __pyx_t_2++){
                         {
-                            __pyx_v_trow = (Py_ssize_t)(0 + 0x200 * __pyx_t_2);
+                            __pyx_v_trow = (Py_ssize_t)(0 + 24 * __pyx_t_2);
                             /* Initialize private variables to invalid values */
                             __pyx_v_col = ((Py_ssize_t)0xbad0bad0);
                             __pyx_v_gr_mean = ((float)__PYX_NAN());
@@ -4647,15 +4667,15 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_12f_matrix_inplace
                             __pyx_v_tcol_max = ((Py_ssize_t)0xbad0bad0);
                             __pyx_v_trow_max = ((Py_ssize_t)0xbad0bad0);
 
-                            /* "skbio/stats/ordination/_cutils.pyx":111
+                            /* "skbio/stats/ordination/_cutils.pyx":113
  *     # use a tiled pattern to maximize locality of row_means
- *     for trow in prange(0, n_samples, 512, nogil=True):
- *         trow_max = min(trow+512, n_samples)             # <<<<<<<<<<<<<<
+ *     for trow in prange(0, n_samples, 24, nogil=True):
+ *         trow_max = min(trow+24, n_samples)             # <<<<<<<<<<<<<<
  * 
- *         for tcol in range(0, n_samples, 512):
+ *         for tcol in range(0, n_samples, 24):
  */
                             __pyx_t_4 = __pyx_v_n_samples;
-                            __pyx_t_5 = (__pyx_v_trow + 0x200);
+                            __pyx_t_5 = (__pyx_v_trow + 24);
                             if (((__pyx_t_4 < __pyx_t_5) != 0)) {
                               __pyx_t_6 = __pyx_t_4;
                             } else {
@@ -4663,27 +4683,27 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_12f_matrix_inplace
                             }
                             __pyx_v_trow_max = __pyx_t_6;
 
-                            /* "skbio/stats/ordination/_cutils.pyx":113
- *         trow_max = min(trow+512, n_samples)
+                            /* "skbio/stats/ordination/_cutils.pyx":115
+ *         trow_max = min(trow+24, n_samples)
  * 
- *         for tcol in range(0, n_samples, 512):             # <<<<<<<<<<<<<<
- *             tcol_max = min(tcol+512, n_samples)
+ *         for tcol in range(0, n_samples, 24):             # <<<<<<<<<<<<<<
+ *             tcol_max = min(tcol+24, n_samples)
  * 
  */
                             __pyx_t_6 = __pyx_v_n_samples;
                             __pyx_t_4 = __pyx_t_6;
-                            for (__pyx_t_5 = 0; __pyx_t_5 < __pyx_t_4; __pyx_t_5+=0x200) {
+                            for (__pyx_t_5 = 0; __pyx_t_5 < __pyx_t_4; __pyx_t_5+=24) {
                               __pyx_v_tcol = __pyx_t_5;
 
-                              /* "skbio/stats/ordination/_cutils.pyx":114
+                              /* "skbio/stats/ordination/_cutils.pyx":116
  * 
- *         for tcol in range(0, n_samples, 512):
- *             tcol_max = min(tcol+512, n_samples)             # <<<<<<<<<<<<<<
+ *         for tcol in range(0, n_samples, 24):
+ *             tcol_max = min(tcol+24, n_samples)             # <<<<<<<<<<<<<<
  * 
  *             for row in range(trow, trow_max, 1):
  */
                               __pyx_t_7 = __pyx_v_n_samples;
-                              __pyx_t_8 = (__pyx_v_tcol + 0x200);
+                              __pyx_t_8 = (__pyx_v_tcol + 24);
                               if (((__pyx_t_7 < __pyx_t_8) != 0)) {
                                 __pyx_t_9 = __pyx_t_7;
                               } else {
@@ -4691,8 +4711,8 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_12f_matrix_inplace
                               }
                               __pyx_v_tcol_max = __pyx_t_9;
 
-                              /* "skbio/stats/ordination/_cutils.pyx":116
- *             tcol_max = min(tcol+512, n_samples)
+                              /* "skbio/stats/ordination/_cutils.pyx":118
+ *             tcol_max = min(tcol+24, n_samples)
  * 
  *             for row in range(trow, trow_max, 1):             # <<<<<<<<<<<<<<
  *                 gr_mean = global_mean - row_means[row]
@@ -4703,7 +4723,7 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_12f_matrix_inplace
                               for (__pyx_t_8 = __pyx_v_trow; __pyx_t_8 < __pyx_t_7; __pyx_t_8+=1) {
                                 __pyx_v_row = __pyx_t_8;
 
-                                /* "skbio/stats/ordination/_cutils.pyx":117
+                                /* "skbio/stats/ordination/_cutils.pyx":119
  * 
  *             for row in range(trow, trow_max, 1):
  *                 gr_mean = global_mean - row_means[row]             # <<<<<<<<<<<<<<
@@ -4713,7 +4733,7 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_12f_matrix_inplace
                                 __pyx_t_10 = __pyx_v_row;
                                 __pyx_v_gr_mean = (__pyx_v_global_mean - (*((float *) ( /* dim=0 */ ((char *) (((float *) __pyx_v_row_means.data) + __pyx_t_10)) ))));
 
-                                /* "skbio/stats/ordination/_cutils.pyx":119
+                                /* "skbio/stats/ordination/_cutils.pyx":121
  *                 gr_mean = global_mean - row_means[row]
  * 
  *                 for col in range(tcol, tcol_max, 1):             # <<<<<<<<<<<<<<
@@ -4725,7 +4745,7 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_12f_matrix_inplace
                                 for (__pyx_t_13 = __pyx_v_tcol; __pyx_t_13 < __pyx_t_12; __pyx_t_13+=1) {
                                   __pyx_v_col = __pyx_t_13;
 
-                                  /* "skbio/stats/ordination/_cutils.pyx":121
+                                  /* "skbio/stats/ordination/_cutils.pyx":123
  *                 for col in range(tcol, tcol_max, 1):
  *                     # Note: do not use +=, so it is not flagged as a global reduction
  *                     centered[row,col] = centered[row,col] + (gr_mean - row_means[col])             # <<<<<<<<<<<<<<
@@ -4754,11 +4774,11 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_12f_matrix_inplace
         #endif
       }
 
-      /* "skbio/stats/ordination/_cutils.pyx":110
+      /* "skbio/stats/ordination/_cutils.pyx":112
  * 
  *     # use a tiled pattern to maximize locality of row_means
- *     for trow in prange(0, n_samples, 512, nogil=True):             # <<<<<<<<<<<<<<
- *         trow_max = min(trow+512, n_samples)
+ *     for trow in prange(0, n_samples, 24, nogil=True):             # <<<<<<<<<<<<<<
+ *         trow_max = min(trow+24, n_samples)
  * 
  */
       /*finally:*/ {
@@ -4773,7 +4793,7 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_12f_matrix_inplace
       }
   }
 
-  /* "skbio/stats/ordination/_cutils.pyx":79
+  /* "skbio/stats/ordination/_cutils.pyx":81
  * @cython.boundscheck(False)
  * @cython.wraparound(False)
  * def f_matrix_inplace_cy(TReal[::1] row_means, TReal global_mean, TReal[:, ::1] centered):             # <<<<<<<<<<<<<<
@@ -4833,17 +4853,17 @@ static PyObject *__pyx_fuse_1__pyx_pw_5skbio_5stats_10ordination_7_cutils_15f_ma
         case  1:
         if (likely((values[1] = __Pyx_PyDict_GetItemStr(__pyx_kwds, __pyx_n_s_global_mean)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("f_matrix_inplace_cy", 1, 3, 3, 1); __PYX_ERR(0, 79, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("f_matrix_inplace_cy", 1, 3, 3, 1); __PYX_ERR(0, 81, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  2:
         if (likely((values[2] = __Pyx_PyDict_GetItemStr(__pyx_kwds, __pyx_n_s_centered)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("f_matrix_inplace_cy", 1, 3, 3, 2); __PYX_ERR(0, 79, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("f_matrix_inplace_cy", 1, 3, 3, 2); __PYX_ERR(0, 81, __pyx_L3_error)
         }
       }
       if (unlikely(kw_args > 0)) {
-        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "f_matrix_inplace_cy") < 0)) __PYX_ERR(0, 79, __pyx_L3_error)
+        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "f_matrix_inplace_cy") < 0)) __PYX_ERR(0, 81, __pyx_L3_error)
       }
     } else if (PyTuple_GET_SIZE(__pyx_args) != 3) {
       goto __pyx_L5_argtuple_error;
@@ -4852,13 +4872,13 @@ static PyObject *__pyx_fuse_1__pyx_pw_5skbio_5stats_10ordination_7_cutils_15f_ma
       values[1] = PyTuple_GET_ITEM(__pyx_args, 1);
       values[2] = PyTuple_GET_ITEM(__pyx_args, 2);
     }
-    __pyx_v_row_means = __Pyx_PyObject_to_MemoryviewSlice_dc_double(values[0], PyBUF_WRITABLE); if (unlikely(!__pyx_v_row_means.memview)) __PYX_ERR(0, 79, __pyx_L3_error)
-    __pyx_v_global_mean = __pyx_PyFloat_AsDouble(values[1]); if (unlikely((__pyx_v_global_mean == (double)-1) && PyErr_Occurred())) __PYX_ERR(0, 79, __pyx_L3_error)
-    __pyx_v_centered = __Pyx_PyObject_to_MemoryviewSlice_d_dc_double(values[2], PyBUF_WRITABLE); if (unlikely(!__pyx_v_centered.memview)) __PYX_ERR(0, 79, __pyx_L3_error)
+    __pyx_v_row_means = __Pyx_PyObject_to_MemoryviewSlice_dc_double(values[0], PyBUF_WRITABLE); if (unlikely(!__pyx_v_row_means.memview)) __PYX_ERR(0, 81, __pyx_L3_error)
+    __pyx_v_global_mean = __pyx_PyFloat_AsDouble(values[1]); if (unlikely((__pyx_v_global_mean == (double)-1) && PyErr_Occurred())) __PYX_ERR(0, 81, __pyx_L3_error)
+    __pyx_v_centered = __Pyx_PyObject_to_MemoryviewSlice_d_dc_double(values[2], PyBUF_WRITABLE); if (unlikely(!__pyx_v_centered.memview)) __PYX_ERR(0, 81, __pyx_L3_error)
   }
   goto __pyx_L4_argument_unpacking_done;
   __pyx_L5_argtuple_error:;
-  __Pyx_RaiseArgtupleInvalid("f_matrix_inplace_cy", 1, 3, 3, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 79, __pyx_L3_error)
+  __Pyx_RaiseArgtupleInvalid("f_matrix_inplace_cy", 1, 3, 3, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 81, __pyx_L3_error)
   __pyx_L3_error:;
   __Pyx_AddTraceback("skbio.stats.ordination._cutils.f_matrix_inplace_cy", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __Pyx_RefNannyFinishContext();
@@ -4906,7 +4926,7 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_14f_matrix_inplace
   int __pyx_clineno = 0;
   __Pyx_RefNannySetupContext("__pyx_fuse_1f_matrix_inplace_cy", 0);
 
-  /* "skbio/stats/ordination/_cutils.pyx":98
+  /* "skbio/stats/ordination/_cutils.pyx":100
  *         Out, the centered matrix
  *     """
  *     cdef Py_ssize_t n_samples = centered.shape[0]             # <<<<<<<<<<<<<<
@@ -4915,7 +4935,7 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_14f_matrix_inplace
  */
   __pyx_v_n_samples = (__pyx_v_centered.shape[0]);
 
-  /* "skbio/stats/ordination/_cutils.pyx":99
+  /* "skbio/stats/ordination/_cutils.pyx":101
  *     """
  *     cdef Py_ssize_t n_samples = centered.shape[0]
  *     cdef Py_ssize_t d2 = centered.shape[1]             # <<<<<<<<<<<<<<
@@ -4924,7 +4944,7 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_14f_matrix_inplace
  */
   __pyx_v_d2 = (__pyx_v_centered.shape[1]);
 
-  /* "skbio/stats/ordination/_cutils.pyx":100
+  /* "skbio/stats/ordination/_cutils.pyx":102
  *     cdef Py_ssize_t n_samples = centered.shape[0]
  *     cdef Py_ssize_t d2 = centered.shape[1]
  *     cdef Py_ssize_t d3 = row_means.shape[0]             # <<<<<<<<<<<<<<
@@ -4933,7 +4953,7 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_14f_matrix_inplace
  */
   __pyx_v_d3 = (__pyx_v_row_means.shape[0]);
 
-  /* "skbio/stats/ordination/_cutils.pyx":102
+  /* "skbio/stats/ordination/_cutils.pyx":104
  *     cdef Py_ssize_t d3 = row_means.shape[0]
  * 
  *     assert n_samples == d2             # <<<<<<<<<<<<<<
@@ -4944,12 +4964,12 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_14f_matrix_inplace
   if (unlikely(!Py_OptimizeFlag)) {
     if (unlikely(!((__pyx_v_n_samples == __pyx_v_d2) != 0))) {
       PyErr_SetNone(PyExc_AssertionError);
-      __PYX_ERR(0, 102, __pyx_L1_error)
+      __PYX_ERR(0, 104, __pyx_L1_error)
     }
   }
   #endif
 
-  /* "skbio/stats/ordination/_cutils.pyx":103
+  /* "skbio/stats/ordination/_cutils.pyx":105
  * 
  *     assert n_samples == d2
  *     assert n_samples == d3             # <<<<<<<<<<<<<<
@@ -4960,16 +4980,16 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_14f_matrix_inplace
   if (unlikely(!Py_OptimizeFlag)) {
     if (unlikely(!((__pyx_v_n_samples == __pyx_v_d3) != 0))) {
       PyErr_SetNone(PyExc_AssertionError);
-      __PYX_ERR(0, 103, __pyx_L1_error)
+      __PYX_ERR(0, 105, __pyx_L1_error)
     }
   }
   #endif
 
-  /* "skbio/stats/ordination/_cutils.pyx":110
+  /* "skbio/stats/ordination/_cutils.pyx":112
  * 
  *     # use a tiled pattern to maximize locality of row_means
- *     for trow in prange(0, n_samples, 512, nogil=True):             # <<<<<<<<<<<<<<
- *         trow_max = min(trow+512, n_samples)
+ *     for trow in prange(0, n_samples, 24, nogil=True):             # <<<<<<<<<<<<<<
+ *         trow_max = min(trow+24, n_samples)
  * 
  */
   {
@@ -4980,7 +5000,7 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_14f_matrix_inplace
       #endif
       /*try:*/ {
         __pyx_t_1 = __pyx_v_n_samples;
-        if ((0x200 == 0)) abort();
+        if ((24 == 0)) abort();
         {
             #if ((defined(__APPLE__) || defined(__OSX__)) && (defined(__GNUC__) && (__GNUC__ > 2 || (__GNUC__ == 2 && (__GNUC_MINOR__ > 95)))))
                 #undef likely
@@ -4988,7 +5008,7 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_14f_matrix_inplace
                 #define likely(x)   (x)
                 #define unlikely(x) (x)
             #endif
-            __pyx_t_3 = (__pyx_t_1 - 0 + 0x200 - 0x200/abs(0x200)) / 0x200;
+            __pyx_t_3 = (__pyx_t_1 - 0 + 24 - 24/abs(24)) / 24;
             if (__pyx_t_3 > 0)
             {
                 #ifdef _OPENMP
@@ -5000,7 +5020,7 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_14f_matrix_inplace
                     #endif /* _OPENMP */
                     for (__pyx_t_2 = 0; __pyx_t_2 < __pyx_t_3; __pyx_t_2++){
                         {
-                            __pyx_v_trow = (Py_ssize_t)(0 + 0x200 * __pyx_t_2);
+                            __pyx_v_trow = (Py_ssize_t)(0 + 24 * __pyx_t_2);
                             /* Initialize private variables to invalid values */
                             __pyx_v_col = ((Py_ssize_t)0xbad0bad0);
                             __pyx_v_gr_mean = ((double)__PYX_NAN());
@@ -5009,15 +5029,15 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_14f_matrix_inplace
                             __pyx_v_tcol_max = ((Py_ssize_t)0xbad0bad0);
                             __pyx_v_trow_max = ((Py_ssize_t)0xbad0bad0);
 
-                            /* "skbio/stats/ordination/_cutils.pyx":111
+                            /* "skbio/stats/ordination/_cutils.pyx":113
  *     # use a tiled pattern to maximize locality of row_means
- *     for trow in prange(0, n_samples, 512, nogil=True):
- *         trow_max = min(trow+512, n_samples)             # <<<<<<<<<<<<<<
+ *     for trow in prange(0, n_samples, 24, nogil=True):
+ *         trow_max = min(trow+24, n_samples)             # <<<<<<<<<<<<<<
  * 
- *         for tcol in range(0, n_samples, 512):
+ *         for tcol in range(0, n_samples, 24):
  */
                             __pyx_t_4 = __pyx_v_n_samples;
-                            __pyx_t_5 = (__pyx_v_trow + 0x200);
+                            __pyx_t_5 = (__pyx_v_trow + 24);
                             if (((__pyx_t_4 < __pyx_t_5) != 0)) {
                               __pyx_t_6 = __pyx_t_4;
                             } else {
@@ -5025,27 +5045,27 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_14f_matrix_inplace
                             }
                             __pyx_v_trow_max = __pyx_t_6;
 
-                            /* "skbio/stats/ordination/_cutils.pyx":113
- *         trow_max = min(trow+512, n_samples)
+                            /* "skbio/stats/ordination/_cutils.pyx":115
+ *         trow_max = min(trow+24, n_samples)
  * 
- *         for tcol in range(0, n_samples, 512):             # <<<<<<<<<<<<<<
- *             tcol_max = min(tcol+512, n_samples)
+ *         for tcol in range(0, n_samples, 24):             # <<<<<<<<<<<<<<
+ *             tcol_max = min(tcol+24, n_samples)
  * 
  */
                             __pyx_t_6 = __pyx_v_n_samples;
                             __pyx_t_4 = __pyx_t_6;
-                            for (__pyx_t_5 = 0; __pyx_t_5 < __pyx_t_4; __pyx_t_5+=0x200) {
+                            for (__pyx_t_5 = 0; __pyx_t_5 < __pyx_t_4; __pyx_t_5+=24) {
                               __pyx_v_tcol = __pyx_t_5;
 
-                              /* "skbio/stats/ordination/_cutils.pyx":114
+                              /* "skbio/stats/ordination/_cutils.pyx":116
  * 
- *         for tcol in range(0, n_samples, 512):
- *             tcol_max = min(tcol+512, n_samples)             # <<<<<<<<<<<<<<
+ *         for tcol in range(0, n_samples, 24):
+ *             tcol_max = min(tcol+24, n_samples)             # <<<<<<<<<<<<<<
  * 
  *             for row in range(trow, trow_max, 1):
  */
                               __pyx_t_7 = __pyx_v_n_samples;
-                              __pyx_t_8 = (__pyx_v_tcol + 0x200);
+                              __pyx_t_8 = (__pyx_v_tcol + 24);
                               if (((__pyx_t_7 < __pyx_t_8) != 0)) {
                                 __pyx_t_9 = __pyx_t_7;
                               } else {
@@ -5053,8 +5073,8 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_14f_matrix_inplace
                               }
                               __pyx_v_tcol_max = __pyx_t_9;
 
-                              /* "skbio/stats/ordination/_cutils.pyx":116
- *             tcol_max = min(tcol+512, n_samples)
+                              /* "skbio/stats/ordination/_cutils.pyx":118
+ *             tcol_max = min(tcol+24, n_samples)
  * 
  *             for row in range(trow, trow_max, 1):             # <<<<<<<<<<<<<<
  *                 gr_mean = global_mean - row_means[row]
@@ -5065,7 +5085,7 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_14f_matrix_inplace
                               for (__pyx_t_8 = __pyx_v_trow; __pyx_t_8 < __pyx_t_7; __pyx_t_8+=1) {
                                 __pyx_v_row = __pyx_t_8;
 
-                                /* "skbio/stats/ordination/_cutils.pyx":117
+                                /* "skbio/stats/ordination/_cutils.pyx":119
  * 
  *             for row in range(trow, trow_max, 1):
  *                 gr_mean = global_mean - row_means[row]             # <<<<<<<<<<<<<<
@@ -5075,7 +5095,7 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_14f_matrix_inplace
                                 __pyx_t_10 = __pyx_v_row;
                                 __pyx_v_gr_mean = (__pyx_v_global_mean - (*((double *) ( /* dim=0 */ ((char *) (((double *) __pyx_v_row_means.data) + __pyx_t_10)) ))));
 
-                                /* "skbio/stats/ordination/_cutils.pyx":119
+                                /* "skbio/stats/ordination/_cutils.pyx":121
  *                 gr_mean = global_mean - row_means[row]
  * 
  *                 for col in range(tcol, tcol_max, 1):             # <<<<<<<<<<<<<<
@@ -5087,7 +5107,7 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_14f_matrix_inplace
                                 for (__pyx_t_13 = __pyx_v_tcol; __pyx_t_13 < __pyx_t_12; __pyx_t_13+=1) {
                                   __pyx_v_col = __pyx_t_13;
 
-                                  /* "skbio/stats/ordination/_cutils.pyx":121
+                                  /* "skbio/stats/ordination/_cutils.pyx":123
  *                 for col in range(tcol, tcol_max, 1):
  *                     # Note: do not use +=, so it is not flagged as a global reduction
  *                     centered[row,col] = centered[row,col] + (gr_mean - row_means[col])             # <<<<<<<<<<<<<<
@@ -5116,11 +5136,11 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_14f_matrix_inplace
         #endif
       }
 
-      /* "skbio/stats/ordination/_cutils.pyx":110
+      /* "skbio/stats/ordination/_cutils.pyx":112
  * 
  *     # use a tiled pattern to maximize locality of row_means
- *     for trow in prange(0, n_samples, 512, nogil=True):             # <<<<<<<<<<<<<<
- *         trow_max = min(trow+512, n_samples)
+ *     for trow in prange(0, n_samples, 24, nogil=True):             # <<<<<<<<<<<<<<
+ *         trow_max = min(trow+24, n_samples)
  * 
  */
       /*finally:*/ {
@@ -5135,7 +5155,7 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_14f_matrix_inplace
       }
   }
 
-  /* "skbio/stats/ordination/_cutils.pyx":79
+  /* "skbio/stats/ordination/_cutils.pyx":81
  * @cython.boundscheck(False)
  * @cython.wraparound(False)
  * def f_matrix_inplace_cy(TReal[::1] row_means, TReal global_mean, TReal[:, ::1] centered):             # <<<<<<<<<<<<<<
@@ -5157,7 +5177,7 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_14f_matrix_inplace
   return __pyx_r;
 }
 
-/* "skbio/stats/ordination/_cutils.pyx":125
+/* "skbio/stats/ordination/_cutils.pyx":127
  * @cython.boundscheck(False)
  * @cython.wraparound(False)
  * def center_distance_matrix_cy(TReal[:, ::1] mat, TReal[:, ::1] centered):             # <<<<<<<<<<<<<<
@@ -5207,23 +5227,23 @@ static PyObject *__pyx_pw_5skbio_5stats_10ordination_7_cutils_5center_distance_m
         case  1:
         if (likely((values[1] = __Pyx_PyDict_GetItemStr(__pyx_kwds, __pyx_n_s_args)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("__pyx_fused_cpdef", 1, 4, 4, 1); __PYX_ERR(0, 125, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("__pyx_fused_cpdef", 1, 4, 4, 1); __PYX_ERR(0, 127, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  2:
         if (likely((values[2] = __Pyx_PyDict_GetItemStr(__pyx_kwds, __pyx_n_s_kwargs)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("__pyx_fused_cpdef", 1, 4, 4, 2); __PYX_ERR(0, 125, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("__pyx_fused_cpdef", 1, 4, 4, 2); __PYX_ERR(0, 127, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  3:
         if (likely((values[3] = __Pyx_PyDict_GetItemStr(__pyx_kwds, __pyx_n_s_defaults)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("__pyx_fused_cpdef", 1, 4, 4, 3); __PYX_ERR(0, 125, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("__pyx_fused_cpdef", 1, 4, 4, 3); __PYX_ERR(0, 127, __pyx_L3_error)
         }
       }
       if (unlikely(kw_args > 0)) {
-        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "__pyx_fused_cpdef") < 0)) __PYX_ERR(0, 125, __pyx_L3_error)
+        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "__pyx_fused_cpdef") < 0)) __PYX_ERR(0, 127, __pyx_L3_error)
       }
     } else if (PyTuple_GET_SIZE(__pyx_args) != 4) {
       goto __pyx_L5_argtuple_error;
@@ -5240,7 +5260,7 @@ static PyObject *__pyx_pw_5skbio_5stats_10ordination_7_cutils_5center_distance_m
   }
   goto __pyx_L4_argument_unpacking_done;
   __pyx_L5_argtuple_error:;
-  __Pyx_RaiseArgtupleInvalid("__pyx_fused_cpdef", 1, 4, 4, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 125, __pyx_L3_error)
+  __Pyx_RaiseArgtupleInvalid("__pyx_fused_cpdef", 1, 4, 4, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 127, __pyx_L3_error)
   __pyx_L3_error:;
   __Pyx_AddTraceback("skbio.stats.ordination._cutils.__pyx_fused_cpdef", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __Pyx_RefNannyFinishContext();
@@ -5294,7 +5314,7 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_4center_distance_m
   int __pyx_clineno = 0;
   __Pyx_RefNannySetupContext("center_distance_matrix_cy", 0);
   __Pyx_INCREF(__pyx_v_kwargs);
-  __pyx_t_1 = PyList_New(1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 125, __pyx_L1_error)
+  __pyx_t_1 = PyList_New(1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 127, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __Pyx_INCREF(Py_None);
   __Pyx_GIVEREF(Py_None);
@@ -5308,7 +5328,7 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_4center_distance_m
     __pyx_t_2 = __pyx_t_4;
     goto __pyx_L4_bool_binop_done;
   }
-  __pyx_t_4 = __Pyx_PyObject_IsTrue(__pyx_v_kwargs); if (unlikely(__pyx_t_4 < 0)) __PYX_ERR(0, 125, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_PyObject_IsTrue(__pyx_v_kwargs); if (unlikely(__pyx_t_4 < 0)) __PYX_ERR(0, 127, __pyx_L1_error)
   __pyx_t_3 = ((!__pyx_t_4) != 0);
   __pyx_t_2 = __pyx_t_3;
   __pyx_L4_bool_binop_done:;
@@ -5316,21 +5336,21 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_4center_distance_m
     __Pyx_INCREF(Py_None);
     __Pyx_DECREF_SET(__pyx_v_kwargs, Py_None);
   }
-  __pyx_t_1 = ((PyObject *)__Pyx_ImportNumPyArrayTypeIfAvailable()); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 125, __pyx_L1_error)
+  __pyx_t_1 = ((PyObject *)__Pyx_ImportNumPyArrayTypeIfAvailable()); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 127, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __pyx_v_ndarray = ((PyTypeObject*)__pyx_t_1);
   __pyx_t_1 = 0;
   __pyx_v_itemsize = -1L;
   if (unlikely(__pyx_v_args == Py_None)) {
     PyErr_SetString(PyExc_TypeError, "object of type 'NoneType' has no len()");
-    __PYX_ERR(0, 125, __pyx_L1_error)
+    __PYX_ERR(0, 127, __pyx_L1_error)
   }
-  __pyx_t_5 = PyTuple_GET_SIZE(((PyObject*)__pyx_v_args)); if (unlikely(__pyx_t_5 == ((Py_ssize_t)-1))) __PYX_ERR(0, 125, __pyx_L1_error)
+  __pyx_t_5 = PyTuple_GET_SIZE(((PyObject*)__pyx_v_args)); if (unlikely(__pyx_t_5 == ((Py_ssize_t)-1))) __PYX_ERR(0, 127, __pyx_L1_error)
   __pyx_t_2 = ((0 < __pyx_t_5) != 0);
   if (__pyx_t_2) {
     if (unlikely(__pyx_v_args == Py_None)) {
       PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-      __PYX_ERR(0, 125, __pyx_L1_error)
+      __PYX_ERR(0, 127, __pyx_L1_error)
     }
     __pyx_t_1 = PyTuple_GET_ITEM(((PyObject*)__pyx_v_args), 0);
     __Pyx_INCREF(__pyx_t_1);
@@ -5347,18 +5367,18 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_4center_distance_m
   }
   if (unlikely(__pyx_v_kwargs == Py_None)) {
     PyErr_SetString(PyExc_TypeError, "'NoneType' object is not iterable");
-    __PYX_ERR(0, 125, __pyx_L1_error)
+    __PYX_ERR(0, 127, __pyx_L1_error)
   }
-  __pyx_t_4 = (__Pyx_PyDict_ContainsTF(__pyx_n_s_mat, ((PyObject*)__pyx_v_kwargs), Py_EQ)); if (unlikely(__pyx_t_4 < 0)) __PYX_ERR(0, 125, __pyx_L1_error)
+  __pyx_t_4 = (__Pyx_PyDict_ContainsTF(__pyx_n_s_mat, ((PyObject*)__pyx_v_kwargs), Py_EQ)); if (unlikely(__pyx_t_4 < 0)) __PYX_ERR(0, 127, __pyx_L1_error)
   __pyx_t_3 = (__pyx_t_4 != 0);
   __pyx_t_2 = __pyx_t_3;
   __pyx_L7_bool_binop_done:;
   if (__pyx_t_2) {
     if (unlikely(__pyx_v_kwargs == Py_None)) {
       PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-      __PYX_ERR(0, 125, __pyx_L1_error)
+      __PYX_ERR(0, 127, __pyx_L1_error)
     }
-    __pyx_t_1 = __Pyx_PyDict_GetItem(((PyObject*)__pyx_v_kwargs), __pyx_n_s_mat); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 125, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_PyDict_GetItem(((PyObject*)__pyx_v_kwargs), __pyx_n_s_mat); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 127, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
     __pyx_v_arg = __pyx_t_1;
     __pyx_t_1 = 0;
@@ -5367,12 +5387,12 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_4center_distance_m
   /*else*/ {
     if (unlikely(__pyx_v_args == Py_None)) {
       PyErr_SetString(PyExc_TypeError, "object of type 'NoneType' has no len()");
-      __PYX_ERR(0, 125, __pyx_L1_error)
+      __PYX_ERR(0, 127, __pyx_L1_error)
     }
-    __pyx_t_5 = PyTuple_GET_SIZE(((PyObject*)__pyx_v_args)); if (unlikely(__pyx_t_5 == ((Py_ssize_t)-1))) __PYX_ERR(0, 125, __pyx_L1_error)
-    __pyx_t_1 = PyInt_FromSsize_t(__pyx_t_5); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 125, __pyx_L1_error)
+    __pyx_t_5 = PyTuple_GET_SIZE(((PyObject*)__pyx_v_args)); if (unlikely(__pyx_t_5 == ((Py_ssize_t)-1))) __PYX_ERR(0, 127, __pyx_L1_error)
+    __pyx_t_1 = PyInt_FromSsize_t(__pyx_t_5); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 127, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
-    __pyx_t_6 = PyTuple_New(3); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 125, __pyx_L1_error)
+    __pyx_t_6 = PyTuple_New(3); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 127, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_6);
     __Pyx_INCREF(__pyx_int_2);
     __Pyx_GIVEREF(__pyx_int_2);
@@ -5383,15 +5403,15 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_4center_distance_m
     __Pyx_GIVEREF(__pyx_t_1);
     PyTuple_SET_ITEM(__pyx_t_6, 2, __pyx_t_1);
     __pyx_t_1 = 0;
-    __pyx_t_1 = __Pyx_PyString_Format(__pyx_kp_s_Expected_at_least_d_argument_s_g, __pyx_t_6); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 125, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_PyString_Format(__pyx_kp_s_Expected_at_least_d_argument_s_g, __pyx_t_6); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 127, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
-    __pyx_t_6 = __Pyx_PyObject_CallOneArg(__pyx_builtin_TypeError, __pyx_t_1); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 125, __pyx_L1_error)
+    __pyx_t_6 = __Pyx_PyObject_CallOneArg(__pyx_builtin_TypeError, __pyx_t_1); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 127, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_6);
     __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
     __Pyx_Raise(__pyx_t_6, 0, 0, 0);
     __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
-    __PYX_ERR(0, 125, __pyx_L1_error)
+    __PYX_ERR(0, 127, __pyx_L1_error)
   }
   __pyx_L6:;
   while (1) {
@@ -5401,7 +5421,7 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_4center_distance_m
       __pyx_t_3 = __Pyx_TypeCheck(__pyx_v_arg, __pyx_v_ndarray); 
       __pyx_t_2 = (__pyx_t_3 != 0);
       if (__pyx_t_2) {
-        __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_dtype); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 125, __pyx_L1_error)
+        __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_dtype); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 127, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_6);
         __pyx_v_dtype = __pyx_t_6;
         __pyx_t_6 = 0;
@@ -5410,14 +5430,14 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_4center_distance_m
       __pyx_t_2 = __pyx_memoryview_check(__pyx_v_arg); 
       __pyx_t_3 = (__pyx_t_2 != 0);
       if (__pyx_t_3) {
-        __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_base); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 125, __pyx_L1_error)
+        __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_base); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 127, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_6);
         __pyx_v_arg_base = __pyx_t_6;
         __pyx_t_6 = 0;
         __pyx_t_3 = __Pyx_TypeCheck(__pyx_v_arg_base, __pyx_v_ndarray); 
         __pyx_t_2 = (__pyx_t_3 != 0);
         if (__pyx_t_2) {
-          __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg_base, __pyx_n_s_dtype); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 125, __pyx_L1_error)
+          __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg_base, __pyx_n_s_dtype); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 127, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_6);
           __pyx_v_dtype = __pyx_t_6;
           __pyx_t_6 = 0;
@@ -5439,14 +5459,14 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_4center_distance_m
       __pyx_t_2 = (__pyx_v_dtype != Py_None);
       __pyx_t_3 = (__pyx_t_2 != 0);
       if (__pyx_t_3) {
-        __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_v_dtype, __pyx_n_s_itemsize); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 125, __pyx_L1_error)
+        __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_v_dtype, __pyx_n_s_itemsize); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 127, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_6);
-        __pyx_t_5 = __Pyx_PyIndex_AsSsize_t(__pyx_t_6); if (unlikely((__pyx_t_5 == (Py_ssize_t)-1) && PyErr_Occurred())) __PYX_ERR(0, 125, __pyx_L1_error)
+        __pyx_t_5 = __Pyx_PyIndex_AsSsize_t(__pyx_t_6); if (unlikely((__pyx_t_5 == (Py_ssize_t)-1) && PyErr_Occurred())) __PYX_ERR(0, 127, __pyx_L1_error)
         __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
         __pyx_v_itemsize = __pyx_t_5;
-        __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_v_dtype, __pyx_n_s_kind); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 125, __pyx_L1_error)
+        __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_v_dtype, __pyx_n_s_kind); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 127, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_6);
-        __pyx_t_7 = __Pyx_PyObject_Ord(__pyx_t_6); if (unlikely(__pyx_t_7 == ((long)(long)(Py_UCS4)-1))) __PYX_ERR(0, 125, __pyx_L1_error)
+        __pyx_t_7 = __Pyx_PyObject_Ord(__pyx_t_6); if (unlikely(__pyx_t_7 == ((long)(long)(Py_UCS4)-1))) __PYX_ERR(0, 127, __pyx_L1_error)
         __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
         __pyx_v_kind = __pyx_t_7;
         __pyx_v_dtype_signed = (__pyx_v_kind == 'i');
@@ -5461,15 +5481,15 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_4center_distance_m
             __pyx_t_3 = __pyx_t_2;
             goto __pyx_L16_bool_binop_done;
           }
-          __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_ndim); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 125, __pyx_L1_error)
+          __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_ndim); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 127, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_6);
-          __pyx_t_5 = __Pyx_PyIndex_AsSsize_t(__pyx_t_6); if (unlikely((__pyx_t_5 == (Py_ssize_t)-1) && PyErr_Occurred())) __PYX_ERR(0, 125, __pyx_L1_error)
+          __pyx_t_5 = __Pyx_PyIndex_AsSsize_t(__pyx_t_6); if (unlikely((__pyx_t_5 == (Py_ssize_t)-1) && PyErr_Occurred())) __PYX_ERR(0, 127, __pyx_L1_error)
           __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
           __pyx_t_2 = ((((Py_ssize_t)__pyx_t_5) == 2) != 0);
           __pyx_t_3 = __pyx_t_2;
           __pyx_L16_bool_binop_done:;
           if (__pyx_t_3) {
-            if (unlikely(__Pyx_SetItemInt(__pyx_v_dest_sig, 0, __pyx_n_s_float, long, 1, __Pyx_PyInt_From_long, 1, 0, 0) < 0)) __PYX_ERR(0, 125, __pyx_L1_error)
+            if (unlikely(__Pyx_SetItemInt(__pyx_v_dest_sig, 0, __pyx_n_s_float, long, 1, __Pyx_PyInt_From_long, 1, 0, 0) < 0)) __PYX_ERR(0, 127, __pyx_L1_error)
             goto __pyx_L10_break;
           }
           __pyx_t_2 = (((sizeof(double)) == __pyx_v_itemsize) != 0);
@@ -5478,15 +5498,15 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_4center_distance_m
             __pyx_t_3 = __pyx_t_2;
             goto __pyx_L19_bool_binop_done;
           }
-          __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_ndim); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 125, __pyx_L1_error)
+          __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_ndim); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 127, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_6);
-          __pyx_t_5 = __Pyx_PyIndex_AsSsize_t(__pyx_t_6); if (unlikely((__pyx_t_5 == (Py_ssize_t)-1) && PyErr_Occurred())) __PYX_ERR(0, 125, __pyx_L1_error)
+          __pyx_t_5 = __Pyx_PyIndex_AsSsize_t(__pyx_t_6); if (unlikely((__pyx_t_5 == (Py_ssize_t)-1) && PyErr_Occurred())) __PYX_ERR(0, 127, __pyx_L1_error)
           __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
           __pyx_t_2 = ((((Py_ssize_t)__pyx_t_5) == 2) != 0);
           __pyx_t_3 = __pyx_t_2;
           __pyx_L19_bool_binop_done:;
           if (__pyx_t_3) {
-            if (unlikely(__Pyx_SetItemInt(__pyx_v_dest_sig, 0, __pyx_n_s_double, long, 1, __Pyx_PyInt_From_long, 1, 0, 0) < 0)) __PYX_ERR(0, 125, __pyx_L1_error)
+            if (unlikely(__Pyx_SetItemInt(__pyx_v_dest_sig, 0, __pyx_n_s_double, long, 1, __Pyx_PyInt_From_long, 1, 0, 0) < 0)) __PYX_ERR(0, 127, __pyx_L1_error)
             goto __pyx_L10_break;
           }
           break;
@@ -5513,7 +5533,7 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_4center_distance_m
       __pyx_t_3 = (__pyx_v_memslice.memview != 0);
       if (__pyx_t_3) {
         __PYX_XDEC_MEMVIEW((&__pyx_v_memslice), 1); 
-        if (unlikely(__Pyx_SetItemInt(__pyx_v_dest_sig, 0, __pyx_n_s_float, long, 1, __Pyx_PyInt_From_long, 1, 0, 0) < 0)) __PYX_ERR(0, 125, __pyx_L1_error)
+        if (unlikely(__Pyx_SetItemInt(__pyx_v_dest_sig, 0, __pyx_n_s_float, long, 1, __Pyx_PyInt_From_long, 1, 0, 0) < 0)) __PYX_ERR(0, 127, __pyx_L1_error)
         goto __pyx_L10_break;
       }
       /*else*/ {
@@ -5535,27 +5555,27 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_4center_distance_m
       __pyx_t_3 = (__pyx_v_memslice.memview != 0);
       if (__pyx_t_3) {
         __PYX_XDEC_MEMVIEW((&__pyx_v_memslice), 1); 
-        if (unlikely(__Pyx_SetItemInt(__pyx_v_dest_sig, 0, __pyx_n_s_double, long, 1, __Pyx_PyInt_From_long, 1, 0, 0) < 0)) __PYX_ERR(0, 125, __pyx_L1_error)
+        if (unlikely(__Pyx_SetItemInt(__pyx_v_dest_sig, 0, __pyx_n_s_double, long, 1, __Pyx_PyInt_From_long, 1, 0, 0) < 0)) __PYX_ERR(0, 127, __pyx_L1_error)
         goto __pyx_L10_break;
       }
       /*else*/ {
         PyErr_Clear(); 
       }
     }
-    if (unlikely(__Pyx_SetItemInt(__pyx_v_dest_sig, 0, Py_None, long, 1, __Pyx_PyInt_From_long, 1, 0, 0) < 0)) __PYX_ERR(0, 125, __pyx_L1_error)
+    if (unlikely(__Pyx_SetItemInt(__pyx_v_dest_sig, 0, Py_None, long, 1, __Pyx_PyInt_From_long, 1, 0, 0) < 0)) __PYX_ERR(0, 127, __pyx_L1_error)
     goto __pyx_L10_break;
   }
   __pyx_L10_break:;
-  __pyx_t_6 = PyList_New(0); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 125, __pyx_L1_error)
+  __pyx_t_6 = PyList_New(0); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 127, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_6);
   __pyx_v_candidates = ((PyObject*)__pyx_t_6);
   __pyx_t_6 = 0;
   __pyx_t_5 = 0;
   if (unlikely(__pyx_v_signatures == Py_None)) {
     PyErr_SetString(PyExc_TypeError, "'NoneType' object is not iterable");
-    __PYX_ERR(0, 125, __pyx_L1_error)
+    __PYX_ERR(0, 127, __pyx_L1_error)
   }
-  __pyx_t_1 = __Pyx_dict_iterator(((PyObject*)__pyx_v_signatures), 1, ((PyObject *)NULL), (&__pyx_t_9), (&__pyx_t_10)); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 125, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_dict_iterator(((PyObject*)__pyx_v_signatures), 1, ((PyObject *)NULL), (&__pyx_t_9), (&__pyx_t_10)); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 127, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __Pyx_XDECREF(__pyx_t_6);
   __pyx_t_6 = __pyx_t_1;
@@ -5563,12 +5583,12 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_4center_distance_m
   while (1) {
     __pyx_t_11 = __Pyx_dict_iter_next(__pyx_t_6, __pyx_t_9, &__pyx_t_5, &__pyx_t_1, NULL, NULL, __pyx_t_10);
     if (unlikely(__pyx_t_11 == 0)) break;
-    if (unlikely(__pyx_t_11 == -1)) __PYX_ERR(0, 125, __pyx_L1_error)
+    if (unlikely(__pyx_t_11 == -1)) __PYX_ERR(0, 127, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_XDECREF_SET(__pyx_v_sig, __pyx_t_1);
     __pyx_t_1 = 0;
     __pyx_v_match_found = 0;
-    __pyx_t_13 = __Pyx_PyObject_GetAttrStr(__pyx_v_sig, __pyx_n_s_strip); if (unlikely(!__pyx_t_13)) __PYX_ERR(0, 125, __pyx_L1_error)
+    __pyx_t_13 = __Pyx_PyObject_GetAttrStr(__pyx_v_sig, __pyx_n_s_strip); if (unlikely(!__pyx_t_13)) __PYX_ERR(0, 127, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_13);
     __pyx_t_14 = NULL;
     if (CYTHON_UNPACK_METHODS && likely(PyMethod_Check(__pyx_t_13))) {
@@ -5582,10 +5602,10 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_4center_distance_m
     }
     __pyx_t_12 = (__pyx_t_14) ? __Pyx_PyObject_Call2Args(__pyx_t_13, __pyx_t_14, __pyx_kp_s_) : __Pyx_PyObject_CallOneArg(__pyx_t_13, __pyx_kp_s_);
     __Pyx_XDECREF(__pyx_t_14); __pyx_t_14 = 0;
-    if (unlikely(!__pyx_t_12)) __PYX_ERR(0, 125, __pyx_L1_error)
+    if (unlikely(!__pyx_t_12)) __PYX_ERR(0, 127, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_12);
     __Pyx_DECREF(__pyx_t_13); __pyx_t_13 = 0;
-    __pyx_t_13 = __Pyx_PyObject_GetAttrStr(__pyx_t_12, __pyx_n_s_split); if (unlikely(!__pyx_t_13)) __PYX_ERR(0, 125, __pyx_L1_error)
+    __pyx_t_13 = __Pyx_PyObject_GetAttrStr(__pyx_t_12, __pyx_n_s_split); if (unlikely(!__pyx_t_13)) __PYX_ERR(0, 127, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_13);
     __Pyx_DECREF(__pyx_t_12); __pyx_t_12 = 0;
     __pyx_t_12 = NULL;
@@ -5600,12 +5620,12 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_4center_distance_m
     }
     __pyx_t_1 = (__pyx_t_12) ? __Pyx_PyObject_Call2Args(__pyx_t_13, __pyx_t_12, __pyx_kp_s__2) : __Pyx_PyObject_CallOneArg(__pyx_t_13, __pyx_kp_s__2);
     __Pyx_XDECREF(__pyx_t_12); __pyx_t_12 = 0;
-    if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 125, __pyx_L1_error)
+    if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 127, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF(__pyx_t_13); __pyx_t_13 = 0;
     __Pyx_XDECREF_SET(__pyx_v_src_sig, __pyx_t_1);
     __pyx_t_1 = 0;
-    __pyx_t_15 = PyList_GET_SIZE(__pyx_v_dest_sig); if (unlikely(__pyx_t_15 == ((Py_ssize_t)-1))) __PYX_ERR(0, 125, __pyx_L1_error)
+    __pyx_t_15 = PyList_GET_SIZE(__pyx_v_dest_sig); if (unlikely(__pyx_t_15 == ((Py_ssize_t)-1))) __PYX_ERR(0, 127, __pyx_L1_error)
     __pyx_t_16 = __pyx_t_15;
     for (__pyx_t_17 = 0; __pyx_t_17 < __pyx_t_16; __pyx_t_17+=1) {
       __pyx_v_i = __pyx_t_17;
@@ -5616,11 +5636,11 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_4center_distance_m
       __pyx_t_3 = (__pyx_v_dst_type != Py_None);
       __pyx_t_2 = (__pyx_t_3 != 0);
       if (__pyx_t_2) {
-        __pyx_t_1 = __Pyx_GetItemInt(__pyx_v_src_sig, __pyx_v_i, Py_ssize_t, 1, PyInt_FromSsize_t, 0, 0, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 125, __pyx_L1_error)
+        __pyx_t_1 = __Pyx_GetItemInt(__pyx_v_src_sig, __pyx_v_i, Py_ssize_t, 1, PyInt_FromSsize_t, 0, 0, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 127, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_1);
-        __pyx_t_13 = PyObject_RichCompare(__pyx_t_1, __pyx_v_dst_type, Py_EQ); __Pyx_XGOTREF(__pyx_t_13); if (unlikely(!__pyx_t_13)) __PYX_ERR(0, 125, __pyx_L1_error)
+        __pyx_t_13 = PyObject_RichCompare(__pyx_t_1, __pyx_v_dst_type, Py_EQ); __Pyx_XGOTREF(__pyx_t_13); if (unlikely(!__pyx_t_13)) __PYX_ERR(0, 127, __pyx_L1_error)
         __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
-        __pyx_t_2 = __Pyx_PyObject_IsTrue(__pyx_t_13); if (unlikely(__pyx_t_2 < 0)) __PYX_ERR(0, 125, __pyx_L1_error)
+        __pyx_t_2 = __Pyx_PyObject_IsTrue(__pyx_t_13); if (unlikely(__pyx_t_2 < 0)) __PYX_ERR(0, 127, __pyx_L1_error)
         __Pyx_DECREF(__pyx_t_13); __pyx_t_13 = 0;
         if (__pyx_t_2) {
           __pyx_v_match_found = 1;
@@ -5636,35 +5656,35 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_4center_distance_m
     __pyx_L32_break:;
     __pyx_t_2 = (__pyx_v_match_found != 0);
     if (__pyx_t_2) {
-      __pyx_t_18 = __Pyx_PyList_Append(__pyx_v_candidates, __pyx_v_sig); if (unlikely(__pyx_t_18 == ((int)-1))) __PYX_ERR(0, 125, __pyx_L1_error)
+      __pyx_t_18 = __Pyx_PyList_Append(__pyx_v_candidates, __pyx_v_sig); if (unlikely(__pyx_t_18 == ((int)-1))) __PYX_ERR(0, 127, __pyx_L1_error)
     }
   }
   __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
   __pyx_t_2 = (PyList_GET_SIZE(__pyx_v_candidates) != 0);
   __pyx_t_3 = ((!__pyx_t_2) != 0);
   if (__pyx_t_3) {
-    __pyx_t_6 = __Pyx_PyObject_Call(__pyx_builtin_TypeError, __pyx_tuple__3, NULL); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 125, __pyx_L1_error)
+    __pyx_t_6 = __Pyx_PyObject_Call(__pyx_builtin_TypeError, __pyx_tuple__3, NULL); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 127, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_6);
     __Pyx_Raise(__pyx_t_6, 0, 0, 0);
     __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
-    __PYX_ERR(0, 125, __pyx_L1_error)
+    __PYX_ERR(0, 127, __pyx_L1_error)
   }
-  __pyx_t_9 = PyList_GET_SIZE(__pyx_v_candidates); if (unlikely(__pyx_t_9 == ((Py_ssize_t)-1))) __PYX_ERR(0, 125, __pyx_L1_error)
+  __pyx_t_9 = PyList_GET_SIZE(__pyx_v_candidates); if (unlikely(__pyx_t_9 == ((Py_ssize_t)-1))) __PYX_ERR(0, 127, __pyx_L1_error)
   __pyx_t_3 = ((__pyx_t_9 > 1) != 0);
   if (__pyx_t_3) {
-    __pyx_t_6 = __Pyx_PyObject_Call(__pyx_builtin_TypeError, __pyx_tuple__4, NULL); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 125, __pyx_L1_error)
+    __pyx_t_6 = __Pyx_PyObject_Call(__pyx_builtin_TypeError, __pyx_tuple__4, NULL); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 127, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_6);
     __Pyx_Raise(__pyx_t_6, 0, 0, 0);
     __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
-    __PYX_ERR(0, 125, __pyx_L1_error)
+    __PYX_ERR(0, 127, __pyx_L1_error)
   }
   /*else*/ {
     __Pyx_XDECREF(__pyx_r);
     if (unlikely(__pyx_v_signatures == Py_None)) {
       PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-      __PYX_ERR(0, 125, __pyx_L1_error)
+      __PYX_ERR(0, 127, __pyx_L1_error)
     }
-    __pyx_t_6 = __Pyx_PyDict_GetItem(((PyObject*)__pyx_v_signatures), PyList_GET_ITEM(__pyx_v_candidates, 0)); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 125, __pyx_L1_error)
+    __pyx_t_6 = __Pyx_PyDict_GetItem(((PyObject*)__pyx_v_signatures), PyList_GET_ITEM(__pyx_v_candidates, 0)); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 127, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_6);
     __pyx_r = __pyx_t_6;
     __pyx_t_6 = 0;
@@ -5731,11 +5751,11 @@ static PyObject *__pyx_fuse_0__pyx_pw_5skbio_5stats_10ordination_7_cutils_19cent
         case  1:
         if (likely((values[1] = __Pyx_PyDict_GetItemStr(__pyx_kwds, __pyx_n_s_centered)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("center_distance_matrix_cy", 1, 2, 2, 1); __PYX_ERR(0, 125, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("center_distance_matrix_cy", 1, 2, 2, 1); __PYX_ERR(0, 127, __pyx_L3_error)
         }
       }
       if (unlikely(kw_args > 0)) {
-        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "center_distance_matrix_cy") < 0)) __PYX_ERR(0, 125, __pyx_L3_error)
+        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "center_distance_matrix_cy") < 0)) __PYX_ERR(0, 127, __pyx_L3_error)
       }
     } else if (PyTuple_GET_SIZE(__pyx_args) != 2) {
       goto __pyx_L5_argtuple_error;
@@ -5743,12 +5763,12 @@ static PyObject *__pyx_fuse_0__pyx_pw_5skbio_5stats_10ordination_7_cutils_19cent
       values[0] = PyTuple_GET_ITEM(__pyx_args, 0);
       values[1] = PyTuple_GET_ITEM(__pyx_args, 1);
     }
-    __pyx_v_mat = __Pyx_PyObject_to_MemoryviewSlice_d_dc_float(values[0], PyBUF_WRITABLE); if (unlikely(!__pyx_v_mat.memview)) __PYX_ERR(0, 125, __pyx_L3_error)
-    __pyx_v_centered = __Pyx_PyObject_to_MemoryviewSlice_d_dc_float(values[1], PyBUF_WRITABLE); if (unlikely(!__pyx_v_centered.memview)) __PYX_ERR(0, 125, __pyx_L3_error)
+    __pyx_v_mat = __Pyx_PyObject_to_MemoryviewSlice_d_dc_float(values[0], PyBUF_WRITABLE); if (unlikely(!__pyx_v_mat.memview)) __PYX_ERR(0, 127, __pyx_L3_error)
+    __pyx_v_centered = __Pyx_PyObject_to_MemoryviewSlice_d_dc_float(values[1], PyBUF_WRITABLE); if (unlikely(!__pyx_v_centered.memview)) __PYX_ERR(0, 127, __pyx_L3_error)
   }
   goto __pyx_L4_argument_unpacking_done;
   __pyx_L5_argtuple_error:;
-  __Pyx_RaiseArgtupleInvalid("center_distance_matrix_cy", 1, 2, 2, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 125, __pyx_L3_error)
+  __Pyx_RaiseArgtupleInvalid("center_distance_matrix_cy", 1, 2, 2, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 127, __pyx_L3_error)
   __pyx_L3_error:;
   __Pyx_AddTraceback("skbio.stats.ordination._cutils.center_distance_matrix_cy", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __Pyx_RefNannyFinishContext();
@@ -5787,7 +5807,7 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_18center_distance_
   int __pyx_clineno = 0;
   __Pyx_RefNannySetupContext("__pyx_fuse_0center_distance_matrix_cy", 0);
 
-  /* "skbio/stats/ordination/_cutils.pyx":144
+  /* "skbio/stats/ordination/_cutils.pyx":146
  *         Can point to mat (i.e. in-place)
  *     """
  *     cdef Py_ssize_t n_samples = mat.shape[0]             # <<<<<<<<<<<<<<
@@ -5796,7 +5816,7 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_18center_distance_
  */
   __pyx_v_n_samples = (__pyx_v_mat.shape[0]);
 
-  /* "skbio/stats/ordination/_cutils.pyx":145
+  /* "skbio/stats/ordination/_cutils.pyx":147
  *     """
  *     cdef Py_ssize_t n_samples = mat.shape[0]
  *     cdef Py_ssize_t d2 = mat.shape[1]             # <<<<<<<<<<<<<<
@@ -5805,7 +5825,7 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_18center_distance_
  */
   __pyx_v_d2 = (__pyx_v_mat.shape[1]);
 
-  /* "skbio/stats/ordination/_cutils.pyx":146
+  /* "skbio/stats/ordination/_cutils.pyx":148
  *     cdef Py_ssize_t n_samples = mat.shape[0]
  *     cdef Py_ssize_t d2 = mat.shape[1]
  *     cdef Py_ssize_t d3 = centered.shape[1]             # <<<<<<<<<<<<<<
@@ -5814,7 +5834,7 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_18center_distance_
  */
   __pyx_v_d3 = (__pyx_v_centered.shape[1]);
 
-  /* "skbio/stats/ordination/_cutils.pyx":147
+  /* "skbio/stats/ordination/_cutils.pyx":149
  *     cdef Py_ssize_t d2 = mat.shape[1]
  *     cdef Py_ssize_t d3 = centered.shape[1]
  *     cdef Py_ssize_t d4 = centered.shape[1]             # <<<<<<<<<<<<<<
@@ -5823,7 +5843,7 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_18center_distance_
  */
   __pyx_v_d4 = (__pyx_v_centered.shape[1]);
 
-  /* "skbio/stats/ordination/_cutils.pyx":149
+  /* "skbio/stats/ordination/_cutils.pyx":151
  *     cdef Py_ssize_t d4 = centered.shape[1]
  * 
  *     assert n_samples == d2             # <<<<<<<<<<<<<<
@@ -5834,12 +5854,12 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_18center_distance_
   if (unlikely(!Py_OptimizeFlag)) {
     if (unlikely(!((__pyx_v_n_samples == __pyx_v_d2) != 0))) {
       PyErr_SetNone(PyExc_AssertionError);
-      __PYX_ERR(0, 149, __pyx_L1_error)
+      __PYX_ERR(0, 151, __pyx_L1_error)
     }
   }
   #endif
 
-  /* "skbio/stats/ordination/_cutils.pyx":150
+  /* "skbio/stats/ordination/_cutils.pyx":152
  * 
  *     assert n_samples == d2
  *     assert n_samples == d3             # <<<<<<<<<<<<<<
@@ -5850,12 +5870,12 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_18center_distance_
   if (unlikely(!Py_OptimizeFlag)) {
     if (unlikely(!((__pyx_v_n_samples == __pyx_v_d3) != 0))) {
       PyErr_SetNone(PyExc_AssertionError);
-      __PYX_ERR(0, 150, __pyx_L1_error)
+      __PYX_ERR(0, 152, __pyx_L1_error)
     }
   }
   #endif
 
-  /* "skbio/stats/ordination/_cutils.pyx":151
+  /* "skbio/stats/ordination/_cutils.pyx":153
  *     assert n_samples == d2
  *     assert n_samples == d3
  *     assert n_samples == d4             # <<<<<<<<<<<<<<
@@ -5866,54 +5886,54 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_18center_distance_
   if (unlikely(!Py_OptimizeFlag)) {
     if (unlikely(!((__pyx_v_n_samples == __pyx_v_d4) != 0))) {
       PyErr_SetNone(PyExc_AssertionError);
-      __PYX_ERR(0, 151, __pyx_L1_error)
+      __PYX_ERR(0, 153, __pyx_L1_error)
     }
   }
   #endif
 
-  /* "skbio/stats/ordination/_cutils.pyx":156
+  /* "skbio/stats/ordination/_cutils.pyx":158
  * 
  *     if TReal is float:
  *         dtype_real = np.float32             # <<<<<<<<<<<<<<
  *     else:
  *         dtype_real = np.float64
  */
-  __Pyx_GetModuleGlobalName(__pyx_t_1, __pyx_n_s_np); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 156, __pyx_L1_error)
+  __Pyx_GetModuleGlobalName(__pyx_t_1, __pyx_n_s_np); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 158, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_t_1, __pyx_n_s_float32); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 156, __pyx_L1_error)
+  __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_t_1, __pyx_n_s_float32); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 158, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   __pyx_v_dtype_real = __pyx_t_2;
   __pyx_t_2 = 0;
 
-  /* "skbio/stats/ordination/_cutils.pyx":160
+  /* "skbio/stats/ordination/_cutils.pyx":162
  *         dtype_real = np.float64
  * 
  *     row_means_np = np.zeros((n_samples,), dtype=dtype_real)             # <<<<<<<<<<<<<<
  *     cdef TReal[::1] row_means = row_means_np
  * 
  */
-  __Pyx_GetModuleGlobalName(__pyx_t_2, __pyx_n_s_np); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 160, __pyx_L1_error)
+  __Pyx_GetModuleGlobalName(__pyx_t_2, __pyx_n_s_np); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 162, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
-  __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_zeros); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 160, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_zeros); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 162, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
-  __pyx_t_2 = PyInt_FromSsize_t(__pyx_v_n_samples); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 160, __pyx_L1_error)
+  __pyx_t_2 = PyInt_FromSsize_t(__pyx_v_n_samples); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 162, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
-  __pyx_t_3 = PyTuple_New(1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 160, __pyx_L1_error)
+  __pyx_t_3 = PyTuple_New(1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 162, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
   __Pyx_GIVEREF(__pyx_t_2);
   PyTuple_SET_ITEM(__pyx_t_3, 0, __pyx_t_2);
   __pyx_t_2 = 0;
-  __pyx_t_2 = PyTuple_New(1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 160, __pyx_L1_error)
+  __pyx_t_2 = PyTuple_New(1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 162, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
   __Pyx_GIVEREF(__pyx_t_3);
   PyTuple_SET_ITEM(__pyx_t_2, 0, __pyx_t_3);
   __pyx_t_3 = 0;
-  __pyx_t_3 = __Pyx_PyDict_NewPresized(1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 160, __pyx_L1_error)
+  __pyx_t_3 = __Pyx_PyDict_NewPresized(1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 162, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
-  if (PyDict_SetItem(__pyx_t_3, __pyx_n_s_dtype, __pyx_v_dtype_real) < 0) __PYX_ERR(0, 160, __pyx_L1_error)
-  __pyx_t_4 = __Pyx_PyObject_Call(__pyx_t_1, __pyx_t_2, __pyx_t_3); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 160, __pyx_L1_error)
+  if (PyDict_SetItem(__pyx_t_3, __pyx_n_s_dtype, __pyx_v_dtype_real) < 0) __PYX_ERR(0, 162, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_PyObject_Call(__pyx_t_1, __pyx_t_2, __pyx_t_3); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 162, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
@@ -5921,32 +5941,32 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_18center_distance_
   __pyx_v_row_means_np = __pyx_t_4;
   __pyx_t_4 = 0;
 
-  /* "skbio/stats/ordination/_cutils.pyx":161
+  /* "skbio/stats/ordination/_cutils.pyx":163
  * 
  *     row_means_np = np.zeros((n_samples,), dtype=dtype_real)
  *     cdef TReal[::1] row_means = row_means_np             # <<<<<<<<<<<<<<
  * 
  *     global_mean = e_matrix_means_cy(mat, centered, row_means)
  */
-  __pyx_t_5 = __Pyx_PyObject_to_MemoryviewSlice_dc_float(__pyx_v_row_means_np, PyBUF_WRITABLE); if (unlikely(!__pyx_t_5.memview)) __PYX_ERR(0, 161, __pyx_L1_error)
+  __pyx_t_5 = __Pyx_PyObject_to_MemoryviewSlice_dc_float(__pyx_v_row_means_np, PyBUF_WRITABLE); if (unlikely(!__pyx_t_5.memview)) __PYX_ERR(0, 163, __pyx_L1_error)
   __pyx_v_row_means = __pyx_t_5;
   __pyx_t_5.memview = NULL;
   __pyx_t_5.data = NULL;
 
-  /* "skbio/stats/ordination/_cutils.pyx":163
+  /* "skbio/stats/ordination/_cutils.pyx":165
  *     cdef TReal[::1] row_means = row_means_np
  * 
  *     global_mean = e_matrix_means_cy(mat, centered, row_means)             # <<<<<<<<<<<<<<
  *     f_matrix_inplace_cy(row_means, global_mean, centered)
  * 
  */
-  __Pyx_GetModuleGlobalName(__pyx_t_3, __pyx_n_s_e_matrix_means_cy); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 163, __pyx_L1_error)
+  __Pyx_GetModuleGlobalName(__pyx_t_3, __pyx_n_s_e_matrix_means_cy); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 165, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
-  __pyx_t_2 = __pyx_memoryview_fromslice(__pyx_v_mat, 2, (PyObject *(*)(char *)) __pyx_memview_get_float, (int (*)(char *, PyObject *)) __pyx_memview_set_float, 0);; if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 163, __pyx_L1_error)
+  __pyx_t_2 = __pyx_memoryview_fromslice(__pyx_v_mat, 2, (PyObject *(*)(char *)) __pyx_memview_get_float, (int (*)(char *, PyObject *)) __pyx_memview_set_float, 0);; if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 165, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
-  __pyx_t_1 = __pyx_memoryview_fromslice(__pyx_v_centered, 2, (PyObject *(*)(char *)) __pyx_memview_get_float, (int (*)(char *, PyObject *)) __pyx_memview_set_float, 0);; if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 163, __pyx_L1_error)
+  __pyx_t_1 = __pyx_memoryview_fromslice(__pyx_v_centered, 2, (PyObject *(*)(char *)) __pyx_memview_get_float, (int (*)(char *, PyObject *)) __pyx_memview_set_float, 0);; if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 165, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_6 = __pyx_memoryview_fromslice(__pyx_v_row_means, 1, (PyObject *(*)(char *)) __pyx_memview_get_float, (int (*)(char *, PyObject *)) __pyx_memview_set_float, 0);; if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 163, __pyx_L1_error)
+  __pyx_t_6 = __pyx_memoryview_fromslice(__pyx_v_row_means, 1, (PyObject *(*)(char *)) __pyx_memview_get_float, (int (*)(char *, PyObject *)) __pyx_memview_set_float, 0);; if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 165, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_6);
   __pyx_t_7 = NULL;
   __pyx_t_8 = 0;
@@ -5963,7 +5983,7 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_18center_distance_
   #if CYTHON_FAST_PYCALL
   if (PyFunction_Check(__pyx_t_3)) {
     PyObject *__pyx_temp[4] = {__pyx_t_7, __pyx_t_2, __pyx_t_1, __pyx_t_6};
-    __pyx_t_4 = __Pyx_PyFunction_FastCall(__pyx_t_3, __pyx_temp+1-__pyx_t_8, 3+__pyx_t_8); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 163, __pyx_L1_error)
+    __pyx_t_4 = __Pyx_PyFunction_FastCall(__pyx_t_3, __pyx_temp+1-__pyx_t_8, 3+__pyx_t_8); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 165, __pyx_L1_error)
     __Pyx_XDECREF(__pyx_t_7); __pyx_t_7 = 0;
     __Pyx_GOTREF(__pyx_t_4);
     __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
@@ -5974,7 +5994,7 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_18center_distance_
   #if CYTHON_FAST_PYCCALL
   if (__Pyx_PyFastCFunction_Check(__pyx_t_3)) {
     PyObject *__pyx_temp[4] = {__pyx_t_7, __pyx_t_2, __pyx_t_1, __pyx_t_6};
-    __pyx_t_4 = __Pyx_PyCFunction_FastCall(__pyx_t_3, __pyx_temp+1-__pyx_t_8, 3+__pyx_t_8); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 163, __pyx_L1_error)
+    __pyx_t_4 = __Pyx_PyCFunction_FastCall(__pyx_t_3, __pyx_temp+1-__pyx_t_8, 3+__pyx_t_8); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 165, __pyx_L1_error)
     __Pyx_XDECREF(__pyx_t_7); __pyx_t_7 = 0;
     __Pyx_GOTREF(__pyx_t_4);
     __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
@@ -5983,7 +6003,7 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_18center_distance_
   } else
   #endif
   {
-    __pyx_t_9 = PyTuple_New(3+__pyx_t_8); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 163, __pyx_L1_error)
+    __pyx_t_9 = PyTuple_New(3+__pyx_t_8); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 165, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_9);
     if (__pyx_t_7) {
       __Pyx_GIVEREF(__pyx_t_7); PyTuple_SET_ITEM(__pyx_t_9, 0, __pyx_t_7); __pyx_t_7 = NULL;
@@ -5997,28 +6017,28 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_18center_distance_
     __pyx_t_2 = 0;
     __pyx_t_1 = 0;
     __pyx_t_6 = 0;
-    __pyx_t_4 = __Pyx_PyObject_Call(__pyx_t_3, __pyx_t_9, NULL); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 163, __pyx_L1_error)
+    __pyx_t_4 = __Pyx_PyObject_Call(__pyx_t_3, __pyx_t_9, NULL); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 165, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_4);
     __Pyx_DECREF(__pyx_t_9); __pyx_t_9 = 0;
   }
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
-  __pyx_t_10 = __pyx_PyFloat_AsFloat(__pyx_t_4); if (unlikely((__pyx_t_10 == (float)-1) && PyErr_Occurred())) __PYX_ERR(0, 163, __pyx_L1_error)
+  __pyx_t_10 = __pyx_PyFloat_AsFloat(__pyx_t_4); if (unlikely((__pyx_t_10 == (float)-1) && PyErr_Occurred())) __PYX_ERR(0, 165, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
   __pyx_v_global_mean = __pyx_t_10;
 
-  /* "skbio/stats/ordination/_cutils.pyx":164
+  /* "skbio/stats/ordination/_cutils.pyx":166
  * 
  *     global_mean = e_matrix_means_cy(mat, centered, row_means)
  *     f_matrix_inplace_cy(row_means, global_mean, centered)             # <<<<<<<<<<<<<<
  * 
  */
-  __Pyx_GetModuleGlobalName(__pyx_t_3, __pyx_n_s_f_matrix_inplace_cy); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 164, __pyx_L1_error)
+  __Pyx_GetModuleGlobalName(__pyx_t_3, __pyx_n_s_f_matrix_inplace_cy); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 166, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
-  __pyx_t_9 = __pyx_memoryview_fromslice(__pyx_v_row_means, 1, (PyObject *(*)(char *)) __pyx_memview_get_float, (int (*)(char *, PyObject *)) __pyx_memview_set_float, 0);; if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 164, __pyx_L1_error)
+  __pyx_t_9 = __pyx_memoryview_fromslice(__pyx_v_row_means, 1, (PyObject *(*)(char *)) __pyx_memview_get_float, (int (*)(char *, PyObject *)) __pyx_memview_set_float, 0);; if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 166, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_9);
-  __pyx_t_6 = PyFloat_FromDouble(__pyx_v_global_mean); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 164, __pyx_L1_error)
+  __pyx_t_6 = PyFloat_FromDouble(__pyx_v_global_mean); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 166, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_6);
-  __pyx_t_1 = __pyx_memoryview_fromslice(__pyx_v_centered, 2, (PyObject *(*)(char *)) __pyx_memview_get_float, (int (*)(char *, PyObject *)) __pyx_memview_set_float, 0);; if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 164, __pyx_L1_error)
+  __pyx_t_1 = __pyx_memoryview_fromslice(__pyx_v_centered, 2, (PyObject *(*)(char *)) __pyx_memview_get_float, (int (*)(char *, PyObject *)) __pyx_memview_set_float, 0);; if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 166, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __pyx_t_2 = NULL;
   __pyx_t_8 = 0;
@@ -6035,7 +6055,7 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_18center_distance_
   #if CYTHON_FAST_PYCALL
   if (PyFunction_Check(__pyx_t_3)) {
     PyObject *__pyx_temp[4] = {__pyx_t_2, __pyx_t_9, __pyx_t_6, __pyx_t_1};
-    __pyx_t_4 = __Pyx_PyFunction_FastCall(__pyx_t_3, __pyx_temp+1-__pyx_t_8, 3+__pyx_t_8); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 164, __pyx_L1_error)
+    __pyx_t_4 = __Pyx_PyFunction_FastCall(__pyx_t_3, __pyx_temp+1-__pyx_t_8, 3+__pyx_t_8); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 166, __pyx_L1_error)
     __Pyx_XDECREF(__pyx_t_2); __pyx_t_2 = 0;
     __Pyx_GOTREF(__pyx_t_4);
     __Pyx_DECREF(__pyx_t_9); __pyx_t_9 = 0;
@@ -6046,7 +6066,7 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_18center_distance_
   #if CYTHON_FAST_PYCCALL
   if (__Pyx_PyFastCFunction_Check(__pyx_t_3)) {
     PyObject *__pyx_temp[4] = {__pyx_t_2, __pyx_t_9, __pyx_t_6, __pyx_t_1};
-    __pyx_t_4 = __Pyx_PyCFunction_FastCall(__pyx_t_3, __pyx_temp+1-__pyx_t_8, 3+__pyx_t_8); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 164, __pyx_L1_error)
+    __pyx_t_4 = __Pyx_PyCFunction_FastCall(__pyx_t_3, __pyx_temp+1-__pyx_t_8, 3+__pyx_t_8); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 166, __pyx_L1_error)
     __Pyx_XDECREF(__pyx_t_2); __pyx_t_2 = 0;
     __Pyx_GOTREF(__pyx_t_4);
     __Pyx_DECREF(__pyx_t_9); __pyx_t_9 = 0;
@@ -6055,7 +6075,7 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_18center_distance_
   } else
   #endif
   {
-    __pyx_t_7 = PyTuple_New(3+__pyx_t_8); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 164, __pyx_L1_error)
+    __pyx_t_7 = PyTuple_New(3+__pyx_t_8); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 166, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_7);
     if (__pyx_t_2) {
       __Pyx_GIVEREF(__pyx_t_2); PyTuple_SET_ITEM(__pyx_t_7, 0, __pyx_t_2); __pyx_t_2 = NULL;
@@ -6069,14 +6089,14 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_18center_distance_
     __pyx_t_9 = 0;
     __pyx_t_6 = 0;
     __pyx_t_1 = 0;
-    __pyx_t_4 = __Pyx_PyObject_Call(__pyx_t_3, __pyx_t_7, NULL); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 164, __pyx_L1_error)
+    __pyx_t_4 = __Pyx_PyObject_Call(__pyx_t_3, __pyx_t_7, NULL); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 166, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_4);
     __Pyx_DECREF(__pyx_t_7); __pyx_t_7 = 0;
   }
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
 
-  /* "skbio/stats/ordination/_cutils.pyx":125
+  /* "skbio/stats/ordination/_cutils.pyx":127
  * @cython.boundscheck(False)
  * @cython.wraparound(False)
  * def center_distance_matrix_cy(TReal[:, ::1] mat, TReal[:, ::1] centered):             # <<<<<<<<<<<<<<
@@ -6144,11 +6164,11 @@ static PyObject *__pyx_fuse_1__pyx_pw_5skbio_5stats_10ordination_7_cutils_21cent
         case  1:
         if (likely((values[1] = __Pyx_PyDict_GetItemStr(__pyx_kwds, __pyx_n_s_centered)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("center_distance_matrix_cy", 1, 2, 2, 1); __PYX_ERR(0, 125, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("center_distance_matrix_cy", 1, 2, 2, 1); __PYX_ERR(0, 127, __pyx_L3_error)
         }
       }
       if (unlikely(kw_args > 0)) {
-        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "center_distance_matrix_cy") < 0)) __PYX_ERR(0, 125, __pyx_L3_error)
+        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "center_distance_matrix_cy") < 0)) __PYX_ERR(0, 127, __pyx_L3_error)
       }
     } else if (PyTuple_GET_SIZE(__pyx_args) != 2) {
       goto __pyx_L5_argtuple_error;
@@ -6156,12 +6176,12 @@ static PyObject *__pyx_fuse_1__pyx_pw_5skbio_5stats_10ordination_7_cutils_21cent
       values[0] = PyTuple_GET_ITEM(__pyx_args, 0);
       values[1] = PyTuple_GET_ITEM(__pyx_args, 1);
     }
-    __pyx_v_mat = __Pyx_PyObject_to_MemoryviewSlice_d_dc_double(values[0], PyBUF_WRITABLE); if (unlikely(!__pyx_v_mat.memview)) __PYX_ERR(0, 125, __pyx_L3_error)
-    __pyx_v_centered = __Pyx_PyObject_to_MemoryviewSlice_d_dc_double(values[1], PyBUF_WRITABLE); if (unlikely(!__pyx_v_centered.memview)) __PYX_ERR(0, 125, __pyx_L3_error)
+    __pyx_v_mat = __Pyx_PyObject_to_MemoryviewSlice_d_dc_double(values[0], PyBUF_WRITABLE); if (unlikely(!__pyx_v_mat.memview)) __PYX_ERR(0, 127, __pyx_L3_error)
+    __pyx_v_centered = __Pyx_PyObject_to_MemoryviewSlice_d_dc_double(values[1], PyBUF_WRITABLE); if (unlikely(!__pyx_v_centered.memview)) __PYX_ERR(0, 127, __pyx_L3_error)
   }
   goto __pyx_L4_argument_unpacking_done;
   __pyx_L5_argtuple_error:;
-  __Pyx_RaiseArgtupleInvalid("center_distance_matrix_cy", 1, 2, 2, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 125, __pyx_L3_error)
+  __Pyx_RaiseArgtupleInvalid("center_distance_matrix_cy", 1, 2, 2, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 127, __pyx_L3_error)
   __pyx_L3_error:;
   __Pyx_AddTraceback("skbio.stats.ordination._cutils.center_distance_matrix_cy", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __Pyx_RefNannyFinishContext();
@@ -6200,7 +6220,7 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_20center_distance_
   int __pyx_clineno = 0;
   __Pyx_RefNannySetupContext("__pyx_fuse_1center_distance_matrix_cy", 0);
 
-  /* "skbio/stats/ordination/_cutils.pyx":144
+  /* "skbio/stats/ordination/_cutils.pyx":146
  *         Can point to mat (i.e. in-place)
  *     """
  *     cdef Py_ssize_t n_samples = mat.shape[0]             # <<<<<<<<<<<<<<
@@ -6209,7 +6229,7 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_20center_distance_
  */
   __pyx_v_n_samples = (__pyx_v_mat.shape[0]);
 
-  /* "skbio/stats/ordination/_cutils.pyx":145
+  /* "skbio/stats/ordination/_cutils.pyx":147
  *     """
  *     cdef Py_ssize_t n_samples = mat.shape[0]
  *     cdef Py_ssize_t d2 = mat.shape[1]             # <<<<<<<<<<<<<<
@@ -6218,7 +6238,7 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_20center_distance_
  */
   __pyx_v_d2 = (__pyx_v_mat.shape[1]);
 
-  /* "skbio/stats/ordination/_cutils.pyx":146
+  /* "skbio/stats/ordination/_cutils.pyx":148
  *     cdef Py_ssize_t n_samples = mat.shape[0]
  *     cdef Py_ssize_t d2 = mat.shape[1]
  *     cdef Py_ssize_t d3 = centered.shape[1]             # <<<<<<<<<<<<<<
@@ -6227,7 +6247,7 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_20center_distance_
  */
   __pyx_v_d3 = (__pyx_v_centered.shape[1]);
 
-  /* "skbio/stats/ordination/_cutils.pyx":147
+  /* "skbio/stats/ordination/_cutils.pyx":149
  *     cdef Py_ssize_t d2 = mat.shape[1]
  *     cdef Py_ssize_t d3 = centered.shape[1]
  *     cdef Py_ssize_t d4 = centered.shape[1]             # <<<<<<<<<<<<<<
@@ -6236,7 +6256,7 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_20center_distance_
  */
   __pyx_v_d4 = (__pyx_v_centered.shape[1]);
 
-  /* "skbio/stats/ordination/_cutils.pyx":149
+  /* "skbio/stats/ordination/_cutils.pyx":151
  *     cdef Py_ssize_t d4 = centered.shape[1]
  * 
  *     assert n_samples == d2             # <<<<<<<<<<<<<<
@@ -6247,12 +6267,12 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_20center_distance_
   if (unlikely(!Py_OptimizeFlag)) {
     if (unlikely(!((__pyx_v_n_samples == __pyx_v_d2) != 0))) {
       PyErr_SetNone(PyExc_AssertionError);
-      __PYX_ERR(0, 149, __pyx_L1_error)
+      __PYX_ERR(0, 151, __pyx_L1_error)
     }
   }
   #endif
 
-  /* "skbio/stats/ordination/_cutils.pyx":150
+  /* "skbio/stats/ordination/_cutils.pyx":152
  * 
  *     assert n_samples == d2
  *     assert n_samples == d3             # <<<<<<<<<<<<<<
@@ -6263,12 +6283,12 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_20center_distance_
   if (unlikely(!Py_OptimizeFlag)) {
     if (unlikely(!((__pyx_v_n_samples == __pyx_v_d3) != 0))) {
       PyErr_SetNone(PyExc_AssertionError);
-      __PYX_ERR(0, 150, __pyx_L1_error)
+      __PYX_ERR(0, 152, __pyx_L1_error)
     }
   }
   #endif
 
-  /* "skbio/stats/ordination/_cutils.pyx":151
+  /* "skbio/stats/ordination/_cutils.pyx":153
  *     assert n_samples == d2
  *     assert n_samples == d3
  *     assert n_samples == d4             # <<<<<<<<<<<<<<
@@ -6279,54 +6299,54 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_20center_distance_
   if (unlikely(!Py_OptimizeFlag)) {
     if (unlikely(!((__pyx_v_n_samples == __pyx_v_d4) != 0))) {
       PyErr_SetNone(PyExc_AssertionError);
-      __PYX_ERR(0, 151, __pyx_L1_error)
+      __PYX_ERR(0, 153, __pyx_L1_error)
     }
   }
   #endif
 
-  /* "skbio/stats/ordination/_cutils.pyx":158
+  /* "skbio/stats/ordination/_cutils.pyx":160
  *         dtype_real = np.float32
  *     else:
  *         dtype_real = np.float64             # <<<<<<<<<<<<<<
  * 
  *     row_means_np = np.zeros((n_samples,), dtype=dtype_real)
  */
-  __Pyx_GetModuleGlobalName(__pyx_t_1, __pyx_n_s_np); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 158, __pyx_L1_error)
+  __Pyx_GetModuleGlobalName(__pyx_t_1, __pyx_n_s_np); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 160, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_t_1, __pyx_n_s_float64); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 158, __pyx_L1_error)
+  __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_t_1, __pyx_n_s_float64); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 160, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   __pyx_v_dtype_real = __pyx_t_2;
   __pyx_t_2 = 0;
 
-  /* "skbio/stats/ordination/_cutils.pyx":160
+  /* "skbio/stats/ordination/_cutils.pyx":162
  *         dtype_real = np.float64
  * 
  *     row_means_np = np.zeros((n_samples,), dtype=dtype_real)             # <<<<<<<<<<<<<<
  *     cdef TReal[::1] row_means = row_means_np
  * 
  */
-  __Pyx_GetModuleGlobalName(__pyx_t_2, __pyx_n_s_np); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 160, __pyx_L1_error)
+  __Pyx_GetModuleGlobalName(__pyx_t_2, __pyx_n_s_np); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 162, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
-  __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_zeros); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 160, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_zeros); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 162, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
-  __pyx_t_2 = PyInt_FromSsize_t(__pyx_v_n_samples); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 160, __pyx_L1_error)
+  __pyx_t_2 = PyInt_FromSsize_t(__pyx_v_n_samples); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 162, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
-  __pyx_t_3 = PyTuple_New(1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 160, __pyx_L1_error)
+  __pyx_t_3 = PyTuple_New(1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 162, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
   __Pyx_GIVEREF(__pyx_t_2);
   PyTuple_SET_ITEM(__pyx_t_3, 0, __pyx_t_2);
   __pyx_t_2 = 0;
-  __pyx_t_2 = PyTuple_New(1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 160, __pyx_L1_error)
+  __pyx_t_2 = PyTuple_New(1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 162, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
   __Pyx_GIVEREF(__pyx_t_3);
   PyTuple_SET_ITEM(__pyx_t_2, 0, __pyx_t_3);
   __pyx_t_3 = 0;
-  __pyx_t_3 = __Pyx_PyDict_NewPresized(1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 160, __pyx_L1_error)
+  __pyx_t_3 = __Pyx_PyDict_NewPresized(1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 162, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
-  if (PyDict_SetItem(__pyx_t_3, __pyx_n_s_dtype, __pyx_v_dtype_real) < 0) __PYX_ERR(0, 160, __pyx_L1_error)
-  __pyx_t_4 = __Pyx_PyObject_Call(__pyx_t_1, __pyx_t_2, __pyx_t_3); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 160, __pyx_L1_error)
+  if (PyDict_SetItem(__pyx_t_3, __pyx_n_s_dtype, __pyx_v_dtype_real) < 0) __PYX_ERR(0, 162, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_PyObject_Call(__pyx_t_1, __pyx_t_2, __pyx_t_3); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 162, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
@@ -6334,32 +6354,32 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_20center_distance_
   __pyx_v_row_means_np = __pyx_t_4;
   __pyx_t_4 = 0;
 
-  /* "skbio/stats/ordination/_cutils.pyx":161
+  /* "skbio/stats/ordination/_cutils.pyx":163
  * 
  *     row_means_np = np.zeros((n_samples,), dtype=dtype_real)
  *     cdef TReal[::1] row_means = row_means_np             # <<<<<<<<<<<<<<
  * 
  *     global_mean = e_matrix_means_cy(mat, centered, row_means)
  */
-  __pyx_t_5 = __Pyx_PyObject_to_MemoryviewSlice_dc_double(__pyx_v_row_means_np, PyBUF_WRITABLE); if (unlikely(!__pyx_t_5.memview)) __PYX_ERR(0, 161, __pyx_L1_error)
+  __pyx_t_5 = __Pyx_PyObject_to_MemoryviewSlice_dc_double(__pyx_v_row_means_np, PyBUF_WRITABLE); if (unlikely(!__pyx_t_5.memview)) __PYX_ERR(0, 163, __pyx_L1_error)
   __pyx_v_row_means = __pyx_t_5;
   __pyx_t_5.memview = NULL;
   __pyx_t_5.data = NULL;
 
-  /* "skbio/stats/ordination/_cutils.pyx":163
+  /* "skbio/stats/ordination/_cutils.pyx":165
  *     cdef TReal[::1] row_means = row_means_np
  * 
  *     global_mean = e_matrix_means_cy(mat, centered, row_means)             # <<<<<<<<<<<<<<
  *     f_matrix_inplace_cy(row_means, global_mean, centered)
  * 
  */
-  __Pyx_GetModuleGlobalName(__pyx_t_3, __pyx_n_s_e_matrix_means_cy); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 163, __pyx_L1_error)
+  __Pyx_GetModuleGlobalName(__pyx_t_3, __pyx_n_s_e_matrix_means_cy); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 165, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
-  __pyx_t_2 = __pyx_memoryview_fromslice(__pyx_v_mat, 2, (PyObject *(*)(char *)) __pyx_memview_get_double, (int (*)(char *, PyObject *)) __pyx_memview_set_double, 0);; if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 163, __pyx_L1_error)
+  __pyx_t_2 = __pyx_memoryview_fromslice(__pyx_v_mat, 2, (PyObject *(*)(char *)) __pyx_memview_get_double, (int (*)(char *, PyObject *)) __pyx_memview_set_double, 0);; if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 165, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
-  __pyx_t_1 = __pyx_memoryview_fromslice(__pyx_v_centered, 2, (PyObject *(*)(char *)) __pyx_memview_get_double, (int (*)(char *, PyObject *)) __pyx_memview_set_double, 0);; if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 163, __pyx_L1_error)
+  __pyx_t_1 = __pyx_memoryview_fromslice(__pyx_v_centered, 2, (PyObject *(*)(char *)) __pyx_memview_get_double, (int (*)(char *, PyObject *)) __pyx_memview_set_double, 0);; if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 165, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_6 = __pyx_memoryview_fromslice(__pyx_v_row_means, 1, (PyObject *(*)(char *)) __pyx_memview_get_double, (int (*)(char *, PyObject *)) __pyx_memview_set_double, 0);; if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 163, __pyx_L1_error)
+  __pyx_t_6 = __pyx_memoryview_fromslice(__pyx_v_row_means, 1, (PyObject *(*)(char *)) __pyx_memview_get_double, (int (*)(char *, PyObject *)) __pyx_memview_set_double, 0);; if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 165, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_6);
   __pyx_t_7 = NULL;
   __pyx_t_8 = 0;
@@ -6376,7 +6396,7 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_20center_distance_
   #if CYTHON_FAST_PYCALL
   if (PyFunction_Check(__pyx_t_3)) {
     PyObject *__pyx_temp[4] = {__pyx_t_7, __pyx_t_2, __pyx_t_1, __pyx_t_6};
-    __pyx_t_4 = __Pyx_PyFunction_FastCall(__pyx_t_3, __pyx_temp+1-__pyx_t_8, 3+__pyx_t_8); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 163, __pyx_L1_error)
+    __pyx_t_4 = __Pyx_PyFunction_FastCall(__pyx_t_3, __pyx_temp+1-__pyx_t_8, 3+__pyx_t_8); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 165, __pyx_L1_error)
     __Pyx_XDECREF(__pyx_t_7); __pyx_t_7 = 0;
     __Pyx_GOTREF(__pyx_t_4);
     __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
@@ -6387,7 +6407,7 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_20center_distance_
   #if CYTHON_FAST_PYCCALL
   if (__Pyx_PyFastCFunction_Check(__pyx_t_3)) {
     PyObject *__pyx_temp[4] = {__pyx_t_7, __pyx_t_2, __pyx_t_1, __pyx_t_6};
-    __pyx_t_4 = __Pyx_PyCFunction_FastCall(__pyx_t_3, __pyx_temp+1-__pyx_t_8, 3+__pyx_t_8); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 163, __pyx_L1_error)
+    __pyx_t_4 = __Pyx_PyCFunction_FastCall(__pyx_t_3, __pyx_temp+1-__pyx_t_8, 3+__pyx_t_8); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 165, __pyx_L1_error)
     __Pyx_XDECREF(__pyx_t_7); __pyx_t_7 = 0;
     __Pyx_GOTREF(__pyx_t_4);
     __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
@@ -6396,7 +6416,7 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_20center_distance_
   } else
   #endif
   {
-    __pyx_t_9 = PyTuple_New(3+__pyx_t_8); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 163, __pyx_L1_error)
+    __pyx_t_9 = PyTuple_New(3+__pyx_t_8); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 165, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_9);
     if (__pyx_t_7) {
       __Pyx_GIVEREF(__pyx_t_7); PyTuple_SET_ITEM(__pyx_t_9, 0, __pyx_t_7); __pyx_t_7 = NULL;
@@ -6410,28 +6430,28 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_20center_distance_
     __pyx_t_2 = 0;
     __pyx_t_1 = 0;
     __pyx_t_6 = 0;
-    __pyx_t_4 = __Pyx_PyObject_Call(__pyx_t_3, __pyx_t_9, NULL); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 163, __pyx_L1_error)
+    __pyx_t_4 = __Pyx_PyObject_Call(__pyx_t_3, __pyx_t_9, NULL); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 165, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_4);
     __Pyx_DECREF(__pyx_t_9); __pyx_t_9 = 0;
   }
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
-  __pyx_t_10 = __pyx_PyFloat_AsDouble(__pyx_t_4); if (unlikely((__pyx_t_10 == (double)-1) && PyErr_Occurred())) __PYX_ERR(0, 163, __pyx_L1_error)
+  __pyx_t_10 = __pyx_PyFloat_AsDouble(__pyx_t_4); if (unlikely((__pyx_t_10 == (double)-1) && PyErr_Occurred())) __PYX_ERR(0, 165, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
   __pyx_v_global_mean = __pyx_t_10;
 
-  /* "skbio/stats/ordination/_cutils.pyx":164
+  /* "skbio/stats/ordination/_cutils.pyx":166
  * 
  *     global_mean = e_matrix_means_cy(mat, centered, row_means)
  *     f_matrix_inplace_cy(row_means, global_mean, centered)             # <<<<<<<<<<<<<<
  * 
  */
-  __Pyx_GetModuleGlobalName(__pyx_t_3, __pyx_n_s_f_matrix_inplace_cy); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 164, __pyx_L1_error)
+  __Pyx_GetModuleGlobalName(__pyx_t_3, __pyx_n_s_f_matrix_inplace_cy); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 166, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
-  __pyx_t_9 = __pyx_memoryview_fromslice(__pyx_v_row_means, 1, (PyObject *(*)(char *)) __pyx_memview_get_double, (int (*)(char *, PyObject *)) __pyx_memview_set_double, 0);; if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 164, __pyx_L1_error)
+  __pyx_t_9 = __pyx_memoryview_fromslice(__pyx_v_row_means, 1, (PyObject *(*)(char *)) __pyx_memview_get_double, (int (*)(char *, PyObject *)) __pyx_memview_set_double, 0);; if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 166, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_9);
-  __pyx_t_6 = PyFloat_FromDouble(__pyx_v_global_mean); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 164, __pyx_L1_error)
+  __pyx_t_6 = PyFloat_FromDouble(__pyx_v_global_mean); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 166, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_6);
-  __pyx_t_1 = __pyx_memoryview_fromslice(__pyx_v_centered, 2, (PyObject *(*)(char *)) __pyx_memview_get_double, (int (*)(char *, PyObject *)) __pyx_memview_set_double, 0);; if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 164, __pyx_L1_error)
+  __pyx_t_1 = __pyx_memoryview_fromslice(__pyx_v_centered, 2, (PyObject *(*)(char *)) __pyx_memview_get_double, (int (*)(char *, PyObject *)) __pyx_memview_set_double, 0);; if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 166, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __pyx_t_2 = NULL;
   __pyx_t_8 = 0;
@@ -6448,7 +6468,7 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_20center_distance_
   #if CYTHON_FAST_PYCALL
   if (PyFunction_Check(__pyx_t_3)) {
     PyObject *__pyx_temp[4] = {__pyx_t_2, __pyx_t_9, __pyx_t_6, __pyx_t_1};
-    __pyx_t_4 = __Pyx_PyFunction_FastCall(__pyx_t_3, __pyx_temp+1-__pyx_t_8, 3+__pyx_t_8); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 164, __pyx_L1_error)
+    __pyx_t_4 = __Pyx_PyFunction_FastCall(__pyx_t_3, __pyx_temp+1-__pyx_t_8, 3+__pyx_t_8); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 166, __pyx_L1_error)
     __Pyx_XDECREF(__pyx_t_2); __pyx_t_2 = 0;
     __Pyx_GOTREF(__pyx_t_4);
     __Pyx_DECREF(__pyx_t_9); __pyx_t_9 = 0;
@@ -6459,7 +6479,7 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_20center_distance_
   #if CYTHON_FAST_PYCCALL
   if (__Pyx_PyFastCFunction_Check(__pyx_t_3)) {
     PyObject *__pyx_temp[4] = {__pyx_t_2, __pyx_t_9, __pyx_t_6, __pyx_t_1};
-    __pyx_t_4 = __Pyx_PyCFunction_FastCall(__pyx_t_3, __pyx_temp+1-__pyx_t_8, 3+__pyx_t_8); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 164, __pyx_L1_error)
+    __pyx_t_4 = __Pyx_PyCFunction_FastCall(__pyx_t_3, __pyx_temp+1-__pyx_t_8, 3+__pyx_t_8); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 166, __pyx_L1_error)
     __Pyx_XDECREF(__pyx_t_2); __pyx_t_2 = 0;
     __Pyx_GOTREF(__pyx_t_4);
     __Pyx_DECREF(__pyx_t_9); __pyx_t_9 = 0;
@@ -6468,7 +6488,7 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_20center_distance_
   } else
   #endif
   {
-    __pyx_t_7 = PyTuple_New(3+__pyx_t_8); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 164, __pyx_L1_error)
+    __pyx_t_7 = PyTuple_New(3+__pyx_t_8); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 166, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_7);
     if (__pyx_t_2) {
       __Pyx_GIVEREF(__pyx_t_2); PyTuple_SET_ITEM(__pyx_t_7, 0, __pyx_t_2); __pyx_t_2 = NULL;
@@ -6482,14 +6502,14 @@ static PyObject *__pyx_pf_5skbio_5stats_10ordination_7_cutils_20center_distance_
     __pyx_t_9 = 0;
     __pyx_t_6 = 0;
     __pyx_t_1 = 0;
-    __pyx_t_4 = __Pyx_PyObject_Call(__pyx_t_3, __pyx_t_7, NULL); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 164, __pyx_L1_error)
+    __pyx_t_4 = __Pyx_PyObject_Call(__pyx_t_3, __pyx_t_7, NULL); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 166, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_4);
     __Pyx_DECREF(__pyx_t_7); __pyx_t_7 = 0;
   }
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
 
-  /* "skbio/stats/ordination/_cutils.pyx":125
+  /* "skbio/stats/ordination/_cutils.pyx":127
  * @cython.boundscheck(False)
  * @cython.wraparound(False)
  * def center_distance_matrix_cy(TReal[:, ::1] mat, TReal[:, ::1] centered):             # <<<<<<<<<<<<<<
@@ -20667,34 +20687,34 @@ static CYTHON_SMALL_CODE int __Pyx_InitCachedConstants(void) {
  *     """
  *     Compute E matrix from a distance matrix, and
  */
-  __pyx_tuple__23 = PyTuple_Pack(13, __pyx_n_s_mat, __pyx_n_s_centered, __pyx_n_s_row_means, __pyx_n_s_n_samples, __pyx_n_s_d2, __pyx_n_s_d3, __pyx_n_s_d4, __pyx_n_s_d5, __pyx_n_s_row, __pyx_n_s_col, __pyx_n_s_row_sum, __pyx_n_s_el0, __pyx_n_s_global_sum); if (unlikely(!__pyx_tuple__23)) __PYX_ERR(0, 23, __pyx_L1_error)
+  __pyx_tuple__23 = PyTuple_Pack(14, __pyx_n_s_mat, __pyx_n_s_centered, __pyx_n_s_row_means, __pyx_n_s_n_samples, __pyx_n_s_d2, __pyx_n_s_d3, __pyx_n_s_d4, __pyx_n_s_d5, __pyx_n_s_row, __pyx_n_s_col, __pyx_n_s_row_sum, __pyx_n_s_el0, __pyx_n_s_global_sum, __pyx_n_s_global_mean); if (unlikely(!__pyx_tuple__23)) __PYX_ERR(0, 23, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_tuple__23);
   __Pyx_GIVEREF(__pyx_tuple__23);
-  __pyx_codeobj__24 = (PyObject*)__Pyx_PyCode_New(3, 0, 13, 0, CO_OPTIMIZED|CO_NEWLOCALS, __pyx_empty_bytes, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_tuple__23, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_kp_s_skbio_stats_ordination__cutils_p, __pyx_n_s_e_matrix_means_cy, 23, __pyx_empty_bytes); if (unlikely(!__pyx_codeobj__24)) __PYX_ERR(0, 23, __pyx_L1_error)
+  __pyx_codeobj__24 = (PyObject*)__Pyx_PyCode_New(3, 0, 14, 0, CO_OPTIMIZED|CO_NEWLOCALS, __pyx_empty_bytes, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_tuple__23, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_kp_s_skbio_stats_ordination__cutils_p, __pyx_n_s_e_matrix_means_cy, 23, __pyx_empty_bytes); if (unlikely(!__pyx_codeobj__24)) __PYX_ERR(0, 23, __pyx_L1_error)
 
-  /* "skbio/stats/ordination/_cutils.pyx":79
+  /* "skbio/stats/ordination/_cutils.pyx":81
  * @cython.boundscheck(False)
  * @cython.wraparound(False)
  * def f_matrix_inplace_cy(TReal[::1] row_means, TReal global_mean, TReal[:, ::1] centered):             # <<<<<<<<<<<<<<
  *     """
  *     Compute F matrix from E matrix inplace.
  */
-  __pyx_tuple__25 = PyTuple_Pack(13, __pyx_n_s_row_means, __pyx_n_s_global_mean, __pyx_n_s_centered, __pyx_n_s_n_samples, __pyx_n_s_d2, __pyx_n_s_d3, __pyx_n_s_trow, __pyx_n_s_tcol, __pyx_n_s_row, __pyx_n_s_col, __pyx_n_s_trow_max, __pyx_n_s_tcol_max, __pyx_n_s_gr_mean); if (unlikely(!__pyx_tuple__25)) __PYX_ERR(0, 79, __pyx_L1_error)
+  __pyx_tuple__25 = PyTuple_Pack(13, __pyx_n_s_row_means, __pyx_n_s_global_mean, __pyx_n_s_centered, __pyx_n_s_n_samples, __pyx_n_s_d2, __pyx_n_s_d3, __pyx_n_s_trow, __pyx_n_s_tcol, __pyx_n_s_row, __pyx_n_s_col, __pyx_n_s_trow_max, __pyx_n_s_tcol_max, __pyx_n_s_gr_mean); if (unlikely(!__pyx_tuple__25)) __PYX_ERR(0, 81, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_tuple__25);
   __Pyx_GIVEREF(__pyx_tuple__25);
-  __pyx_codeobj__26 = (PyObject*)__Pyx_PyCode_New(3, 0, 13, 0, CO_OPTIMIZED|CO_NEWLOCALS, __pyx_empty_bytes, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_tuple__25, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_kp_s_skbio_stats_ordination__cutils_p, __pyx_n_s_f_matrix_inplace_cy, 79, __pyx_empty_bytes); if (unlikely(!__pyx_codeobj__26)) __PYX_ERR(0, 79, __pyx_L1_error)
+  __pyx_codeobj__26 = (PyObject*)__Pyx_PyCode_New(3, 0, 13, 0, CO_OPTIMIZED|CO_NEWLOCALS, __pyx_empty_bytes, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_tuple__25, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_kp_s_skbio_stats_ordination__cutils_p, __pyx_n_s_f_matrix_inplace_cy, 81, __pyx_empty_bytes); if (unlikely(!__pyx_codeobj__26)) __PYX_ERR(0, 81, __pyx_L1_error)
 
-  /* "skbio/stats/ordination/_cutils.pyx":125
+  /* "skbio/stats/ordination/_cutils.pyx":127
  * @cython.boundscheck(False)
  * @cython.wraparound(False)
  * def center_distance_matrix_cy(TReal[:, ::1] mat, TReal[:, ::1] centered):             # <<<<<<<<<<<<<<
  *     """
  *     Centers a distance matrix.
  */
-  __pyx_tuple__27 = PyTuple_Pack(10, __pyx_n_s_mat, __pyx_n_s_centered, __pyx_n_s_n_samples, __pyx_n_s_d2, __pyx_n_s_d3, __pyx_n_s_d4, __pyx_n_s_global_mean, __pyx_n_s_dtype_real, __pyx_n_s_row_means_np, __pyx_n_s_row_means); if (unlikely(!__pyx_tuple__27)) __PYX_ERR(0, 125, __pyx_L1_error)
+  __pyx_tuple__27 = PyTuple_Pack(10, __pyx_n_s_mat, __pyx_n_s_centered, __pyx_n_s_n_samples, __pyx_n_s_d2, __pyx_n_s_d3, __pyx_n_s_d4, __pyx_n_s_global_mean, __pyx_n_s_dtype_real, __pyx_n_s_row_means_np, __pyx_n_s_row_means); if (unlikely(!__pyx_tuple__27)) __PYX_ERR(0, 127, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_tuple__27);
   __Pyx_GIVEREF(__pyx_tuple__27);
-  __pyx_codeobj__28 = (PyObject*)__Pyx_PyCode_New(2, 0, 10, 0, CO_OPTIMIZED|CO_NEWLOCALS, __pyx_empty_bytes, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_tuple__27, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_kp_s_skbio_stats_ordination__cutils_p, __pyx_n_s_center_distance_matrix_cy, 125, __pyx_empty_bytes); if (unlikely(!__pyx_codeobj__28)) __PYX_ERR(0, 125, __pyx_L1_error)
+  __pyx_codeobj__28 = (PyObject*)__Pyx_PyCode_New(2, 0, 10, 0, CO_OPTIMIZED|CO_NEWLOCALS, __pyx_empty_bytes, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_tuple__27, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_kp_s_skbio_stats_ordination__cutils_p, __pyx_n_s_center_distance_matrix_cy, 127, __pyx_empty_bytes); if (unlikely(!__pyx_codeobj__28)) __PYX_ERR(0, 127, __pyx_L1_error)
 
   /* "View.MemoryView":286
  *         return self.name
@@ -21157,60 +21177,60 @@ if (!__Pyx_RefNanny) {
   if (PyDict_SetItem(__pyx_d, __pyx_n_s_e_matrix_means_cy, __pyx_t_2) < 0) __PYX_ERR(0, 23, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
 
-  /* "skbio/stats/ordination/_cutils.pyx":79
+  /* "skbio/stats/ordination/_cutils.pyx":81
  * @cython.boundscheck(False)
  * @cython.wraparound(False)
  * def f_matrix_inplace_cy(TReal[::1] row_means, TReal global_mean, TReal[:, ::1] centered):             # <<<<<<<<<<<<<<
  *     """
  *     Compute F matrix from E matrix inplace.
  */
-  __pyx_t_2 = __Pyx_PyDict_NewPresized(2); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 79, __pyx_L1_error)
+  __pyx_t_2 = __Pyx_PyDict_NewPresized(2); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 81, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
-  __pyx_t_1 = __pyx_FusedFunction_New(&__pyx_fuse_0__pyx_mdef_5skbio_5stats_10ordination_7_cutils_13f_matrix_inplace_cy, 0, __pyx_n_s_f_matrix_inplace_cy, NULL, __pyx_n_s_skbio_stats_ordination__cutils, __pyx_d, ((PyObject *)__pyx_codeobj__26)); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 79, __pyx_L1_error)
+  __pyx_t_1 = __pyx_FusedFunction_New(&__pyx_fuse_0__pyx_mdef_5skbio_5stats_10ordination_7_cutils_13f_matrix_inplace_cy, 0, __pyx_n_s_f_matrix_inplace_cy, NULL, __pyx_n_s_skbio_stats_ordination__cutils, __pyx_d, ((PyObject *)__pyx_codeobj__26)); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 81, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __Pyx_CyFunction_SetDefaultsTuple(__pyx_t_1, __pyx_empty_tuple);
-  if (PyDict_SetItem(__pyx_t_2, __pyx_n_s_float, __pyx_t_1) < 0) __PYX_ERR(0, 79, __pyx_L1_error)
+  if (PyDict_SetItem(__pyx_t_2, __pyx_n_s_float, __pyx_t_1) < 0) __PYX_ERR(0, 81, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
-  __pyx_t_1 = __pyx_FusedFunction_New(&__pyx_fuse_1__pyx_mdef_5skbio_5stats_10ordination_7_cutils_15f_matrix_inplace_cy, 0, __pyx_n_s_f_matrix_inplace_cy, NULL, __pyx_n_s_skbio_stats_ordination__cutils, __pyx_d, ((PyObject *)__pyx_codeobj__26)); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 79, __pyx_L1_error)
+  __pyx_t_1 = __pyx_FusedFunction_New(&__pyx_fuse_1__pyx_mdef_5skbio_5stats_10ordination_7_cutils_15f_matrix_inplace_cy, 0, __pyx_n_s_f_matrix_inplace_cy, NULL, __pyx_n_s_skbio_stats_ordination__cutils, __pyx_d, ((PyObject *)__pyx_codeobj__26)); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 81, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __Pyx_CyFunction_SetDefaultsTuple(__pyx_t_1, __pyx_empty_tuple);
-  if (PyDict_SetItem(__pyx_t_2, __pyx_n_s_double, __pyx_t_1) < 0) __PYX_ERR(0, 79, __pyx_L1_error)
+  if (PyDict_SetItem(__pyx_t_2, __pyx_n_s_double, __pyx_t_1) < 0) __PYX_ERR(0, 81, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
-  __pyx_t_1 = __pyx_FusedFunction_New(&__pyx_mdef_5skbio_5stats_10ordination_7_cutils_3f_matrix_inplace_cy, 0, __pyx_n_s_f_matrix_inplace_cy, NULL, __pyx_n_s_skbio_stats_ordination__cutils, __pyx_d, ((PyObject *)__pyx_codeobj__26)); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 79, __pyx_L1_error)
+  __pyx_t_1 = __pyx_FusedFunction_New(&__pyx_mdef_5skbio_5stats_10ordination_7_cutils_3f_matrix_inplace_cy, 0, __pyx_n_s_f_matrix_inplace_cy, NULL, __pyx_n_s_skbio_stats_ordination__cutils, __pyx_d, ((PyObject *)__pyx_codeobj__26)); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 81, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __Pyx_CyFunction_SetDefaultsTuple(__pyx_t_1, __pyx_empty_tuple);
   ((__pyx_FusedFunctionObject *) __pyx_t_1)->__signatures__ = __pyx_t_2;
   __Pyx_GIVEREF(__pyx_t_2);
   __pyx_t_2 = 0;
-  if (PyDict_SetItem(__pyx_d, __pyx_n_s_f_matrix_inplace_cy, __pyx_t_1) < 0) __PYX_ERR(0, 79, __pyx_L1_error)
+  if (PyDict_SetItem(__pyx_d, __pyx_n_s_f_matrix_inplace_cy, __pyx_t_1) < 0) __PYX_ERR(0, 81, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
 
-  /* "skbio/stats/ordination/_cutils.pyx":125
+  /* "skbio/stats/ordination/_cutils.pyx":127
  * @cython.boundscheck(False)
  * @cython.wraparound(False)
  * def center_distance_matrix_cy(TReal[:, ::1] mat, TReal[:, ::1] centered):             # <<<<<<<<<<<<<<
  *     """
  *     Centers a distance matrix.
  */
-  __pyx_t_1 = __Pyx_PyDict_NewPresized(2); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 125, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyDict_NewPresized(2); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 127, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_2 = __pyx_FusedFunction_New(&__pyx_fuse_0__pyx_mdef_5skbio_5stats_10ordination_7_cutils_19center_distance_matrix_cy, 0, __pyx_n_s_center_distance_matrix_cy, NULL, __pyx_n_s_skbio_stats_ordination__cutils, __pyx_d, ((PyObject *)__pyx_codeobj__28)); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 125, __pyx_L1_error)
+  __pyx_t_2 = __pyx_FusedFunction_New(&__pyx_fuse_0__pyx_mdef_5skbio_5stats_10ordination_7_cutils_19center_distance_matrix_cy, 0, __pyx_n_s_center_distance_matrix_cy, NULL, __pyx_n_s_skbio_stats_ordination__cutils, __pyx_d, ((PyObject *)__pyx_codeobj__28)); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 127, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
   __Pyx_CyFunction_SetDefaultsTuple(__pyx_t_2, __pyx_empty_tuple);
-  if (PyDict_SetItem(__pyx_t_1, __pyx_n_s_float, __pyx_t_2) < 0) __PYX_ERR(0, 125, __pyx_L1_error)
+  if (PyDict_SetItem(__pyx_t_1, __pyx_n_s_float, __pyx_t_2) < 0) __PYX_ERR(0, 127, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
-  __pyx_t_2 = __pyx_FusedFunction_New(&__pyx_fuse_1__pyx_mdef_5skbio_5stats_10ordination_7_cutils_21center_distance_matrix_cy, 0, __pyx_n_s_center_distance_matrix_cy, NULL, __pyx_n_s_skbio_stats_ordination__cutils, __pyx_d, ((PyObject *)__pyx_codeobj__28)); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 125, __pyx_L1_error)
+  __pyx_t_2 = __pyx_FusedFunction_New(&__pyx_fuse_1__pyx_mdef_5skbio_5stats_10ordination_7_cutils_21center_distance_matrix_cy, 0, __pyx_n_s_center_distance_matrix_cy, NULL, __pyx_n_s_skbio_stats_ordination__cutils, __pyx_d, ((PyObject *)__pyx_codeobj__28)); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 127, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
   __Pyx_CyFunction_SetDefaultsTuple(__pyx_t_2, __pyx_empty_tuple);
-  if (PyDict_SetItem(__pyx_t_1, __pyx_n_s_double, __pyx_t_2) < 0) __PYX_ERR(0, 125, __pyx_L1_error)
+  if (PyDict_SetItem(__pyx_t_1, __pyx_n_s_double, __pyx_t_2) < 0) __PYX_ERR(0, 127, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
-  __pyx_t_2 = __pyx_FusedFunction_New(&__pyx_mdef_5skbio_5stats_10ordination_7_cutils_5center_distance_matrix_cy, 0, __pyx_n_s_center_distance_matrix_cy, NULL, __pyx_n_s_skbio_stats_ordination__cutils, __pyx_d, ((PyObject *)__pyx_codeobj__28)); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 125, __pyx_L1_error)
+  __pyx_t_2 = __pyx_FusedFunction_New(&__pyx_mdef_5skbio_5stats_10ordination_7_cutils_5center_distance_matrix_cy, 0, __pyx_n_s_center_distance_matrix_cy, NULL, __pyx_n_s_skbio_stats_ordination__cutils, __pyx_d, ((PyObject *)__pyx_codeobj__28)); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 127, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
   __Pyx_CyFunction_SetDefaultsTuple(__pyx_t_2, __pyx_empty_tuple);
   ((__pyx_FusedFunctionObject *) __pyx_t_2)->__signatures__ = __pyx_t_1;
   __Pyx_GIVEREF(__pyx_t_1);
   __pyx_t_1 = 0;
-  if (PyDict_SetItem(__pyx_d, __pyx_n_s_center_distance_matrix_cy, __pyx_t_2) < 0) __PYX_ERR(0, 125, __pyx_L1_error)
+  if (PyDict_SetItem(__pyx_d, __pyx_n_s_center_distance_matrix_cy, __pyx_t_2) < 0) __PYX_ERR(0, 127, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
 
   /* "skbio/stats/ordination/_cutils.pyx":1

--- a/skbio/stats/ordination/_cutils.pyx
+++ b/skbio/stats/ordination/_cutils.pyx
@@ -55,10 +55,10 @@ def e_matrix_means_cy(TReal[:, ::1] mat, TReal[:, ::1] centered, TReal[::1] row_
     assert n_samples == d5
 
     cdef Py_ssize_t row,col
-    cdef TReal row_sum
+    cdef long double row_sum
     cdef TReal el0
 
-    cdef TReal global_sum = 0.0
+    cdef long double global_sum = 0.0
     for row in prange(n_samples, nogil=True):
         row_sum = 0.0
 
@@ -72,7 +72,9 @@ def e_matrix_means_cy(TReal[:, ::1] mat, TReal[:, ::1] centered, TReal[::1] row_
         global_sum += row_sum
         row_means[row] = row_sum/n_samples
 
-    return (global_sum/n_samples)/n_samples
+    cdef TReal global_mean = (global_sum/n_samples)/n_samples
+
+    return global_mean
 
 @cython.boundscheck(False)
 @cython.wraparound(False)

--- a/skbio/stats/ordination/_cutils.pyx
+++ b/skbio/stats/ordination/_cutils.pyx
@@ -107,11 +107,11 @@ def f_matrix_inplace_cy(TReal[::1] row_means, TReal global_mean, TReal[:, ::1] c
     cdef TReal gr_mean
 
     # use a tiled pattern to maximize locality of row_means
-    for trow in prange(0, n_samples, 512, nogil=True):
-        trow_max = min(trow+512, n_samples)
+    for trow in prange(0, n_samples, 24, nogil=True):
+        trow_max = min(trow+24, n_samples)
 
-        for tcol in range(0, n_samples, 512):
-            tcol_max = min(tcol+512, n_samples)
+        for tcol in range(0, n_samples, 24):
+            tcol_max = min(tcol+24, n_samples)
 
             for row in range(trow, trow_max, 1):
                 gr_mean = global_mean - row_means[row]


### PR DESCRIPTION
Properly tune the tilling in f_matrix_inplace_cy and is_symmetric_and_hollow_cy.

It was too big and was trashing the L1 cache.
Addresses issue #1762 and builds on #1748.

For a 100k*100k matrix on a 16 core Xeon Gold 6242 we go from
center_matrix 50s to 5s
DistanceMatrix validation from 54s to 3.8s

Please complete the following checklist:

* [x] I have read the guidelines in [CONTRIBUTING.md](https://github.com/biocore/scikit-bio/blob/master/CONTRIBUTING.md).

* [x] I have documented all public-facing changes in [CHANGELOG.md](https://github.com/biocore/scikit-bio/blob/master/CHANGELOG.md).

* [ ] **This pull request includes code, documentation, or other content derived from external source(s).** If this is the case, ensure the external source's license is compatible with scikit-bio's [license](https://github.com/biocore/scikit-bio/blob/master/COPYING.txt). Include the license in the `licenses` directory and add a comment in the code giving proper attribution. Ensure any other requirements set forth by the license and/or author are satisfied. **It is your responsibility to disclose code, documentation, or other content derived from external source(s).** If you have questions about whether something can be included in the project or how to give proper attribution, include those questions in your pull request and a reviewer will assist you.

* [x] **This pull request does not include code, documentation, or other content derived from external source(s).**

**Note:** [REVIEWING.md](https://github.com/biocore/scikit-bio/blob/master/REVIEWING.md) may also be helpful to see some of the things code reviewers will be verifying when reviewing your pull request.
