### PR TITLE
Replaced sparse matrices with sparse arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
 
 * Fixed `permdisp` mutating the input `OrdinationResults` object by adding a `"grouping"` column to its `samples` DataFrame ([#2440](https://github.com/scikit-bio/scikit-bio/pull/2440)).
 
+### Miscellaneous
+
+* Replaced SciPy sparse matrix constructors with sparse array constructors to align with SciPy's sparse array APIs. This affects `subsample_counts` (`csr_array`) (no public-facing effect) and `tree_basis` (`coo_array`).
+
 ## Version 0.7.2
 
 ### Features

--- a/skbio/stats/_subsample.py
+++ b/skbio/stats/_subsample.py
@@ -236,8 +236,8 @@ def subsample_counts(counts, n, replace=False, seed=None):
     if counts.ndim != 1:
         raise ValueError("Only 1-D vectors are supported.")
 
-    # csr_matrix will report ndim of 2 if vector
-    counts = sparse.csr_matrix(counts)
+    # csr_array will report ndim of 2 if vector
+    counts = sparse.csr_array(counts)
 
     counts_sum = counts.sum()
     if n > counts_sum and not replace:

--- a/skbio/stats/composition/_base.py
+++ b/skbio/stats/composition/_base.py
@@ -1255,7 +1255,7 @@ def tree_basis(tree):
 
     Returns
     -------
-    scipy.sparse.coo_matrix
+    scipy.sparse.coo_array
         The ilr basis required to perform the ilr_inv transform. This is also
         known as the sequential binary partition. Note that this matrix is
         represented in clr coordinates.
@@ -1278,7 +1278,7 @@ def tree_basis(tree):
            [-0.70710678,  0.70710678,  0.        ]])
 
     """
-    from scipy.sparse import coo_matrix
+    from scipy.sparse import coo_array
 
     # Specifies which child is numerator and denominator
     # within any given node in a tree.
@@ -1355,7 +1355,7 @@ def tree_basis(tree):
         i += 1
         nodes.append(n.name)
 
-    basis = coo_matrix((value, (row, col)), shape=(D - 1, D))
+    basis = coo_array((value, (row, col)), shape=(D - 1, D))
 
     return basis, nodes
 

--- a/skbio/stats/composition/tests/test_base.py
+++ b/skbio/stats/composition/tests/test_base.py
@@ -13,7 +13,7 @@ import numpy.testing as npt
 from numpy.exceptions import AxisError
 from numpy.random import rand, randint
 import pandas as pd
-from scipy.sparse import coo_matrix
+from scipy.sparse import coo_array
 
 from skbio import TreeNode
 from skbio.stats.distance import DistanceMatrixError
@@ -920,7 +920,7 @@ class TestTreeBasis(TestCase):
         tree = u"(a,b);"
         t = TreeNode.read([tree])
 
-        exp_basis = coo_matrix(
+        exp_basis = coo_array(
             np.array([[-np.sqrt(1. / 2),
                        np.sqrt(1. / 2)]]))
         exp_keys = [t.name]
@@ -938,7 +938,7 @@ class TestTreeBasis(TestCase):
     def test_tree_basis_unbalanced(self):
         tree = u"((a,b)c, d);"
         t = TreeNode.read([tree])
-        exp_basis = coo_matrix(np.array(
+        exp_basis = coo_array(np.array(
             [[-np.sqrt(1. / 6), -np.sqrt(1. / 6), np.sqrt(2. / 3)],
              [-np.sqrt(1. / 2), np.sqrt(1. / 2), 0]]
         ))
@@ -953,7 +953,7 @@ class TestTreeBasis(TestCase):
 
         t = TreeNode.read([tree])
 
-        exp_basis = coo_matrix(np.array(
+        exp_basis = coo_array(np.array(
             [
                 [-np.sqrt(2. / 3), np.sqrt(1. / 6), np.sqrt(1. / 6)],
                 [0, -np.sqrt(1. / 2), np.sqrt(1. / 2)]

--- a/skbio/stats/ordination/_mmvec.py
+++ b/skbio/stats/ordination/_mmvec.py
@@ -16,7 +16,7 @@ import numpy as np
 import pandas as pd
 from scipy.optimize import minimize
 from scipy.special import logsumexp
-from scipy.sparse import coo_matrix, issparse
+from scipy.sparse import coo_array, issparse
 
 from skbio._base import SkbioObject
 from skbio.stats.composition import clr_inv as softmax
@@ -125,9 +125,7 @@ class _MMvecModel:
         d1 = self.n_microbes
 
         U_aug = np.hstack([np.ones((d1, 1)), self.b_U, self.U])
-        V_aug = np.vstack(
-            [self.b_V, np.ones((1, self.n_metabolites - 1)), self.V]
-        )
+        V_aug = np.vstack([self.b_V, np.ones((1, self.n_metabolites - 1)), self.V])
         return U_aug, V_aug
 
     def forward(self, microbe_indices):
@@ -146,9 +144,7 @@ class _MMvecModel:
         U_aug, V_aug = self._build_augmented_matrices()
         u_batch = U_aug[microbe_indices, :]  # (B, p+2)
         logits_nonref = u_batch @ V_aug  # (B, d2-1)
-        logits = np.hstack(
-            [np.zeros((len(microbe_indices), 1)), logits_nonref]
-        )
+        logits = np.hstack([np.zeros((len(microbe_indices), 1)), logits_nonref])
         return logits
 
     def loss_and_gradients(
@@ -185,7 +181,7 @@ class _MMvecModel:
         if issparse(X):
             X_coo = X.tocoo()
         else:
-            X_coo = coo_matrix(X)
+            X_coo = coo_array(X)
 
         n_samples = X.shape[0]
         total_count = X_coo.data.sum()
@@ -249,17 +245,17 @@ class _MMvecModel:
 
         # Compute total loss (negative log posterior)
         prior_loss = 0.0
-        prior_loss += 0.5 * np.sum((self.U - self.u_prior_mean) ** 2) / (
-            self.u_prior_scale**2
+        prior_loss += (
+            0.5 * np.sum((self.U - self.u_prior_mean) ** 2) / (self.u_prior_scale**2)
         )
-        prior_loss += 0.5 * np.sum((self.b_U - self.u_prior_mean) ** 2) / (
-            self.u_prior_scale**2
+        prior_loss += (
+            0.5 * np.sum((self.b_U - self.u_prior_mean) ** 2) / (self.u_prior_scale**2)
         )
-        prior_loss += 0.5 * np.sum((self.V - self.v_prior_mean) ** 2) / (
-            self.v_prior_scale**2
+        prior_loss += (
+            0.5 * np.sum((self.V - self.v_prior_mean) ** 2) / (self.v_prior_scale**2)
         )
-        prior_loss += 0.5 * np.sum((self.b_V - self.v_prior_mean) ** 2) / (
-            self.v_prior_scale**2
+        prior_loss += (
+            0.5 * np.sum((self.b_V - self.v_prior_mean) ** 2) / (self.v_prior_scale**2)
         )
 
         loss = -norm * loglik + prior_loss
@@ -277,9 +273,7 @@ class _MMvecModel:
             Row-centered log conditional probabilities.
         """
         U_aug, V_aug = self._build_augmented_matrices()
-        logits = np.hstack(
-            [np.zeros((self.n_microbes, 1)), U_aug @ V_aug]
-        )
+        logits = np.hstack([np.zeros((self.n_microbes, 1)), U_aug @ V_aug])
         # Center each row
         ranks = logits - logits.mean(axis=1, keepdims=True)
         return ranks
@@ -292,12 +286,14 @@ class _MMvecModel:
         theta : np.ndarray
             Flattened parameters [U, b_U, V, b_V].
         """
-        return np.concatenate([
-            self.U.ravel(),
-            self.b_U.ravel(),
-            self.V.ravel(),
-            self.b_V.ravel(),
-        ])
+        return np.concatenate(
+            [
+                self.U.ravel(),
+                self.b_U.ravel(),
+                self.V.ravel(),
+                self.b_V.ravel(),
+            ]
+        )
 
     def unpack_params(self, theta):
         """Restore parameter matrices from flat vector.
@@ -312,20 +308,20 @@ class _MMvecModel:
         p = self.n_components
 
         idx = 0
-        self.U = theta[idx:idx + d1 * p].reshape(d1, p)
+        self.U = theta[idx : idx + d1 * p].reshape(d1, p)
         idx += d1 * p
-        self.b_U = theta[idx:idx + d1].reshape(d1, 1)
+        self.b_U = theta[idx : idx + d1].reshape(d1, 1)
         idx += d1
-        self.V = theta[idx:idx + p * (d2 - 1)].reshape(p, d2 - 1)
+        self.V = theta[idx : idx + p * (d2 - 1)].reshape(p, d2 - 1)
         idx += p * (d2 - 1)
-        self.b_V = theta[idx:idx + (d2 - 1)].reshape(1, d2 - 1)
+        self.b_V = theta[idx : idx + (d2 - 1)].reshape(1, d2 - 1)
 
     def full_batch_loss_and_gradient(self, X_coo, Y):
         """Compute full-batch loss and gradient for L-BFGS.
 
         Parameters
         ----------
-        X_coo : coo_matrix
+        X_coo : coo_array
             Microbe counts in COO format.
         Y : np.ndarray of shape (n_samples, n_metabolites)
             Metabolite counts.
@@ -409,12 +405,14 @@ class _MMvecModel:
         db_V += b_v_diff / self.v_prior_scale**2
 
         # Pack gradients
-        grad = np.concatenate([
-            dU.ravel(),
-            db_U.ravel(),
-            dV.ravel(),
-            db_V.ravel(),
-        ])
+        grad = np.concatenate(
+            [
+                dU.ravel(),
+                db_U.ravel(),
+                dV.ravel(),
+                db_V.ravel(),
+            ]
+        )
 
         return loss, grad
 
@@ -568,9 +566,7 @@ class MMvecResults(SkbioObject):
             Each row sums to 1.
         """
         probs = softmax(self.ranks.values)
-        return pd.DataFrame(
-            probs, index=self.ranks.index, columns=self.ranks.columns
-        )
+        return pd.DataFrame(probs, index=self.ranks.index, columns=self.ranks.columns)
 
     def predict(self, microbes):
         """Predict metabolite distributions given microbe abundances.
@@ -798,9 +794,7 @@ def _clip_gradients(grads, clipnorm):
     grads : dict
         Clipped gradients.
     """
-    global_norm = np.sqrt(
-        sum(np.sum(g**2) for g in grads.values())
-    )
+    global_norm = np.sqrt(sum(np.sum(g**2) for g in grads.values()))
 
     if global_norm > clipnorm:
         scale = clipnorm / global_norm
@@ -865,14 +859,10 @@ def _validate_inputs(microbes, metabolites, u_prior_scale, v_prior_scale):
         )
 
     if u_prior_scale <= 0:
-        raise ValueError(
-            f"u_prior_scale must be positive, got {u_prior_scale}."
-        )
+        raise ValueError(f"u_prior_scale must be positive, got {u_prior_scale}.")
 
     if v_prior_scale <= 0:
-        raise ValueError(
-            f"v_prior_scale must be positive, got {v_prior_scale}."
-        )
+        raise ValueError(f"v_prior_scale must be positive, got {v_prior_scale}.")
 
     # Check for all-zero columns in microbes
     microbe_sums = X.sum(axis=0)
@@ -913,7 +903,7 @@ def _train_lbfgs(model, X_coo, Y, max_iter, verbose):
     ----------
     model : _MMvecModel
         Initialized model to train.
-    X_coo : coo_matrix
+    X_coo : coo_array
         Microbe counts in sparse COO format.
     Y : np.ndarray
         Metabolite counts.
@@ -935,10 +925,12 @@ def _train_lbfgs(model, X_coo, Y, max_iter, verbose):
         loss, grad = model.full_batch_loss_and_gradient(X_coo, Y)
         iteration_count[0] += 1
 
-        convergence_data.append({
-            "iteration": iteration_count[0],
-            "loss": loss,
-        })
+        convergence_data.append(
+            {
+                "iteration": iteration_count[0],
+                "loss": loss,
+            }
+        )
 
         if verbose and iteration_count[0] % 10 == 0:
             print(f"Iteration {iteration_count[0]}, Loss: {loss:.4f}")
@@ -966,8 +958,10 @@ def _train_lbfgs(model, X_coo, Y, max_iter, verbose):
     model.unpack_params(result.x)
 
     if verbose:
-        print(f"L-BFGS-B converged: {result.success}, "
-              f"iterations: {result.nit}, message: {result.message}")
+        print(
+            f"L-BFGS-B converged: {result.success}, "
+            f"iterations: {result.nit}, message: {result.message}"
+        )
 
     return convergence_data
 
@@ -997,7 +991,7 @@ def _train_adam(
         Microbe counts.
     Y : np.ndarray
         Metabolite counts.
-    X_coo : coo_matrix
+    X_coo : coo_array
         Microbe counts in sparse COO format.
     rng : np.random.Generator
         Random number generator.
@@ -1106,23 +1100,21 @@ def _build_results(model, microbe_ids, metabolite_ids, convergence_data):
     # Microbe embeddings: U with bias
     microbe_emb = np.hstack([model.U, model.b_U])
     pc_cols = [f"PC{i}" for i in range(n_components)] + ["bias"]
-    microbe_embeddings = pd.DataFrame(
-        microbe_emb, index=microbe_ids, columns=pc_cols
-    )
+    microbe_embeddings = pd.DataFrame(microbe_emb, index=microbe_ids, columns=pc_cols)
 
     # Metabolite embeddings: V^T with bias
     # First row is reference (no embedding), rest are actual embeddings
-    metabolite_emb = np.vstack([
-        np.zeros((1, n_components + 1)),  # Reference category
-        np.hstack([model.V.T, model.b_V.T]),
-    ])
+    metabolite_emb = np.vstack(
+        [
+            np.zeros((1, n_components + 1)),  # Reference category
+            np.hstack([model.V.T, model.b_V.T]),
+        ]
+    )
     metabolite_embeddings = pd.DataFrame(
         metabolite_emb, index=metabolite_ids, columns=pc_cols
     )
 
-    ranks_df = pd.DataFrame(
-        ranks, index=microbe_ids, columns=metabolite_ids
-    )
+    ranks_df = pd.DataFrame(ranks, index=microbe_ids, columns=metabolite_ids)
 
     convergence = pd.DataFrame(convergence_data)
 
@@ -1288,9 +1280,7 @@ def mmvec(
     # Validate optimizer
     optimizer = optimizer.lower()
     if optimizer not in ("lbfgs", "adam"):
-        raise ValueError(
-            f"optimizer must be 'lbfgs' or 'adam', got '{optimizer}'."
-        )
+        raise ValueError(f"optimizer must be 'lbfgs' or 'adam', got '{optimizer}'.")
 
     # Initialize model
     model = _MMvecModel(
@@ -1305,7 +1295,7 @@ def mmvec(
     )
 
     # Convert to sparse COO format
-    X_coo = coo_matrix(X)
+    X_coo = coo_array(X)
 
     # Train model
     if optimizer == "lbfgs":


### PR DESCRIPTION
SciPy has recommended migrating from the old sparse matrix interface to the new sparse array interface. This PR replaces all sparse matrix calls with corresponding sparse array calls. Affected features include:

1. `skbio.stats.composition.tree_basis` using `coo_array`
2. `skbio.stats.subsample_counts` using `csr_array`
3. `skbio.stats.ordination.mmvec` pipeline using `coo_array` inputs and type references

Only 1) has a public-facing effect (return values is now a `coo_array`). But it is largely compatible with the old `coo_matrix` in subsequent analyses.

***

Please complete the following checklist:

* [x] I have read the [contribution guidelines](https://scikit.bio/contribute.html).

* [x] I have documented all public-facing changes in the [changelog](https://github.com/scikit-bio/scikit-bio/blob/main/CHANGELOG.md).

* [ ] **This pull request includes code, documentation, or other content derived from external source(s).** If this is the case, ensure the external source's license is compatible with scikit-bio's [license](https://github.com/scikit-bio/scikit-bio/blob/main/LICENSE.txt). Include the license in the `licenses` directory and add a comment in the code giving proper attribution. Ensure any other requirements set forth by the license and/or author are satisfied.

  - **It is your responsibility to disclose** code, documentation, or other content derived from external source(s). If you have questions about whether something can be included in the project or how to give proper attribution, include those questions in your pull request and a reviewer will assist you.

* [x] This pull request does not include code, documentation, or other content derived from external source(s).

Note: [This document](https://scikit.bio/devdoc/review.html) may also be helpful to see some of the things code reviewers will be verifying when reviewing your pull request.
