### PR TITLE
Refactor abstract validation logic in GrammaredSequenceMeta

### DIFF
--- a/skbio/sequence/_grammared_sequence.py
+++ b/skbio/sequence/_grammared_sequence.py
@@ -22,26 +22,12 @@ class GrammaredSequenceMeta(ABCMeta, type):
     def __new__(mcs, name, bases, dct):
         cls = super(GrammaredSequenceMeta, mcs).__new__(mcs, name, bases, dct)
 
-        concrete_gap_chars = type(cls.gap_chars) is not abstractproperty
-        concrete_degenerate_map = type(cls.degenerate_map) is not abstractproperty
-        concrete_definite_chars = type(cls.definite_chars) is not abstractproperty
-        concrete_default_gap_char = type(cls.default_gap_char) is not abstractproperty
-        # degenerate_chars is not abstract but it depends on degenerate_map
-        # which is abstract.
-        concrete_degenerate_chars = concrete_degenerate_map
+        is_concrete = not getattr(cls, "__abstractmethods__", set())
 
-        # Only perform metaclass checks if none of the attributes on the class
-        # are abstract.
-        # TODO: Rather than hard-coding a list of attributes to check, we can
-        # probably check all the attributes on the class and make sure none of
-        # them are abstract.
-        if (
-            concrete_gap_chars
-            and concrete_degenerate_map
-            and concrete_definite_chars
-            and concrete_default_gap_char
-            and concrete_degenerate_chars
-        ):
+        # Perform metaclass validation only when the class is concrete.
+        # We rely on ABCMeta's __abstractmethods__ to determine whether
+        # any abstract attributes remain unimplemented.
+        if is_concrete:
             if cls.default_gap_char not in cls.gap_chars:
                 raise TypeError(
                     "default_gap_char must be in gap_chars for class %s" % name


### PR DESCRIPTION
Please complete the following checklist:

* [x] I have read the [contribution guidelines](https://scikit.bio/contribute.html).

* [ ] I have documented all public-facing changes in the [changelog](https://github.com/scikit-bio/scikit-bio/blob/main/CHANGELOG.md).

* [x] This pull request does not include code, documentation, or other content derived from external source(s).


### Summary:
This PR simplifies how GrammaredSequenceMeta determines whether a class is concrete before performing metaclass validation.

- Removed manual checks of individual abstract attributes.

- Replaced hard-coded logic with:

<pre>is_concrete = not getattr(cls, "__abstractmethods__", set())</pre>

- Updates comments to clarify reliance on ABCMeta.

- Leaves existing abstractproperty usage unchanged.

### Rationale & Impact

This change improves maintainability by delegating abstract class detection to Python’s built-in ABCMeta instead of relying on fragile, hard-coded attribute inspection. It reduces duplication of abstraction logic and makes the codebase easier to extend in the future.

There are no functional or behavioral changes. Concrete subclasses are validated as before, abstract subclasses remain abstract, and all existing tests continue to pass.