### PR TITLE
Fix installation process by disallowing Cython version 3.0 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["Cython>=0.29.32", "numpy>=1.9.2", "setuptools", "wheel"]
+requires = ["Cython>=0.29.32, <3.0.0", "numpy>=1.9.2", "setuptools", "wheel"]
 
 [tool.pytest.ini_options]
 filterwarnings = [


### PR DESCRIPTION
Cython released [a major update (3.0)](https://pypi.org/project/Cython/#history) last week, which among other things changed `/-division uses the true (float) division operator, unless cdivision is enabled.` 

This new version - and given the error, probably related to this specific change - leads to the following compile error when attempting to install scikit-bio via Poetry:

```
        [1/6] Cythonizing skbio/alignment/_ssw_wrapper.pyx
        /tmp/pip-build-env-xsru6wu_/overlay/lib/python3.8/site-packages/Cython/Compiler/Main.py:381: FutureWarning: Cython directive 'language_level' not set, using '3str' for now (Py3). This has changed from earlier releases! File: /tmp/pip-req-build-7o17y4ab/skbio/alignment/_ssw_wrapper.pyx
          tree = Parsing.p_module(s, pxd, full_module_name)
        
        Error compiling Cython file:
        ------------------------------------------------------------
        ...
                else:
                    matrix = self._convert_dict2d_to_matrix(substitution_matrix)
                # Set up our mask_length
                # Mask is recommended to be max(query_sequence/2, 15)
                if mask_auto:
                    self.mask_length = len(query_sequence) / 2
                                                           ^
        ------------------------------------------------------------
        
        skbio/alignment/_ssw_wrapper.pyx:584:51: Cannot assign type 'double' to 'int32_t'
```

The solution to this is to limit the Cython version used in the build process to 0.29 versions only - this is the quickest fix possible to allow users to continue installing scikit-bio.

A more knowledgeable person than I would be needed to enable compatibility with Cython 3.0 :)

---

* [x] I have read the guidelines in [CONTRIBUTING.md](https://github.com/biocore/scikit-bio/blob/master/.github/CONTRIBUTING.md).

* [x] I have documented all public-facing changes in [CHANGELOG.md](https://github.com/biocore/scikit-bio/blob/master/CHANGELOG.md).

* [ ] **This pull request includes code, documentation, or other content derived from external source(s).** If this is the case, ensure the external source's license is compatible with scikit-bio's [license](https://github.com/biocore/scikit-bio/blob/master/LICENSE.txt). Include the license in the `licenses` directory and add a comment in the code giving proper attribution. Ensure any other requirements set forth by the license and/or author are satisfied. **It is your responsibility to disclose code, documentation, or other content derived from external source(s).** If you have questions about whether something can be included in the project or how to give proper attribution, include those questions in your pull request and a reviewer will assist you.

* [x] **This pull request does not include code, documentation, or other content derived from external source(s).**
