### PR TITLE
DOC: Add pip-based setup instructions to contribution guide

### DIFF
--- a/web/contribute.rst
+++ b/web/contribute.rst
@@ -167,6 +167,20 @@ When done, activate the environment::
 
 .. note:: This may be slightly different depending on the operating system. Refer to the `Conda documentation <https://docs.conda.io/>`_ to find instructions for your OS.
 
+.. rubric:: Alternative: using pip
+
+If you prefer to use ``pip`` instead of Conda, you can create a virtual environment and install the dependencies manually::
+
+    python -m venv ~/virtualenvs/skbio-dev
+    source ~/virtualenvs/skbio-dev/bin/activate
+
+Then install the dependencies::
+
+    pip install -r ci/conda_requirements.txt \
+                -r ci/requirements.test.txt \
+                -r ci/requirements.lint.txt \
+                -r ci/requirements.doc.txt
+
 4. Install scikit-bio from source code::
 
     pip install --no-deps -e .


### PR DESCRIPTION
Closes #2417 

This PR adds a short optional section under step 3 of "Set up a workspace" showing the pip equivalent of the Conda environment setup. It does not replace the existing Conda recommendation, just documents the pip path for contributors who prefer or require it.

--------------------
Please complete the following checklist:

* [x] I have read the [contribution guidelines](https://scikit.bio/contribute.html).

* [x] This pull request does not include code, documentation, or other content derived from external source(s).

Note: [This document](https://scikit.bio/devdoc/review.html) may also be helpful to see some of the things code reviewers will be verifying when reviewing your pull request.
