### PR TITLE
deprecate local_pairwise_align_ssw

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@
     skbio_dm = skbio.DistanceMatrix(sklearn_dm)
     ```
 
+### Deprecated functionality [experimental]
+* `skbio.alignment.local_pairwise_align_ssw` has been deprecated ([#1814](https://github.com/biocore/scikit-bio/issues/1814)) and will be removed or replaced in scikit-bio 0.6.0.
+
 ## Version 0.5.7
 
 ### Features

--- a/skbio/alignment/_pairwise.py
+++ b/skbio/alignment/_pairwise.py
@@ -641,7 +641,10 @@ def global_pairwise_align(seq1, seq2, gap_open_penalty, gap_extend_penalty,
     return msa, score, start_end_positions
 
 
-@experimental(as_of="0.4.0")
+@deprecated(as_of="0.5.8", until="0.6.0",
+            reason="This will be removed or replaced, in favor of more general"
+                   "-purpose performant aligners. Additional details at "
+                   "https://github.com/biocore/scikit-bio/issues/1814")
 def local_pairwise_align_ssw(sequence1, sequence2, **kwargs):
     """Align query and target sequences with Striped Smith-Waterman.
 


### PR DESCRIPTION
Addresses #1814. 

Example: 

```python
In [1]: import warnings

In [2]: warnings.simplefilter('default')

In [3]: from skbio import DNA

In [4]: from skbio.alignment import local_pairwise_align_ssw

In [5]: local_pairwise_align_ssw(DNA('ACCGTTGAC'), DNA('CAGGTAGT'))
/Users/gregcaporaso/Documents/code/scikit-bio/skbio/util/_decorator.py:254: DeprecationWarning: local_pairwise_align_ssw is deprecated as of scikit-bio version 0.5.8, and will be removed in version 0.6.0. This will be removed or replaced, in favor of more general-purpose performant aligners. Additional details at https://github.com/biocore/scikit-bio/issues/1814
...
```