### PR TITLE
Removed autosummary signatures from documentation

### DIFF
--- a/doc/source/autoinherit.py
+++ b/doc/source/autoinherit.py
@@ -6,16 +6,25 @@
 # The full license is in the file LICENSE.txt, distributed with this software.
 # ----------------------------------------------------------------------------
 
-# Custom class to patch Sphinx extension "autosummary". When applied to the
-# inherited members of a class, this patch automatically trace up to the base
-# class from which each member is inherited, and create a link to the stub
-# page of the base class' member.
-
-from sphinx.ext.autosummary import Autosummary
 from sphinx.util.inspect import safe_getattr
 
 
 def trace_inherit(name, real_name):
+    """Trace the base class from which a member is inherited.
+
+    Parameters
+    ----------
+    name : str
+        Public name of the member.
+    real_name : str
+        True import path of the member.
+
+    Returns
+    -------
+    str
+        Import path of the member from the base class.
+
+    """
     # `real_name` is the full path to the member, such as:
     #   skbio.sequence.DNA.frequencies
     # It can be split into:
@@ -73,13 +82,3 @@ def trace_inherit(name, real_name):
     # Eventually, it returns:
     #   skbio.sequence.Sequence.frequencies
     return ".".join(path + [origin.__name__, name])
-
-
-class InheritedAutosummary(Autosummary):
-    def get_items(self, names):
-        items = super().get_items(names)
-        new_items = []
-        for name, sig, summary, real_name in items:
-            origin = trace_inherit(name, real_name)
-            new_items.append((name, sig, summary, origin or real_name))
-        return new_items


### PR DESCRIPTION
This PR changes the visual flavor of the [documentation](https://scikit.bio/docs/dev/index.html): Signatures of each member (class, function, method, etc.) are no longer displayed in the table of content (toc) trees. This saves screen space and makes the pages less verbose (noisy), especially on mobile devices.

It seems that multiple very basic packages (such as SciPy, Pandas and Matplotlib) display signatures, whereas some more downstream packages (such as scikit-learn, ScanPy, Biotite) hide signatures.

Afterall, this is a matter of design flavor. Not necessarily an improvement.

Original:
<img width="321" height="694.5" alt="origin" src="https://github.com/user-attachments/assets/8612d5c3-4db5-4d1f-88d0-212178257a07" />

Signatures removed:
<img width="321" height="694.5" alt="nosig" src="https://github.com/user-attachments/assets/a48a5c2f-1b6a-4892-b555-05eebc55f0b5" />

===

Please complete the following checklist:

* [x] I have read the [contribution guidelines](https://scikit.bio/contribute.html).

* [ ] I have documented all public-facing changes in the [changelog](https://github.com/scikit-bio/scikit-bio/blob/main/CHANGELOG.md).

* [ ] **This pull request includes code, documentation, or other content derived from external source(s).** If this is the case, ensure the external source's license is compatible with scikit-bio's [license](https://github.com/scikit-bio/scikit-bio/blob/main/LICENSE.txt). Include the license in the `licenses` directory and add a comment in the code giving proper attribution. Ensure any other requirements set forth by the license and/or author are satisfied.

  - **It is your responsibility to disclose** code, documentation, or other content derived from external source(s). If you have questions about whether something can be included in the project or how to give proper attribution, include those questions in your pull request and a reviewer will assist you.

* [x] This pull request does not include code, documentation, or other content derived from external source(s).

Note: [This document](https://scikit.bio/devdoc/review.html) may also be helpful to see some of the things code reviewers will be verifying when reviewing your pull request.
