### PR TITLE
DOC: document constructor parameter in TabularMSA.read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Version 0.7.3-dev
 
+### Miscellaneous
+
+* Documented the `constructor` parameter in the auto-generated docstring for `TabularMSA.read()`, which is required to specify the sequence type (e.g., `DNA`, `RNA`, `Protein`) ([#2388](https://github.com/scikit-bio/scikit-bio/issues/2388)).
 
 ## Version 0.7.2
 

--- a/skbio/io/descriptors.py
+++ b/skbio/io/descriptors.py
@@ -26,6 +26,7 @@ class Read:
 
     def _make_docstring(self, cls):
         name, supported_fmts, default, see = _docstring_vars(cls, "read")
+        constructor_param = _constructor_param(cls)
         return f"""Create a new ``{name}`` instance from a file.
 
 This is a convenience method for :func:`skbio.io.registry.read`. For more information
@@ -42,7 +43,7 @@ file : openable (filepath, URL, filehandle, etc.)
 format : str, optional
     The format of the file. The format must be a format name with a reader for
     ``{name}``. If None, the format will be inferred.
-kwargs : dict, optional
+{constructor_param}kwargs : dict, optional
     Additional arguments passed to :func:`skbio.io.registry.read()` and the reader for
     ``{name}``.
 
@@ -118,6 +119,19 @@ skbio.io.util.open
 {see}
 
 """
+
+
+def _constructor_param(cls):
+    """Generate constructor parameter docs if the class needs it."""
+    from skbio.alignment._tabular_msa import TabularMSA
+
+    if cls is TabularMSA:
+        return (
+            "constructor : type, required\n"
+            "    The type of sequence to read into. Must be a subclass of\n"
+            "    ``GrammaredSequence`` (e.g., ``DNA``, ``RNA``, ``Protein``).\n"
+        )
+    return ""
 
 
 def _docstring_vars(cls, func):


### PR DESCRIPTION
## What

Document the `constructor` parameter in the auto-generated docstring for `TabularMSA.read()`.

## Why

The current documentation only lists `file`, `format`, and `kwargs`, omitting the required `constructor` parameter. Users following the docs encounter a confusing error when they don't pass `constructor`.

## How

Added a `_constructor_param` helper in `skbio/io/descriptors.py` that conditionally inserts the `constructor` parameter documentation for `TabularMSA`. Other classes using the `Read` descriptor are unaffected.

## Checklist

* [x] I have read the [contribution guidelines](https://scikit.bio/contribute.html).
* [x] I have documented all public-facing changes in the [changelog](https://github.com/scikit-bio/scikit-bio/blob/main/CHANGELOG.md).
* [x] This pull request does not include code, documentation, or other content derived from external source(s).

Closes #2388