### PR TITLE
FIX: Updating Sphinx theme custom color setting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,8 +65,7 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v3
         with:
           auto-update-conda: true
-          # Pin to 3.13 for now because no Sphinx is compatible with Python 3.14
-          python-version: "3.13"
+          python-version: ${{ env.latest_python }}
           environment-file: ci/conda_host_env.yml
       - name: Install dependencies
         run: |

--- a/ci/requirements.doc.txt
+++ b/ci/requirements.doc.txt
@@ -1,4 +1,4 @@
-sphinx < 9
+sphinx
 sphinx-design
 sphinx-copybutton
 pydata-sphinx-theme

--- a/doc/source/_static/css/style.css
+++ b/doc/source/_static/css/style.css
@@ -14,11 +14,11 @@ Instructions:
 https://pydata-sphinx-theme.readthedocs.io/en/stable/user_guide/styling.html
 */
 
-/* hide external link icon */
-
 html {
+  /* hide external link icon */
   --pst-icon-external-link: unset; 
 
+  /* custom font sizes for heading levels */
   --pst-font-size-h1: 2rem;
   --pst-font-size-h2: 1.5rem;
   --pst-font-size-h3: 1.25rem;
@@ -43,9 +43,6 @@ primary color (for links, default: teal)
 secondary color (for links on hover, default: violet)
 target color (for highlights, default: sunset)
 inline code color (default: violet)
-
-Color variables are not well documented; but some of them can be found here:
-https://github.com/pydata/pydata-sphinx-theme/blob/50fa47727af8d23757ddecd375c7a31cd282d248/pydata_sphinx_theme/static/css/theme.css#L43-L48
 */
 
 html[data-theme="light"] {
@@ -53,7 +50,7 @@ html[data-theme="light"] {
   --pst-color-target: #F5FDC6;
   --pst-color-secondary: var(--pst-color-primary);
   --pst-color-inline-code: var(--pst-color-accent);
-  --pst-color-inline-code-links: var(--pst-color-primary);
+  --pst-color-link-higher-contrast: var(--pst-color-primary);
   --pst-color-table-row-hover-bg: var(--pst-color-target);
 }
 
@@ -62,7 +59,7 @@ html[data-theme="dark"] {
   --pst-color-target: #2C1E7F;
   --pst-color-secondary: var(--pst-color-primary);
   --pst-color-inline-code: var(--pst-color-accent);
-  --pst-color-inline-code-links: var(--pst-color-primary);
+  --pst-color-link-higher-contrast: var(--pst-color-primary);
   --pst-color-table-row-hover-bg: var(--pst-color-target);
 }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ test = [
     "matplotlib"
 ]
 docs = [
-    "sphinx < 9",
+    "sphinx",
     "sphinx-design",
     "sphinx-copybutton",
     "pydata-sphinx-theme",
@@ -84,7 +84,7 @@ dev = [
     "coverage",
     "responses",
     "matplotlib",
-    "sphinx < 9",
+    "sphinx",
     "sphinx-design",
     "sphinx-copybutton",
     "pydata-sphinx-theme",


### PR DESCRIPTION
This PR fixes an issue in documentation text color rendering caused by updates in PyData Sphinx Theme. The issue is that inline code links (such as links to function or method pages) are rendered using default color rather than custom color. Through updating the relevant CSS setting, this issue is now fixed.

This PR also removed the version restriction of Sphinx (v9.0 not working with Python 3.14). Such restriction is no longer needed in Sphinx v9.1.

***

Please complete the following checklist:

* [x] I have read the [contribution guidelines](https://scikit.bio/contribute.html).

* [ ] I have documented all public-facing changes in the [changelog](https://github.com/scikit-bio/scikit-bio/blob/main/CHANGELOG.md).

* [ ] **This pull request includes code, documentation, or other content derived from external source(s).** If this is the case, ensure the external source's license is compatible with scikit-bio's [license](https://github.com/scikit-bio/scikit-bio/blob/main/LICENSE.txt). Include the license in the `licenses` directory and add a comment in the code giving proper attribution. Ensure any other requirements set forth by the license and/or author are satisfied.

  - **It is your responsibility to disclose** code, documentation, or other content derived from external source(s). If you have questions about whether something can be included in the project or how to give proper attribution, include those questions in your pull request and a reviewer will assist you.

* [x] This pull request does not include code, documentation, or other content derived from external source(s).

Note: [This document](https://scikit.bio/devdoc/review.html) may also be helpful to see some of the things code reviewers will be verifying when reviewing your pull request.
