### PR TITLE
BUG: Avoid mutating caller-owned OrdinationResults in permdisp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 * Added support to `TreeNode.from_taxonomy` for parsing taxonomic lineage strings into trees with an optional `extract_rank` parameter. ([#2406](https://github.com/scikit-bio/scikit-bio/pull/2406))
 * Added `mmvec` (Microbe-Metabolite Vectors) to `skbio.stats.ordination` for learning joint embeddings of two feature sets from co-occurrence patterns. Supports L-BFGS and Adam optimizers, cross-validation via Q² scores, and prediction of one modality from another. ([#2360](https://github.com/scikit-bio/scikit-bio/pull/2360))
 
+### Bug Fixes
+
+* Fixed `permdisp` mutating the input `OrdinationResults` object by adding a `"grouping"` column to its `samples` DataFrame ([#2440](https://github.com/scikit-bio/scikit-bio/pull/2440)).
 
 ## Version 0.7.2
 

--- a/skbio/stats/distance/_permdisp.py
+++ b/skbio/stats/distance/_permdisp.py
@@ -331,5 +331,5 @@ def _config_med(x):
 
     Transpose the vector to be compatible with hd.geomedian.
     """
-    X = x.values
-    return pd.Series(np.array(geomedian_axis_one(X.T)), index=x.columns)
+    Xt = np.ascontiguousarray(x.to_numpy(copy=True).T)
+    return pd.Series(np.array(geomedian_axis_one(Xt)), index=x.columns)

--- a/skbio/stats/distance/_permdisp.py
+++ b/skbio/stats/distance/_permdisp.py
@@ -287,7 +287,7 @@ def permdisp(
     else:
         raise TypeError("Input must be a DistanceMatrix or OrdinationResults.")
 
-    samples = ordination.samples.copy()
+    samples = ordination.samples
 
     num_groups, grouping = _preprocess_input_sng(ids, sample_size, grouping, column)
 
@@ -305,17 +305,16 @@ def permdisp(
 def _compute_groups(samples, test_type, grouping):
     groups = []
 
-    samples["grouping"] = grouping
     if test_type == "centroid":
-        centroids = samples.groupby("grouping").aggregate("mean")
+        centroids = samples.groupby(grouping).aggregate("mean")
     else:  # median
         grouping_cols = samples.columns.to_list()
-        centroids = samples.groupby("grouping")[grouping_cols].apply(_config_med)
+        centroids = samples.groupby(grouping)[grouping_cols].apply(_config_med)
 
-    for label, df in samples.groupby("grouping"):
+    for label, df in samples.groupby(grouping):
         groups.append(
             cdist(
-                df.values[:, :-1].astype("float64"),
+                df.values.astype("float64"),
                 [centroids.loc[label].values],
                 metric="euclidean",
             )
@@ -328,10 +327,9 @@ def _compute_groups(samples, test_type, grouping):
 
 
 def _config_med(x):
-    """Slice and transpose the vector.
+    """Transpose the vector.
 
-    Slice the vector up to the last value to exclude grouping column
-    and transpose the vector to be compatible with hd.geomedian.
+    Transpose the vector to be compatible with hd.geomedian.
     """
-    X = x.values[:, :-1]
-    return pd.Series(np.array(geomedian_axis_one(X.T)), index=x.columns[:-1])
+    X = x.values
+    return pd.Series(np.array(geomedian_axis_one(X.T)), index=x.columns)

--- a/skbio/stats/distance/_permdisp.py
+++ b/skbio/stats/distance/_permdisp.py
@@ -287,7 +287,7 @@ def permdisp(
     else:
         raise TypeError("Input must be a DistanceMatrix or OrdinationResults.")
 
-    samples = ordination.samples
+    samples = ordination.samples.copy()
 
     num_groups, grouping = _preprocess_input_sng(ids, sample_size, grouping, column)
 

--- a/skbio/stats/distance/_permdisp.py
+++ b/skbio/stats/distance/_permdisp.py
@@ -331,5 +331,6 @@ def _config_med(x):
 
     Transpose the vector to be compatible with hd.geomedian.
     """
-    Xt = np.ascontiguousarray(x.to_numpy(copy=True).T)
-    return pd.Series(np.array(geomedian_axis_one(Xt)), index=x.columns)
+    X = x.to_numpy(copy=True)
+    return pd.Series(np.array(geomedian_axis_one(X.T)), index=x.columns)
+

--- a/skbio/stats/distance/tests/test_permdisp.py
+++ b/skbio/stats/distance/tests/test_permdisp.py
@@ -360,6 +360,15 @@ class PERMDISPTests(TestCase):
             permdisp(self.unifrac_dm, [], method='invalid')
         self.assertEqual(str(cm.exception), "Method must be eigh or fsvd.")
 
+    def test_no_mutation_of_ordination_results(self):
+        po = pcoa(self.unifrac_dm, warn_neg_eigval=False)
+        original_columns = po.samples.columns.tolist()
+        
+        permdisp(po, self.unif_grouping, permutations=0, warn_neg_eigval=False)
+        
+        self.assertEqual(po.samples.columns.tolist(), original_columns)
+        self.assertNotIn("grouping", po.samples.columns.tolist())
+
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Please complete the following checklist:

* [x] I have read the [contribution guidelines](https://scikit.bio/contribute.html).

* [x] I have documented all public-facing changes in the [changelog](https://github.com/scikit-bio/scikit-bio/blob/main/CHANGELOG.md).

* [ ] **This pull request includes code, documentation, or other content derived from external source(s).** If this is the case, ensure the external source's license is compatible with scikit-bio's [license](https://github.com/scikit-bio/scikit-bio/blob/main/LICENSE.txt). Include the license in the `licenses` directory and add a comment in the code giving proper attribution. Ensure any other requirements set forth by the license and/or author are satisfied.

  - **It is your responsibility to disclose** code, documentation, or other content derived from external source(s). If you have questions about whether something can be included in the project or how to give proper attribution, include those questions in your pull request and a reviewer will assist you.

* [x] This pull request does not include code, documentation, or other content derived from external source(s).

Note: [This document](https://scikit.bio/devdoc/review.html) may also be helpful to see some of the things code reviewers will be verifying when reviewing your pull request.

---

Closes #2438

### Description

`permdisp` was modifying the `samples` DataFrame of an `OrdinationResults` object in-place by adding a `"grouping"` column when the input was an `OrdinationResults` instance.

This PR fixes the bug by creating a shallow `.copy()` of `ordination.samples` alongside the initial setup so that the original object safely preserves its exact state without unexpected mutation side effects in downstream pipelines.
