### PR TITLE
DOC: update autosummary templates to avoid double entry

### DIFF
--- a/doc/source/_templates/autosummary/module.rst
+++ b/doc/source/_templates/autosummary/module.rst
@@ -1,61 +1,19 @@
-{{ fullname | escape | underline}}
+..
+  The extra blocks seem to be required for autosummary to populate our
+  docstrings correctly. In the original template, these would recusively call
+  autosummary again, but we already do that in the narratively convenient
+  places.
 
 .. automodule:: {{ fullname }}
 
    {% block attributes %}
-   {% if attributes %}
-   .. rubric:: {{ _('Module Attributes') }}
-
-   .. autosummary::
-   {% for item in attributes %}
-      {{ item }}
-   {%- endfor %}
-   {% endif %}
    {% endblock %}
 
    {% block functions %}
-   {% if functions %}
-   .. rubric:: {{ _('Functions') }}
-
-   .. autosummary::
-   {% for item in functions %}
-      {{ item }}
-   {%- endfor %}
-   {% endif %}
    {% endblock %}
 
    {% block classes %}
-   {% if classes %}
-   .. rubric:: {{ _('Classes') }}
-
-   .. autosummary::
-   {% for item in classes %}
-      {{ item }}
-   {%- endfor %}
-   {% endif %}
    {% endblock %}
 
    {% block exceptions %}
-   {% if exceptions %}
-   .. rubric:: {{ _('Exceptions') }}
-
-   .. autosummary::
-   {% for item in exceptions %}
-      {{ item }}
-   {%- endfor %}
-   {% endif %}
    {% endblock %}
-
-{% block modules %}
-{% if modules %}
-.. rubric:: Modules
-
-.. autosummary::
-   :toctree:
-   :recursive:
-{% for item in modules %}
-   {{ item }}
-{%- endfor %}
-{% endif %}
-{% endblock %}
-


### PR DESCRIPTION
Docs now look the same as the last release, and even work with the current sphinx alpha release to boot.