### PR TITLE
Simplify `array-api-compatible` decorator and add it to relevant functions

### DIFF
--- a/skbio/stats/composition/_base.py
+++ b/skbio/stats/composition/_base.py
@@ -18,7 +18,7 @@ from skbio.util._decorator import (
     aliased,
     register_aliases,
     params_aliased,
-    array_api_compatible,
+    array_api_doc,
 )
 from skbio.util._array import ingest_array
 
@@ -88,7 +88,7 @@ def _check_composition(
         raise ValueError(f"Input matrix can only have {maxdim} dimensions or less.")
 
 
-@array_api_compatible(
+@array_api_doc(
     backends=["numpy", "cupy", "torch", "jax", "dask"],
     devices=["cpu", "gpu"],
 )
@@ -424,7 +424,7 @@ def inner(x: ArrayLike, y: ArrayLike, validate: bool = True) -> StdArray:
     return xp.matmul(clrx, clry.T)
 
 
-@array_api_compatible(
+@array_api_doc(
     backends=["numpy", "cupy", "torch", "jax", "dask"],
     devices=["cpu", "gpu"],
 )
@@ -496,7 +496,7 @@ def _clr(xp: ModuleType, mat: StdArray, axis: int) -> StdArray:
     return (lmat := xp.log(mat)) - xp.mean(lmat, axis=axis, keepdims=True)
 
 
-@array_api_compatible(
+@array_api_doc(
     backends=["numpy", "cupy", "torch", "jax", "dask"],
     devices=["cpu", "gpu"],
 )
@@ -584,7 +584,7 @@ def _clr_inv(xp: ModuleType, mat: StdArray, axis: int) -> StdArray:
     return _closure(xp, diff, axis)
 
 
-@array_api_compatible(
+@array_api_doc(
     backends=["numpy", "cupy", "torch", "jax", "dask"],
     devices=["cpu", "gpu"],
 )
@@ -693,7 +693,7 @@ def _rclr(xp: ModuleType, mat: StdArray, axis: int) -> StdArray:
 
 
 @params_aliased([("validate", "check", "0.7.0", True)])
-@array_api_compatible(
+@array_api_doc(
     backends=["numpy", "cupy", "torch", "jax", "dask"],
     devices=["cpu", "gpu"],
 )
@@ -816,7 +816,7 @@ def _ilr(xp: ModuleType, mat: StdArray, basis: StdArray, axis: int) -> StdArray:
 
 
 @params_aliased([("validate", "check", "0.7.0", True)])
-@array_api_compatible(
+@array_api_doc(
     backends=["numpy", "cupy", "torch", "jax", "dask"],
     devices=["cpu", "gpu"],
 )
@@ -924,7 +924,7 @@ def _ilr_inv(xp: ModuleType, mat: StdArray, basis: StdArray, axis: int) -> StdAr
 
 
 @params_aliased([("ref_idx", "denominator_idx", "0.7.0", False)])
-@array_api_compatible(
+@array_api_doc(
     backends=["numpy", "cupy", "torch", "jax", "dask"],
     devices=["cpu", "gpu"],
 )
@@ -1037,7 +1037,7 @@ def _alr(xp: ModuleType, mat: StdArray, ref_idx: int, axis: int) -> StdArray:
 
 
 @params_aliased([("ref_idx", "denominator_idx", "0.7.0", False)])
-@array_api_compatible(
+@array_api_doc(
     backends=["numpy", "cupy", "torch", "jax", "dask"],
     devices=["cpu", "gpu"],
 )

--- a/skbio/stats/composition/_base.py
+++ b/skbio/stats/composition/_base.py
@@ -424,6 +424,10 @@ def inner(x: ArrayLike, y: ArrayLike, validate: bool = True) -> StdArray:
     return xp.matmul(clrx, clry.T)
 
 
+@array_api_compatible(
+    backends=["numpy", "cupy", "torch", "jax", "dask"],
+    devices=["cpu", "gpu"],
+)
 def clr(mat: ArrayLike, axis: int = -1, validate: bool = True) -> StdArray:
     r"""Perform centre log ratio (CLR) transformation.
 
@@ -492,6 +496,10 @@ def _clr(xp: ModuleType, mat: StdArray, axis: int) -> StdArray:
     return (lmat := xp.log(mat)) - xp.mean(lmat, axis=axis, keepdims=True)
 
 
+@array_api_compatible(
+    backends=["numpy", "cupy", "torch", "jax", "dask"],
+    devices=["cpu", "gpu"],
+)
 def clr_inv(mat: ArrayLike, axis: int = -1, validate: bool = True) -> StdArray:
     r"""Perform inverse centre log ratio (CLR) transformation.
 
@@ -576,6 +584,10 @@ def _clr_inv(xp: ModuleType, mat: StdArray, axis: int) -> StdArray:
     return _closure(xp, diff, axis)
 
 
+@array_api_compatible(
+    backends=["numpy", "cupy", "torch", "jax", "dask"],
+    devices=["cpu", "gpu"],
+)
 def rclr(mat: ArrayLike, axis: int = -1, validate: bool = True) -> StdArray:
     r"""Perform robust centre log ratio (rclr) transformation.
 
@@ -681,6 +693,10 @@ def _rclr(xp: ModuleType, mat: StdArray, axis: int) -> StdArray:
 
 
 @params_aliased([("validate", "check", "0.7.0", True)])
+@array_api_compatible(
+    backends=["numpy", "cupy", "torch", "jax", "dask"],
+    devices=["cpu", "gpu"],
+)
 def ilr(
     mat: ArrayLike,
     basis: ArrayLike | None = None,
@@ -800,6 +816,10 @@ def _ilr(xp: ModuleType, mat: StdArray, basis: StdArray, axis: int) -> StdArray:
 
 
 @params_aliased([("validate", "check", "0.7.0", True)])
+@array_api_compatible(
+    backends=["numpy", "cupy", "torch", "jax", "dask"],
+    devices=["cpu", "gpu"],
+)
 def ilr_inv(
     mat: ArrayLike,
     basis: ArrayLike | None = None,
@@ -904,6 +924,10 @@ def _ilr_inv(xp: ModuleType, mat: StdArray, basis: StdArray, axis: int) -> StdAr
 
 
 @params_aliased([("ref_idx", "denominator_idx", "0.7.0", False)])
+@array_api_compatible(
+    backends=["numpy", "cupy", "torch", "jax", "dask"],
+    devices=["cpu", "gpu"],
+)
 def alr(
     mat: ArrayLike, ref_idx: int = 0, axis: int = -1, validate: bool = True
 ) -> StdArray:
@@ -1013,6 +1037,10 @@ def _alr(xp: ModuleType, mat: StdArray, ref_idx: int, axis: int) -> StdArray:
 
 
 @params_aliased([("ref_idx", "denominator_idx", "0.7.0", False)])
+@array_api_compatible(
+    backends=["numpy", "cupy", "torch", "jax", "dask"],
+    devices=["cpu", "gpu"],
+)
 def alr_inv(mat: ArrayLike, ref_idx: int = 0, axis: int = -1) -> StdArray:
     r"""Perform inverse additive log ratio (ALR) transform.
 

--- a/skbio/stats/composition/tests/test_base.py
+++ b/skbio/stats/composition/tests/test_base.py
@@ -1036,7 +1036,7 @@ class VLRTests(TestCase):
         self.assertAlmostEqual(output, 0.2857382286903922)
 
 
-class TestRclr(TestCase):
+class TestRclr(TestCase, ArrayAPITestMixin):
     """Tests for the robust centered log-ratio transformation."""
 
     def test_basic_rclr(self):
@@ -1050,6 +1050,20 @@ class TestRclr(TestCase):
         for i in range(mat.shape[0]):
             observed = ~np.isnan(result[i])
             npt.assert_almost_equal(result[i, observed].mean(), 0.0)
+
+    @array_backends("numpy", "jax", "torch", "cupy")
+    def test_rclr_backends(self, xp, device):
+        # Dense data (no zeros) — should match clr
+        data = rand(4, 6, 3) + 1e-4
+        lmat = np.log(data)
+        expected = lmat - np.mean(lmat, axis=-1, keepdims=True)
+
+        arr = self.make_array(xp, device, data)
+        result = rclr(arr)
+
+        self.assert_type_preserved(result, xp, device)
+        self.assertEqual(result.shape, arr.shape)
+        self.assert_close(result, expected, rtol=_RELAXED_RTOL)
 
     def test_rclr_with_zeros(self):
         """Test rclr handles zeros by producing NaN."""

--- a/skbio/stats/composition/tests/test_base.py
+++ b/skbio/stats/composition/tests/test_base.py
@@ -1065,6 +1065,25 @@ class TestRclr(TestCase, ArrayAPITestMixin):
         self.assertEqual(result.shape, arr.shape)
         self.assert_close(result, expected, rtol=_RELAXED_RTOL)
 
+        # Sparse data (with zeros) — zeros become NaN, observed values centered
+        data_sparse = np.array([[3.0, 3.0, 0.0],
+                                [0.0, 4.0, 2.0]])
+        expected_sparse = np.array([[0.0, 0.0, np.nan],
+                                    [np.nan, 0.34657359, -0.34657359]])
+
+        arr_sparse = self.make_array(xp, device, data_sparse)
+        result_sparse = rclr(arr_sparse)
+
+        self.assert_type_preserved(result_sparse, xp, device)
+        self.assertEqual(result_sparse.shape, arr_sparse.shape)
+
+        # Convert to numpy for NaN-aware comparison
+        result_np = np.asarray(result_sparse)
+        npt.assert_array_equal(np.isnan(result_np), np.isnan(expected_sparse))
+        npt.assert_allclose(result_np[~np.isnan(result_np)],
+                            expected_sparse[~np.isnan(expected_sparse)],
+                            rtol=_RELAXED_RTOL)
+
     def test_rclr_with_zeros(self):
         """Test rclr handles zeros by producing NaN."""
         mat = np.array([[1, 0, 3], [4, 5, 0]])

--- a/skbio/util/__init__.py
+++ b/skbio/util/__init__.py
@@ -55,7 +55,7 @@ Decorators
    aliased
    register_aliases
    params_aliased
-   array_api_compatible
+   array_api_doc
 
 
 Miscellaneous utilities
@@ -101,7 +101,7 @@ from ._decorator import (
     aliased,
     register_aliases,
     params_aliased,
-    array_api_compatible,
+    array_api_doc,
 )
 from ._optionals import get_package
 from ._plotting import PlottableMixin
@@ -125,7 +125,7 @@ __all__ = [
     "aliased",
     "register_aliases",
     "params_aliased",
-    "array_api_compatible",
+    "array_api_doc",
     "xp_assert_close",
     "xp_assert_equal",
     "array_backends",

--- a/skbio/util/_decorator.py
+++ b/skbio/util/_decorator.py
@@ -24,11 +24,12 @@ from ._docstring import (
 from ._warning import _warn_deprecated, _warn_renamed, _warn_param_renamed
 
 
-def array_api_compatible(backends, devices=None):
-    r"""Mark a function as compatible with the Python array API standard.
+def array_api_doc(backends, devices=None):
+    r"""Add an array API compatibility table to a function's documentation.
 
     An array API compatibility table is inserted into the Notes section of the
-    function's docstring.
+    function's docstring. If the docstring has no Notes section, the table is
+    inserted at the end of the docstring.
 
     Parameters
     ----------

--- a/skbio/util/_decorator.py
+++ b/skbio/util/_decorator.py
@@ -21,12 +21,14 @@ from ._docstring import (
     _array_api_compat_section,
     _insert_into_notes_section,
 )
-from ._array import _get_namespace_from_args, _check_array_api_backend
 from ._warning import _warn_deprecated, _warn_renamed, _warn_param_renamed
 
 
 def array_api_compatible(backends, devices=None):
     r"""Mark a function as compatible with the Python array API standard.
+
+    An array API compatibility table is inserted into the Notes section of the
+    function's docstring.
 
     Parameters
     ----------
@@ -37,35 +39,12 @@ def array_api_compatible(backends, devices=None):
         Supported devices: `'cpu'`, `'gpu'`. Defaults to per-backend
         defaults.
 
-    Notes
-    -----
-    This decorator has two effects:
-
-    1. An array API compatibility table is inserted into the Notes section of
-       the function's docstring.
-    2. At runtime, if the caller passes an array API object from an unsupported
-       backend, a `TypeError` is raised.
-
-    The decorated function gains two attributes:
-    `_array_api_backends` and `_array_api_devices`.
-
     """
 
     def decorator(func):
         section = _array_api_compat_section(backends, devices)
-
-        @wraps(func)
-        def wrapper(*args, **kwargs):
-            xp = _get_namespace_from_args(args, kwargs)
-            if xp is not None:
-                _check_array_api_backend(xp, backends, func.__name__)
-            return func(*args, **kwargs)
-
-        wrapper.__doc__ = _insert_into_notes_section(section, func.__doc__ or "")
-        wrapper._array_backends = backends
-        wrapper._devices = devices
-
-        return wrapper
+        func.__doc__ = _insert_into_notes_section(section, func.__doc__ or "")
+        return func
 
     return decorator
 


### PR DESCRIPTION
This PR simplifies the `@array-api-compatible` decorator to reduce its scope to docstring modification only. Additionally, it adds the decorator to functions in the composition module which have array API support, and adds a simple test to the new `rclr` function. It also renames the decorator as `@array-api-doc` to more accurately reflect the scope of the decorator.

Please complete the following checklist:

* [x] I have read the [contribution guidelines](https://scikit.bio/contribute.html).

* [ ] I have documented all public-facing changes in the [changelog](https://github.com/scikit-bio/scikit-bio/blob/main/CHANGELOG.md).

* [ ] **This pull request includes code, documentation, or other content derived from external source(s).** If this is the case, ensure the external source's license is compatible with scikit-bio's [license](https://github.com/scikit-bio/scikit-bio/blob/main/LICENSE.txt). Include the license in the `licenses` directory and add a comment in the code giving proper attribution. Ensure any other requirements set forth by the license and/or author are satisfied.

  - **It is your responsibility to disclose** code, documentation, or other content derived from external source(s). If you have questions about whether something can be included in the project or how to give proper attribution, include those questions in your pull request and a reviewer will assist you.

* [x] This pull request does not include code, documentation, or other content derived from external source(s).

Note: [This document](https://scikit.bio/devdoc/review.html) may also be helpful to see some of the things code reviewers will be verifying when reviewing your pull request.
