### PR TITLE
Update macOS version used in ci workflows for x86 architectures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,7 @@ jobs:
       # about-github-hosted-runners/about-github-hosted-runners#standard-
       # github-hosted-runners-for-public-repositories
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest, ubuntu-24.04-arm, macos-13]
+        os: [ubuntu-latest, macos-latest, windows-latest, ubuntu-24.04-arm, macos-15-intel]
     steps:
       - uses: actions/checkout@v4
       - uses: conda-incubator/setup-miniconda@v3

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, windows-11-arm, macos-13, macos-latest]
+        os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, windows-11-arm, macos-15-intel, macos-latest]
         # The 6 runners correspond to 6 architectures. Details:
         # https://cibuildwheel.pypa.io/en/stable/options/#archs
         # The runners and architectures should be automatically associated. However, in
@@ -29,7 +29,7 @@ jobs:
         #     cibw_archs: 'AMD64'
         #   - os: windows-11-arm
         #     cibw_archs: 'ARM64'
-        #   - os: macos-13
+        #   - os: macos-15-intel
         #     cibw_archs: 'x86_64'
         #   - os: macos-latest
         #     cibw_archs: 'arm64'


### PR DESCRIPTION
[`macos-13`](https://github.com/actions/runner-images/issues/13046) is being deprecated in GitHub Actions. They are introducing the new [`macos-15-intel`](https://github.com/actions/runner-images/issues/13045) runner for x86_64 support for macOS. It will be supported until August 2027, at which point GitHub Actions will no longer support macOS on x86_64 architecture.


Please complete the following checklist:

* [x] I have read the [contribution guidelines](https://scikit.bio/contribute.html).

* [ ] I have documented all public-facing changes in the [changelog](https://github.com/scikit-bio/scikit-bio/blob/main/CHANGELOG.md).

* [ ] **This pull request includes code, documentation, or other content derived from external source(s).** If this is the case, ensure the external source's license is compatible with scikit-bio's [license](https://github.com/scikit-bio/scikit-bio/blob/main/LICENSE.txt). Include the license in the `licenses` directory and add a comment in the code giving proper attribution. Ensure any other requirements set forth by the license and/or author are satisfied.

  - **It is your responsibility to disclose** code, documentation, or other content derived from external source(s). If you have questions about whether something can be included in the project or how to give proper attribution, include those questions in your pull request and a reviewer will assist you.

* [x] This pull request does not include code, documentation, or other content derived from external source(s).

Note: [This document](https://scikit.bio/devdoc/review.html) may also be helpful to see some of the things code reviewers will be verifying when reviewing your pull request.
