### PR TITLE
FIX: Updating outdated decorators

### DIFF
--- a/skbio/sequence/_grammared_sequence.py
+++ b/skbio/sequence/_grammared_sequence.py
@@ -7,7 +7,7 @@
 # ----------------------------------------------------------------------------
 
 from warnings import warn
-from abc import ABCMeta, abstractproperty
+from abc import ABCMeta, abstractmethod
 from itertools import product
 import re
 
@@ -22,10 +22,11 @@ class GrammaredSequenceMeta(ABCMeta, type):
     def __new__(mcs, name, bases, dct):
         cls = super(GrammaredSequenceMeta, mcs).__new__(mcs, name, bases, dct)
 
-        concrete_gap_chars = type(cls.gap_chars) is not abstractproperty
-        concrete_degenerate_map = type(cls.degenerate_map) is not abstractproperty
-        concrete_definite_chars = type(cls.definite_chars) is not abstractproperty
-        concrete_default_gap_char = type(cls.default_gap_char) is not abstractproperty
+        abstract_methods = cls.__abstractmethods__
+        concrete_gap_chars = "gap_chars" not in abstract_methods
+        concrete_degenerate_map = "degenerate_map" not in abstract_methods
+        concrete_definite_chars = "definite_chars" not in abstract_methods
+        concrete_default_gap_char = "default_gap_char" not in abstract_methods
         # degenerate_chars is not abstract but it depends on degenerate_map
         # which is abstract.
         concrete_degenerate_chars = concrete_degenerate_map
@@ -277,8 +278,8 @@ class GrammaredSequence(Sequence, metaclass=GrammaredSequenceMeta):
         """
         return cls.degenerate_chars | cls.definite_chars | cls.gap_chars
 
-    @abstractproperty
     @classproperty
+    @abstractmethod
     def gap_chars(cls):
         """Return characters defined as gaps.
 
@@ -290,8 +291,8 @@ class GrammaredSequence(Sequence, metaclass=GrammaredSequenceMeta):
         """
         raise NotImplementedError
 
-    @abstractproperty
     @classproperty
+    @abstractmethod
     def default_gap_char(cls):
         """Gap character to use when constructing a new gapped sequence.
 
@@ -343,8 +344,8 @@ class GrammaredSequence(Sequence, metaclass=GrammaredSequenceMeta):
 
         return cls.definite_chars
 
-    @abstractproperty
     @classproperty
+    @abstractmethod
     def definite_chars(cls):
         """Return definite characters.
 
@@ -368,8 +369,8 @@ class GrammaredSequence(Sequence, metaclass=GrammaredSequenceMeta):
         """
         return set()
 
-    @abstractproperty
     @classproperty
+    @abstractmethod
     def degenerate_map(cls):
         """Return mapping of degenerate to definite characters.
 

--- a/skbio/sequence/_nucleotide_mixin.py
+++ b/skbio/sequence/_nucleotide_mixin.py
@@ -6,7 +6,7 @@
 # The full license is in the file LICENSE.txt, distributed with this software.
 # ----------------------------------------------------------------------------
 
-from abc import ABCMeta, abstractproperty
+from abc import ABCMeta, abstractmethod
 
 import numpy as np
 
@@ -51,8 +51,8 @@ class NucleotideMixin(metaclass=ABCMeta):
     def _motifs(self):
         return _motifs
 
-    @abstractproperty
     @classproperty
+    @abstractmethod
     def complement_map(cls):
         """Return mapping of nucleotide characters to their complements.
 

--- a/skbio/util/_decorator.py
+++ b/skbio/util/_decorator.py
@@ -140,12 +140,16 @@ class classproperty(property):
     def __init__(self, func):
         name = func.__name__
         doc = func.__doc__
-        super(classproperty, self).__init__(classmethod(func))
+        # Keep fget as a plain function so introspection tools (e.g. Sphinx)
+        # can inspect its signature without tripping on a classmethod object.
+        super(classproperty, self).__init__(func)
         self.__name__ = name
         self.__doc__ = doc
 
-    def __get__(self, cls, owner):
-        return self.fget.__get__(None, owner)()
+    def __get__(self, obj, owner=None):
+        if owner is None:
+            owner = type(obj)
+        return self.fget(owner)
 
     def __set__(self, obj, value):
         raise AttributeError("can't set attribute")

--- a/skbio/util/_decorator.py
+++ b/skbio/util/_decorator.py
@@ -147,6 +147,8 @@ class classproperty(property):
         self.__doc__ = doc
 
     def __get__(self, obj, owner=None):
+        if getattr(self.fget, "__isabstractmethod__", False):
+            return self
         if owner is None:
             owner = type(obj)
         return self.fget(owner)

--- a/skbio/util/tests/test_decorator.py
+++ b/skbio/util/tests/test_decorator.py
@@ -140,6 +140,23 @@ class TestClassProperty(unittest.TestCase):
         with self.assertRaises(AttributeError):
             f.foo = 4242
 
+    def test_no_owner(self):
+        class Foo:
+            _foo = 42
+
+            @classproperty
+            def foo(cls):
+                return cls._foo
+
+        class Bar(Foo):
+            _foo = 84
+
+        descriptor = Foo.__dict__["foo"]
+
+        # Exercise classproperty.__get__(obj, owner=None) explicitly.
+        self.assertEqual(descriptor.__get__(Foo(), None), 42)
+        self.assertEqual(descriptor.__get__(Bar(), None), 84)
+
 
 class TestDeprecated(unittest.TestCase):
     def test_deprecated(self):


### PR DESCRIPTION
This PR aims to fix the emerging warning message of Sphinx when rendering the documentation:

> WARNING: Failed to get a function signature for skbio.sequence.GrammaredSequence.default_gap_char: <skbio.util._decorator.classproperty object at 0x7f30425d44d0> is not a callable object

The root cause for this is the custom decorator `classproperty`. It is now patched to resolve this problem. Also fixed is the deprecated `@abstractproperty` decorator, which is now replaced with `@abstractmethod`. After these fixes, the warning messages are gone.

There is no public-facing effect of this PR.

***

Please complete the following checklist:

* [x] I have read the [contribution guidelines](https://scikit.bio/contribute.html).

* [ ] I have documented all public-facing changes in the [changelog](https://github.com/scikit-bio/scikit-bio/blob/main/CHANGELOG.md).

* [ ] **This pull request includes code, documentation, or other content derived from external source(s).** If this is the case, ensure the external source's license is compatible with scikit-bio's [license](https://github.com/scikit-bio/scikit-bio/blob/main/LICENSE.txt). Include the license in the `licenses` directory and add a comment in the code giving proper attribution. Ensure any other requirements set forth by the license and/or author are satisfied.

  - **It is your responsibility to disclose** code, documentation, or other content derived from external source(s). If you have questions about whether something can be included in the project or how to give proper attribution, include those questions in your pull request and a reviewer will assist you.

* [x] This pull request does not include code, documentation, or other content derived from external source(s).

Note: [This document](https://scikit.bio/devdoc/review.html) may also be helpful to see some of the things code reviewers will be verifying when reviewing your pull request.
