### PR TITLE
Fix dtype mismatch in `_nodes_by_counts()` on 32-bit arch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * Fixed IO format `binary_dm` implementation, was completely broken before ([#2282](https://github.com/scikit-bio/scikit-bio/pull/2282),[#2283](https://github.com/scikit-bio/scikit-bio/pull/2283)).
 * Fixed a bug in reading binary dissimilarity matrix format (`io.format.binary_dm`), that a float32 data file would be unnecessarily casted into float64 ([#2230](https://github.com/scikit-bio/scikit-bio/pull/2230)).
 * Replace "Correspondance Analysis" with "Correspondence Analysis" in creating `OrdinationResults` objects for the accuracy of terminology. This term has been "Correspondence Analysis" otherwise in the project.
+* Fixed a runtime error when computing phylogenetic diversity metrics on 32-bit architectures.
 
 ### Miscellaneous
 

--- a/skbio/diversity/_phylogenetic.pyx
+++ b/skbio/diversity/_phylogenetic.pyx
@@ -10,7 +10,7 @@ import numpy as np
 cimport numpy as np
 cimport cython
 
-DTYPE = np.int64
+DTYPE = np.intp
 ctypedef np.npy_intp intp_t
 
 @cython.boundscheck(False)


### PR DESCRIPTION
When running `skbio.diversity._phylogenetic._nodes_by_counts()` on 32-bit architecture (e.g. Pyodide/WebAssembly), an error is raised due to dtype mismatch between 32-bit and 64-bit pointers:

```
ValueError: Buffer dtype mismatch, expected 'intp_t' but got 'long long'
```

Changing the dtype from `np.int64` to `np.intp` fixes the error.

---

Please complete the following checklist:

* [x] I have read the [contribution guidelines](https://scikit.bio/contribute.html).

* [x] I have documented all public-facing changes in the [changelog](https://github.com/scikit-bio/scikit-bio/blob/main/CHANGELOG.md).

* [x] This pull request does not include code, documentation, or other content derived from external source(s).