### PR TITLE
Add biweekly testing job to wheels

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -5,6 +5,8 @@ on:
     branches: [ main ]
   workflow_dispatch:
   workflow_call:
+  schedule:
+    - cron: "0 7 1,15 * *"
 
 env:
   latest_python: "3.14"
@@ -43,9 +45,9 @@ jobs:
         # This may need to be updated for new Python versions, double check before release.
         uses: pypa/cibuildwheel@v3.2.1
         env:
-        # Run full tests on release or manual trigger, otherwise (i.e. on PRs) do simple import/print test.
+        # Run full tests on release, manual trigger, and schedule (twice a month). Otherwise (i.e. on PRs) do simple import/print test.
           CIBW_TEST_COMMAND: >
-            ${{ ((github.event_name == 'push' && startsWith(github.ref, 'refs/tags')) || github.event_name == 'workflow_dispatch') &&
+            ${{ ((github.event_name == 'push' && startsWith(github.ref, 'refs/tags')) || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule') &&
                 'python -m skbio.test' ||
                 'python -c "import skbio; print(skbio.__version__)"' }}
 


### PR DESCRIPTION
This PR adds a cron job to the `wheels.yml` workflow so that the wheels will be fully unit tested every two weeks instead of waiting until release to fully test the wheels.

Please complete the following checklist:

* [x] I have read the [contribution guidelines](https://scikit.bio/contribute.html).

* [ ] I have documented all public-facing changes in the [changelog](https://github.com/scikit-bio/scikit-bio/blob/main/CHANGELOG.md).

* [ ] **This pull request includes code, documentation, or other content derived from external source(s).** If this is the case, ensure the external source's license is compatible with scikit-bio's [license](https://github.com/scikit-bio/scikit-bio/blob/main/LICENSE.txt). Include the license in the `licenses` directory and add a comment in the code giving proper attribution. Ensure any other requirements set forth by the license and/or author are satisfied.

  - **It is your responsibility to disclose** code, documentation, or other content derived from external source(s). If you have questions about whether something can be included in the project or how to give proper attribution, include those questions in your pull request and a reviewer will assist you.

* [x] This pull request does not include code, documentation, or other content derived from external source(s).

Note: [This document](https://scikit.bio/devdoc/review.html) may also be helpful to see some of the things code reviewers will be verifying when reviewing your pull request.
