### PR TITLE
remove scikit-learn dependency 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,10 @@
 * scikit-learn has been removed as a dependency. This was a fairly heavy-weight dependency that was providing minor functionality to scikit-bio. The critical components have been implemented in scikit-bio directly, and the non-criticial components are listed under "Backward-incompatible changes [experimental]".
 
 ### Backward-incompatible changes [experimental]
-* With the removal of the scikit-learn dependency, four beta diversity metrics are no longer available. These are `manhatten`, `wminkowski`, `nan_euclidean`, and `haversine`. On testing, `wminkowski` and `haversine` did not work through `skbio.diversity.beta_diversity` (or `sklearn.metrics.pairwise_distances`). The former was deprecated in favor of calling `minkowski` with a vector of weights provided as kwarg `w` , and the latter does not work with data of this shape. `manhattan` and `nan_euclidean` can still be accessed fron scikit-learn directly if a user installs scikit-learn in their environment. For example:
+* With the removal of the scikit-learn dependency, four beta diversity metric names can no longer be specified. These are `manhatten`, `wminkowski`, `nan_euclidean`, and `haversine`. On testing, `wminkowski` and `haversine` did not work through `skbio.diversity.beta_diversity` (or `sklearn.metrics.pairwise_distances`). The former was deprecated in favor of calling `minkowski` with a vector of weights provided as kwarg `w` (example below), and the latter does not work with data of this shape. `manhattan` distance is available as `cityblock`, which is what it's called in SciPy. `nan_euclidean` can still be accessed fron scikit-learn directly if needed, if a user installs scikit-learn in their environment (example below).
 
     ```
+    # accessing nan_euclidean through scikit-learn directly
     import skbio
     from sklearn.metrics import pairwise_distances
     counts = [[23, 64, 14, 0, 0, 3, 1],
@@ -23,11 +24,10 @@
             [88, 31, 0, 5, 5, 5, 5],
             [44, 39, 0, 0, 0, 0, 0]]
 
-    sklearn_dm = pairwise_distances(counts, metric="manhattan")
+    sklearn_dm = pairwise_distances(counts, metric="nan_euclidean")
     skbio_dm = skbio.DistanceMatrix(sklearn_dm)
 
-    pairwise_distances(counts, metric="nan_euclidean")
-
+    # new mechanism of accessing wminkowski
     from skbio.diversity import beta_diversity
     beta_diversity("minkowski", counts, w=[1,1,1,1,1,1,2])
     ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,15 @@
 * scikit-learn has been removed as a dependency. This was a fairly heavy-weight dependency that was providing minor functionality to scikit-bio. The critical components have been implemented in scikit-bio directly, and the non-criticial components are listed under "Backward-incompatible changes [experimental]".
 
 ### Backward-incompatible changes [experimental]
-* With the removal of the scikit-learn dependency, four beta diversity metrics are no longer available. These are `manhatten`, `wminkowski`, `nan_euclidean`, and `haversine`.
+* With the removal of the scikit-learn dependency, four beta diversity metrics are no longer available. These are `manhatten`, `wminkowski`, `nan_euclidean`, and `haversine`. These metrics can now be accessed fron scikit-learn directly. For example:
+
+    ```
+    from skbio import DistanceMatrix
+    from sklearn.metrics import pairwise_distances
+
+    sklearn_dm = pairwise_distances(counts, metric="manhattan")
+    skbio_dm = skbio.DistanceMatrix(sklearn_dm)
+    ```
 
 ## Version 0.5.7
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * Added NCBI taxonomy database dump format (`taxdump`) ([#1810](https://github.com/biocore/scikit-bio/pull/1810)).
 * Added `TreeNode.from_taxdump` for converting taxdump into a tree ([#1810](https://github.com/biocore/scikit-bio/pull/1810)).
+* scikit-learn has been removed as a dependency. This was a fairly heavy-weight dependency that was providing minor functionality to scikit-bio. The critical components have been implemented in scikit-bio directly, and the non-criticial components are listed under "Backward-incompatible changes [experimental]".
+
+### Backward-incompatible changes [experimental]
+* With the removal of the scikit-learn dependency, four beta diversity metrics are no longer available. These are `manhatten`, `wminkowski`, `nan_euclidean`, and `haversine`.
 
 ## Version 0.5.7
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,23 +9,28 @@
 * scikit-learn has been removed as a dependency. This was a fairly heavy-weight dependency that was providing minor functionality to scikit-bio. The critical components have been implemented in scikit-bio directly, and the non-criticial components are listed under "Backward-incompatible changes [experimental]".
 
 ### Backward-incompatible changes [experimental]
-* With the removal of the scikit-learn dependency, four beta diversity metrics are no longer available. These are `manhatten`, `wminkowski`, `nan_euclidean`, and `haversine`. On testing, `wminkowski` and `haversine` did not work through `skbio.diversity.beta_diversity` (or `sklearn.metrics.pairwise_distances`). The former seems to be undefined, and the latter does not work with data of this shape. `manhattan` and `nan_euclidean` can still be accessed fron scikit-learn directly if a user installs scikit-learn in their environment. For example:
+* With the removal of the scikit-learn dependency, four beta diversity metrics are no longer available. These are `manhatten`, `wminkowski`, `nan_euclidean`, and `haversine`. On testing, `wminkowski` and `haversine` did not work through `skbio.diversity.beta_diversity` (or `sklearn.metrics.pairwise_distances`). The former was deprecated in favor of calling `minkowski` with a vector of weights provided as kwarg `w` , and the latter does not work with data of this shape. `manhattan` and `nan_euclidean` can still be accessed fron scikit-learn directly if a user installs scikit-learn in their environment. For example:
 
-```
-import skbio
-from sklearn.metrics import pairwise_distances
-counts = [[23, 64, 14, 0, 0, 3, 1],
-          [0, 3, 35, 42, 0, 12, 1],
-          [0, 5, 5, 0, 40, 40, 0],
-          [44, 35, 9, 0, 1, 0, 0],
-          [0, 2, 8, 0, 35, 45, 1],
-          [0, 0, 25, 35, 0, 19, 0],
-          [88, 31, 0, 5, 5, 5, 5],
-          [44, 39, 0, 0, 0, 0, 0]]
+    ```
+    import skbio
+    from sklearn.metrics import pairwise_distances
+    counts = [[23, 64, 14, 0, 0, 3, 1],
+            [0, 3, 35, 42, 0, 12, 1],
+            [0, 5, 5, 0, 40, 40, 0],
+            [44, 35, 9, 0, 1, 0, 0],
+            [0, 2, 8, 0, 35, 45, 1],
+            [0, 0, 25, 35, 0, 19, 0],
+            [88, 31, 0, 5, 5, 5, 5],
+            [44, 39, 0, 0, 0, 0, 0]]
 
-sklearn_dm = pairwise_distances(counts, metric="manhattan")
-skbio_dm = skbio.DistanceMatrix(sklearn_dm)
-```
+    sklearn_dm = pairwise_distances(counts, metric="manhattan")
+    skbio_dm = skbio.DistanceMatrix(sklearn_dm)
+
+    pairwise_distances(counts, metric="nan_euclidean")
+
+    from skbio.diversity import beta_diversity
+    beta_diversity("minkowski", counts, w=[1,1,1,1,1,1,2])
+    ```
 
 ## Version 0.5.7
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,9 @@
 * scikit-learn has been removed as a dependency. This was a fairly heavy-weight dependency that was providing minor functionality to scikit-bio. The critical components have been implemented in scikit-bio directly, and the non-criticial components are listed under "Backward-incompatible changes [experimental]".
 
 ### Backward-incompatible changes [experimental]
-* With the removal of the scikit-learn dependency, four beta diversity metric names can no longer be specified. These are `manhatten`, `wminkowski`, `nan_euclidean`, and `haversine`. On testing, `wminkowski` and `haversine` did not work through `skbio.diversity.beta_diversity` (or `sklearn.metrics.pairwise_distances`). The former was deprecated in favor of calling `minkowski` with a vector of weights provided as kwarg `w` (example below), and the latter does not work with data of this shape. `manhattan` distance is available as `cityblock`, which is what it's called in SciPy. `nan_euclidean` can still be accessed fron scikit-learn directly if needed, if a user installs scikit-learn in their environment (example below).
+* With the removal of the scikit-learn dependency, three beta diversity metric names can no longer be specified. These are `wminkowski`, `nan_euclidean`, and `haversine`. On testing, `wminkowski` and `haversine` did not work through `skbio.diversity.beta_diversity` (or `sklearn.metrics.pairwise_distances`). The former was deprecated in favor of calling `minkowski` with a vector of weights provided as kwarg `w` (example below), and the latter does not work with data of this shape. `nan_euclidean` can still be accessed fron scikit-learn directly if needed, if a user installs scikit-learn in their environment (example below).
 
     ```
-    # accessing nan_euclidean through scikit-learn directly
-    import skbio
-    from sklearn.metrics import pairwise_distances
     counts = [[23, 64, 14, 0, 0, 3, 1],
             [0, 3, 35, 42, 0, 12, 1],
             [0, 5, 5, 0, 40, 40, 0],
@@ -24,12 +21,15 @@
             [88, 31, 0, 5, 5, 5, 5],
             [44, 39, 0, 0, 0, 0, 0]]
 
-    sklearn_dm = pairwise_distances(counts, metric="nan_euclidean")
-    skbio_dm = skbio.DistanceMatrix(sklearn_dm)
-
     # new mechanism of accessing wminkowski
     from skbio.diversity import beta_diversity
     beta_diversity("minkowski", counts, w=[1,1,1,1,1,1,2])
+
+    # accessing nan_euclidean through scikit-learn directly
+    import skbio
+    from sklearn.metrics import pairwise_distances
+    sklearn_dm = pairwise_distances(counts, metric="nan_euclidean")
+    skbio_dm = skbio.DistanceMatrix(sklearn_dm)
     ```
 
 ## Version 0.5.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,15 +9,23 @@
 * scikit-learn has been removed as a dependency. This was a fairly heavy-weight dependency that was providing minor functionality to scikit-bio. The critical components have been implemented in scikit-bio directly, and the non-criticial components are listed under "Backward-incompatible changes [experimental]".
 
 ### Backward-incompatible changes [experimental]
-* With the removal of the scikit-learn dependency, four beta diversity metrics are no longer available. These are `manhatten`, `wminkowski`, `nan_euclidean`, and `haversine`. These metrics can now be accessed fron scikit-learn directly. For example:
+* With the removal of the scikit-learn dependency, four beta diversity metrics are no longer available. These are `manhatten`, `wminkowski`, `nan_euclidean`, and `haversine`. On testing, `wminkowski` and `haversine` did not work through `skbio.diversity.beta_diversity` (or `sklearn.metrics.pairwise_distances`). The former seems to be undefined, and the latter does not work with data of this shape. `manhattan` and `nan_euclidean` can still be accessed fron scikit-learn directly if a user installs scikit-learn in their environment. For example:
 
-    ```
-    from skbio import DistanceMatrix
-    from sklearn.metrics import pairwise_distances
+```
+import skbio
+from sklearn.metrics import pairwise_distances
+counts = [[23, 64, 14, 0, 0, 3, 1],
+          [0, 3, 35, 42, 0, 12, 1],
+          [0, 5, 5, 0, 40, 40, 0],
+          [44, 35, 9, 0, 1, 0, 0],
+          [0, 2, 8, 0, 35, 45, 1],
+          [0, 0, 25, 35, 0, 19, 0],
+          [88, 31, 0, 5, 5, 5, 5],
+          [44, 39, 0, 0, 0, 0, 0]]
 
-    sklearn_dm = pairwise_distances(counts, metric="manhattan")
-    skbio_dm = skbio.DistanceMatrix(sklearn_dm)
-    ```
+sklearn_dm = pairwise_distances(counts, metric="manhattan")
+skbio_dm = skbio.DistanceMatrix(sklearn_dm)
+```
 
 ## Version 0.5.7
 

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ endif
 # simulate a user's install/test process this way to find package data that did
 # not install correctly (for example).
 test:
+	cd ci && $(TEST_COMMAND) && cd -
 	flake8 skbio setup.py checklist.py
 	./checklist.py
-	cd ci && $(TEST_COMMAND) && cd -
 	check-manifest

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ endif
 # simulate a user's install/test process this way to find package data that did
 # not install correctly (for example).
 test:
-	cd ci && $(TEST_COMMAND) && cd -
 	flake8 skbio setup.py checklist.py
 	./checklist.py
+	cd ci && $(TEST_COMMAND) && cd -
 	check-manifest

--- a/ci/conda_requirements.txt
+++ b/ci/conda_requirements.txt
@@ -9,7 +9,6 @@ pyflakes
 flake8
 python-dateutil
 decorator
-scikit-learn
 pytest
 coverage
 h5py >= 3.6.0

--- a/setup.py
+++ b/setup.py
@@ -155,7 +155,6 @@ setup(name='scikit-bio',
           'scipy >= 1.3.0',
           'h5py >= 2.9.0',
           'hdmedians >= 0.14.1',
-          'scikit-learn >= 0.19.1',
           'h5py'
       ],
       classifiers=classifiers,

--- a/skbio/diversity/_driver.py
+++ b/skbio/diversity/_driver.py
@@ -298,6 +298,7 @@ _valid_beta_metrics = [
     "jaccard",
     "kulsinski",
     "mahalanobis",
+    "manhattan", # aliases to "cityblock" in beta_diversity
     "matching",
     "minkowski",
     "rogerstanimoto",
@@ -409,6 +410,8 @@ def beta_diversity(metric, counts, ids=None, validate=True, pairwise_func=None,
             counts, otu_ids=otu_ids, tree=tree, normalized=normalized,
             validate=validate)
         counts = counts_by_node
+    elif metric == "manhattan":
+        metric = "cityblock"
     elif callable(metric):
         metric = functools.partial(metric, **kwargs)
         # remove all values from kwargs, since they have already been provided
@@ -419,9 +422,10 @@ def beta_diversity(metric, counts, ids=None, validate=True, pairwise_func=None,
     elif metric not in _valid_beta_metrics:
         raise ValueError(
             "Metric %s is not available. "
-            "beta_diversity is only compatible with the following metrics as "
-            "we know whether each should be treated as a qualitative or "
-            "quantitative metric. Available metrics are: %s"
+            "Only the following metrics can be passed as strings to "
+            "beta_diversity as we know whether each of these should be "
+            "treated as a qualitative or quantitative metric. Other metrics "
+            "can be provided as functions.\n Available metrics are: %s"
             % (metric, ', '.join(_valid_beta_metrics)))
     else:
         # metric is a string that scikit-bio doesn't know about, for

--- a/skbio/diversity/_driver.py
+++ b/skbio/diversity/_driver.py
@@ -298,7 +298,7 @@ _valid_beta_metrics = [
     "jaccard",
     "kulsinski",
     "mahalanobis",
-    "manhattan", # aliases to "cityblock" in beta_diversity
+    "manhattan",  # aliases to "cityblock" in beta_diversity
     "matching",
     "minkowski",
     "rogerstanimoto",

--- a/skbio/diversity/_driver.py
+++ b/skbio/diversity/_driver.py
@@ -10,7 +10,7 @@ import functools
 import itertools
 
 import numpy as np
-import sklearn.metrics
+import scipy.spatial.distance
 import pandas as pd
 
 import skbio
@@ -21,7 +21,8 @@ from skbio.diversity.beta._unifrac import (
 from skbio.util._decorator import experimental, deprecated
 from skbio.stats.distance import DistanceMatrix
 from skbio.diversity._util import (_validate_counts_matrix,
-                                   _get_phylogenetic_kwargs)
+                                   _get_phylogenetic_kwargs,
+                                   _quantitative_to_qualitative_counts)
 
 
 def _get_alpha_diversity_metric_map():
@@ -246,6 +247,7 @@ def partial_beta_diversity(metric, counts, ids, id_pairs, validate=True,
         raise ValueError("A duplicate or a self-self pair was observed.")
 
     if metric == 'unweighted_unifrac':
+        counts = _quantitative_to_qualitative_counts(counts)
         otu_ids, tree, kwargs = _get_phylogenetic_kwargs(counts, **kwargs)
         metric, counts_by_node = _setup_multiple_unweighted_unifrac(
             counts, otu_ids=otu_ids, tree=tree, validate=validate)
@@ -277,6 +279,48 @@ def partial_beta_diversity(metric, counts, ids, id_pairs, validate=True,
         dm[u, v] = metric(counts[u], counts[v], **kwargs)
 
     return DistanceMatrix(dm + dm.T, ids)
+
+
+# The following two lists are adapted from sklearn.metrics.pairwise. Metrics
+# that are not available in SciPy (only in sklearn) have been removed from
+# the list of _valid_beta_metrics here (those are: manhatten, wminkowski,
+# nan_euclidean, and haversine)
+_valid_beta_metrics = [
+    "euclidean",
+    "cityblock",
+    "braycurtis",
+    "canberra",
+    "chebyshev",
+    "correlation",
+    "cosine",
+    "dice",
+    "hamming",
+    "jaccard",
+    "kulsinski",
+    "mahalanobis",
+    "matching",
+    "minkowski",
+    "rogerstanimoto",
+    "russellrao",
+    "seuclidean",
+    "sokalmichener",
+    "sokalsneath",
+    "sqeuclidean",
+    "yule",
+]
+
+
+_qualitative_beta_metrics = [
+    "dice",
+    "jaccard",
+    "kulsinski",
+    "matching",
+    "rogerstanimoto",
+    "russellrao",
+    "sokalmichener",
+    "sokalsneath",
+    "yule"
+]
 
 
 @experimental(as_of="0.4.0")
@@ -312,7 +356,7 @@ def beta_diversity(metric, counts, ids=None, validate=True, pairwise_func=None,
         ``numpy.ndarray`` of dissimilarities (floats). Examples of functions
         that can be provided are ``scipy.spatial.distance.pdist`` and
         ``sklearn.metrics.pairwise_distances``. By default,
-        ``sklearn.metrics.pairwise_distances`` will be used.
+        ``scipy.spatial.distance.pdist`` will be used.
     kwargs : kwargs, optional
         Metric-specific parameters.
 
@@ -350,6 +394,7 @@ def beta_diversity(metric, counts, ids=None, validate=True, pairwise_func=None,
         return DistanceMatrix(np.zeros((len(ids), len(ids))), ids)
 
     if metric == 'unweighted_unifrac':
+        counts = _quantitative_to_qualitative_counts(counts)
         otu_ids, tree, kwargs = _get_phylogenetic_kwargs(counts, **kwargs)
         metric, counts_by_node = _setup_multiple_unweighted_unifrac(
             counts, otu_ids=otu_ids, tree=tree, validate=validate)
@@ -369,13 +414,22 @@ def beta_diversity(metric, counts, ids=None, validate=True, pairwise_func=None,
         # remove all values from kwargs, since they have already been provided
         # through the partial
         kwargs = {}
+    elif metric in _qualitative_beta_metrics:
+        counts = _quantitative_to_qualitative_counts(counts)
+    elif metric not in _valid_beta_metrics:
+        raise ValueError(
+            "Metric %s is not available. "
+            "beta_diversity is only compatible with the following metrics as "
+            "we know whether each should be treated as a qualitative or "
+            "quantitative metric. Available metrics are: %s"
+            % (metric, ', '.join(_valid_beta_metrics)))
     else:
         # metric is a string that scikit-bio doesn't know about, for
         # example one of the SciPy metrics
         pass
 
     if pairwise_func is None:
-        pairwise_func = sklearn.metrics.pairwise_distances
+        pairwise_func = scipy.spatial.distance.pdist
 
     distances = pairwise_func(counts, metric=metric, **kwargs)
     return DistanceMatrix(distances, ids)

--- a/skbio/diversity/_util.py
+++ b/skbio/diversity/_util.py
@@ -149,3 +149,7 @@ def _get_phylogenetic_kwargs(counts, **kwargs):
                          "metrics.")
 
     return otu_ids, tree, kwargs
+
+
+def _quantitative_to_qualitative_counts(counts):
+    return counts > 0.0

--- a/skbio/diversity/tests/test_driver.py
+++ b/skbio/diversity/tests/test_driver.py
@@ -22,6 +22,8 @@ from skbio.diversity import (alpha_diversity, beta_diversity,
 from skbio.diversity.alpha import faith_pd, observed_otus
 from skbio.diversity.beta import unweighted_unifrac, weighted_unifrac
 from skbio.tree import DuplicateNodeError, MissingNodeError
+from skbio.diversity._driver import (_qualitative_beta_metrics,
+                                     _valid_beta_metrics)
 
 
 class AlphaDiversityTests(TestCase):
@@ -281,15 +283,34 @@ class BetaDiversityTests(TestCase):
                        [0, 0, 25, 35, 0, 19, 0]]
         self.sids2 = list('ABCDEF')
 
+        self.table3 = [[23, 64, 14, 0, 0, 3, 1],
+                       [0, 3, 35, 42, 0, 12, 1],
+                       [0, 5, 5, 0, 40, 40, 0],
+                       [44, 35, 9, 0, 1, 0, 0],
+                       [0, 2, 8, 0, 35, 45, 1],
+                       [0, 0, 25, 35, 0, 19, 0],
+                       [88, 31, 0, 5, 5, 5, 5],
+                       [44, 39, 0, 0, 0, 0, 0]]
+
+    def test_available_metrics(self):
+
+        for metric in _valid_beta_metrics:
+            try:
+                beta_diversity(metric, self.table3)
+            except Exception as exc:
+                raise ValueError(
+                    f'Metric {metric} failed with exception:\n {exc}')
+
     def test_qualitative_bug_issue_1549(self):
-        mat = np.array([[42, 0, 37, 99, 1],
-                        [12, 1, 22, 88, 0],
-                        [25, 3, 23, 86, 0],
-                        [0, 0, 87, 12, 0]])
-        as_presence_absence = mat > 0
-        obs_mat = beta_diversity('jaccard', mat)
-        obs_presence_absence = beta_diversity('jaccard', as_presence_absence)
-        self.assertEqual(obs_mat, obs_presence_absence)
+        as_presence_absence = np.asarray(self.table3) > 0
+
+        for metric in _valid_beta_metrics:
+            obs_mat = beta_diversity(metric, self.table3)
+            obs_presence_absence = beta_diversity(metric, as_presence_absence)
+            if metric in _qualitative_beta_metrics:
+                self.assertEqual(obs_mat, obs_presence_absence)
+            else:
+                self.assertNotEqual(obs_mat, obs_presence_absence)
 
     def test_invalid_input(self):
         # number of ids doesn't match the number of samples
@@ -315,7 +336,7 @@ class BetaDiversityTests(TestCase):
             beta_diversity('euclidean', [[0, 1, 3, -4], [0, 3, 12, 42]])
 
         # additional kwargs
-        error_msg = r"keyword argument"
+        error_msg = r"argument"
         with self.assertRaisesRegex(TypeError, error_msg):
             beta_diversity('euclidean', [[0, 1, 3], [0, 3, 12]],
                            not_a_real_kwarg=42.0)

--- a/skbio/diversity/tests/test_util.py
+++ b/skbio/diversity/tests/test_util.py
@@ -17,7 +17,8 @@ from skbio import TreeNode
 from skbio.diversity._util import (_validate_counts_vector,
                                    _validate_counts_matrix,
                                    _validate_otu_ids_and_tree,
-                                   _vectorize_counts_and_tree)
+                                   _vectorize_counts_and_tree,
+                                   _quantitative_to_qualitative_counts)
 from skbio.tree import DuplicateNodeError, MissingNodeError
 
 
@@ -249,6 +250,17 @@ class ValidationTests(TestCase):
             _vectorize_counts_and_tree(counts, np.array(['a', 'b']), t)
         exp_counts = np.array([[0, 1, 10], [1, 5, 1], [1, 6, 11], [1, 6, 11]])
         npt.assert_equal(count_array, exp_counts.T)
+
+    def test_quantitative_to_qualitative_counts(self):
+        counts = np.array([[0, 1], [1, 5], [10, 1]])
+        exp = np.array([[False, True], [True, True], [True, True]])
+        obs = _quantitative_to_qualitative_counts(counts)
+        npt.assert_equal(obs, exp)
+
+        counts = np.array([[0, 0, 0], [1, 0, 42]])
+        exp = np.array([[False, False, False], [True, False, True]])
+        obs = _quantitative_to_qualitative_counts(counts)
+        npt.assert_equal(obs, exp)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
scikit-learn has been removed as a dependency. This was a fairly heavy-weight dependency that was providing minor functionality to scikit-bio. The critical components have been implemented in scikit-bio directly. 

The other change that comes along with this is that three beta diversity metrics that were provided by sklearn are no longer available. These are `wminkowski`, `nan_euclidean`, and `haversine`. On testing, `wminkowski` and `haversine` did not work through `skbio.diversity.beta_diversity` (or `sklearn.metrics.pairwise_distances`). The former was deprecated in favor of calling `minkowski` with a vector of weights provided as kwarg `w` , and the latter does not work with data of this shape. `nan_euclidean` can still be accessed from scikit-learn directly if a user installs scikit-learn in their environment. For example:

```python
import skbio
from sklearn.metrics import pairwise_distances
counts = [[23, 64, 14, 0, 0, 3, 1],
        [0, 3, 35, 42, 0, 12, 1],
        [0, 5, 5, 0, 40, 40, 0],
        [44, 35, 9, 0, 1, 0, 0],
        [0, 2, 8, 0, 35, 45, 1],
        [0, 0, 25, 35, 0, 19, 0],
        [88, 31, 0, 5, 5, 5, 5],
        [44, 39, 0, 0, 0, 0, 0]]

sklearn_dm = pairwise_distances(counts, metric="nan_euclidean")
skbio_dm = skbio.DistanceMatrix(sklearn_dm)

from skbio.diversity import beta_diversity
beta_diversity("minkowski", counts, w=[1,1,1,1,1,1,2])
```

addresses #1827